### PR TITLE
fix: clarify dual-license structure (BSD-3-Clause + FoxIO License 1.1)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -26,3 +26,31 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+DUAL-LICENSE NOTICE
+===================
+
+This repository has a dual-license structure:
+
+1. The ja4plus library code (this repository) is licensed under the
+   BSD 3-Clause License above.
+
+2. The JA4+ fingerprinting specifications themselves were created by
+   FoxIO-LLC. The fingerprinting methods JA4S, JA4H, JA4T, JA4TS, JA4L,
+   JA4X, and JA4SSH are implementations of those specifications and are
+   subject to the FoxIO License 1.1.
+
+   JA4 (TLS Client Fingerprinting) is open source under BSD-3-Clause
+   per FoxIO's own licensing terms.
+
+   The FoxIO License 1.1 is permissive for most use cases, including:
+   - Academic and research use
+   - Internal business use
+   - Security research and tooling
+
+   Commercial productization or resale of JA4+ fingerprinting (other than
+   JA4 itself) may require a separate commercial license from FoxIO.
+
+   Full terms: https://github.com/FoxIO-LLC/ja4/blob/main/LICENSE

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ cd ja4plus
 pip install -e .
 ```
 
+## Licensing
+
+This library (ja4plus) is released under the **BSD 3-Clause License**.
+
+The JA4+ fingerprinting specifications were created by [FoxIO](https://foxio.io):
+
+- **JA4** (TLS Client Fingerprinting) is open source under **BSD-3-Clause** per FoxIO.
+- **JA4S, JA4H, JA4T, JA4TS, JA4L, JA4X, JA4SSH** implement FoxIO's specifications and are subject to the **FoxIO License 1.1**.
+
+The FoxIO License 1.1 is permissive for most use cases, including academic use, internal business use, and security research. Commercial productization or resale of these fingerprinting methods (other than JA4) may require a separate license from FoxIO.
+
+See the [FoxIO License](https://github.com/FoxIO-LLC/ja4/blob/main/LICENSE) for full terms, and [LICENSE](LICENSE) in this repository for the complete dual-license notice.
+
 ## Quick Start
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ja4plus"
 version = "0.2.0"
 description = "JA4+ network fingerprinting library for TLS, TCP, HTTP, SSH, and X.509 analysis"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = "BSD-3-Clause AND LicenseRef-FoxIO-1.1"
 requires-python = ">=3.8"
 keywords = ["ja4", "ja4plus", "fingerprinting", "tls", "tcp", "http", "ssh", "x509", "network", "security", "scapy"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ja4plus"
 version = "0.2.0"
 description = "JA4+ network fingerprinting library for TLS, TCP, HTTP, SSH, and X.509 analysis"
 readme = "README.md"
-license = "BSD-3-Clause AND LicenseRef-FoxIO-1.1"
+license = {text = "BSD-3-Clause AND LicenseRef-FoxIO-1.1"}
 requires-python = ">=3.8"
 keywords = ["ja4", "ja4plus", "fingerprinting", "tls", "tcp", "http", "ssh", "x509", "network", "security", "scapy"]
 classifiers = [


### PR DESCRIPTION
## Summary
- JA4 (TLS Client) is BSD-3-Clause per FoxIO
- JA4S, JA4H, JA4T, JA4TS, JA4L, JA4X, JA4SSH implement FoxIO specs under FoxIO License 1.1
- Updates LICENSE, README, and pyproject.toml to reflect dual-license structure