### PR TITLE
v0.4.0: QUIC support, IPv6, TCP reassembly, bug fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 - [Usage Guide](usage.md) - Detailed usage for each fingerprinter with examples
 - [API Reference](api_reference.md) - Classes, methods, and convenience functions
+- [Implementation Notes](implementation_notes.md) - Spec deviations and undocumented behaviors
 
 ## Quick Links
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -173,6 +173,30 @@ result = generate_ja4(packet)
 | `extract_certificate_from_bytes(data)` | Find DER certificates in raw TLS record bytes |
 | `extract_certificate_info(packet)` | Extract certificate details from a scapy packet |
 
+### ja4plus.utils.quic_utils
+
+| Function | Description |
+|----------|-------------|
+| `parse_quic_initial(udp_payload)` | Parse QUIC Initial, return tls_info with `is_quic=True` or None |
+| `derive_initial_secrets(dcid, version)` | Derive secrets from DCID (version 1 or 2) |
+| `extract_crypto_frames(plaintext)` | Reassemble CRYPTO frames from decrypted payload |
+
+### ja4plus.utils.tcp_stream
+
+| Class/Function | Description |
+|----------------|-------------|
+| `TCPStreamReassembler(max_streams, max_stream_bytes)` | Sequence-aware TCP stream reassembly |
+| `.add_segment(key, seq, data)` | Add a TCP segment |
+| `.get_stream(key)` | Get reassembled contiguous bytes |
+| `.remove_stream(key)` | Remove a tracked stream |
+
+### ja4plus.utils.packet_utils
+
+| Function | Description |
+|----------|-------------|
+| `get_ip_layer(packet)` | Return IP or IPv6 layer, or None |
+| `get_ttl(packet)` | Return TTL (IPv4) or Hop Limit (IPv6), or None |
+
 ## CLI Module
 
 ### ja4plus.cli

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -1,0 +1,143 @@
+# Implementation Notes
+
+Behaviors in the Python ja4plus library that are not documented in the
+FoxIO JA4+ specification. The Go implementation MUST match these behaviors
+to produce identical fingerprints.
+
+---
+
+## JA4 - TLS Client Hello
+
+### ALPN non-ASCII handling
+
+When the first byte of the first ALPN protocol has `ord() > 127`, the ALPN
+field is set to `'99'` rather than the hex representation of the byte.
+
+**Location:** `ja4plus/fingerprinters/ja4.py:90`
+
+**Rationale:** Simplifies output to a fixed 2-char field. The spec says
+"hex representation of the byte" but `'99'` is used as an unambiguous
+sentinel for non-ASCII protocols.
+
+### Version mapping (beyond TLS 1.0-1.3)
+
+The spec only mentions TLS 1.0 through 1.3. The implementation also maps:
+
+| Wire value | String | Protocol   |
+|------------|--------|------------|
+| `0x0300`   | `s3`   | SSL 3.0    |
+| `0x0200`   | `s2`   | SSL 2.0    |
+| `0xFEFF`   | `d1`   | DTLS 1.0   |
+| `0xFEFD`   | `d2`   | DTLS 1.2   |
+| `0xFEFC`   | `d3`   | DTLS 1.3   |
+
+Any unrecognized version maps to `'00'`.
+
+### Cipher sorting
+
+Ciphers are sorted numerically on their integer values before formatting
+as 4-char hex and hashing. This produces the same result as lexicographic
+sort on zero-padded 4-char hex strings.
+
+### Raw fingerprint format
+
+Raw fingerprints use prefixed output: `JA4_r = {fp}` and `JA4_ro = {fp}`.
+Note the spaces around `=`. This is a display convention, not part of the
+fingerprint value itself.
+
+---
+
+## JA4L - Latency
+
+### Output format includes prefix
+
+JA4L fingerprints include a direction prefix:
+`JA4L-S={latency_us}_{ttl}` and `JA4L-C={latency_us}_{ttl}`.
+The spec describes `{latency_microseconds}_{ttl}` without a prefix.
+
+### Latency is raw time difference, not RTT/2
+
+The latency value is the raw time difference between handshake points,
+not the round-trip time divided by 2.
+
+---
+
+## JA4SSH - SSH Traffic
+
+### Early fingerprint trigger
+
+The fingerprint window triggers at `min(configured_packet_count, 10)`,
+not at the configured count. Additionally triggers immediately when both
+HASSH fingerprints are available.
+
+### Direction detection on non-standard ports
+
+**BUG (fixed in v0.4.0):** Prior to v0.4.0, non-standard port direction
+detection was inverted: the lower port was assigned as client when it
+should be server. Fixed by swapping the assignment.
+
+---
+
+## JA4X - X.509 Certificates
+
+### Certificate deduplication cleanup
+
+The processed certificate set is pruned when it exceeds 1000 entries,
+keeping the most recent 500. This is a memory management strategy,
+not a hard limit on unique certificates.
+
+### TCP reassembly
+
+**Fixed in v0.4.0:** Stream reassembly now uses TCP sequence numbers
+for correct ordering. Prior versions appended data in arrival order,
+which could corrupt streams with out-of-order TCP segments.
+
+---
+
+## JA4H - HTTP
+
+### TCP reassembly
+
+**Fixed in v0.4.0:** HTTP parsing now accumulates TCP stream data
+before attempting to parse. Prior versions operated on single-packet
+payloads only, missing HTTP requests spanning multiple TCP segments.
+
+---
+
+## TLS Utilities
+
+### SNI parsing returns boolean True for unparseable SNI
+
+When the SNI extension is present but the hostname cannot be extracted,
+`_parse_sni()` returns `True` (boolean). This works because the JA4
+fingerprinter checks `'d' if sni else 'i'`, and `True` is truthy.
+
+---
+
+## IPv6 Support
+
+**Added in v0.4.0:** All fingerprinters support both IPv4 and IPv6.
+Prior versions only checked for scapy's `IP` layer.
+
+---
+
+## QUIC Support
+
+**Added in v0.4.0.** QUIC Initial packet parsing decrypts the Initial
+packet using DCID-derived keys, extracts CRYPTO frames, and parses the
+contained TLS ClientHello.
+
+**Crypto pipeline:**
+1. Extract DCID from the Initial long header
+2. Derive Initial secret via HKDF (salt depends on QUIC version)
+3. Derive client key, IV, and header protection key
+4. Remove header protection (AES-ECB mask)
+5. Decrypt payload with AES-128-GCM
+6. Extract CRYPTO frames and reassemble by offset
+7. Parse the contained TLS ClientHello
+
+**Version detection:** QUIC v2 identified by wire version `0x6B3343CF`;
+all other non-zero versions use the v1 salt.
+
+**Integration:** `extract_tls_info` checks for QUIC on UDP packets
+before falling through to standard TLS parsing.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ result = fp.process_packet(packet)
 ```
 
 **Format breakdown:**
-- `t` = TCP (`q` = QUIC, `d` = DTLS)
+- `t` = TCP, `q` = QUIC (auto-detected from UDP/QUIC Initial), `d` = DTLS
 - `13` = TLS 1.3 (from `supported_versions` extension)
 - `d` = domain name present via SNI (`i` = IP / no SNI)
 - `15` = 15 cipher suites (excluding GREASE, max 99)
@@ -238,6 +238,30 @@ for h in hassh_fps:
 # Look up known HASSH values
 info = fp.lookup_hassh("b5752e36ba6c5979a575e43178908adf")
 print(info["identified_as"])  # "Paramiko 2.4.1 (Metasploit)"
+```
+
+---
+
+## QUIC Support
+
+QUIC Initial packets (RFC 9001, RFC 9369) are automatically detected on UDP.
+The library decrypts the Initial packet using DCID-derived keys, extracts
+the CRYPTO frames containing the TLS ClientHello, and feeds it into the
+standard JA4 fingerprinting pipeline.
+
+**Supported:** QUIC v1 (`0x00000001`) and v2 (`0x6b3343cf`).
+
+**Limitations:** Only client Initial packets. No retry or 0-RTT. No coalesced packet splitting.
+
+```python
+from scapy.all import rdpcap
+from ja4plus import JA4Fingerprinter
+
+fp = JA4Fingerprinter()
+for packet in rdpcap("quic_capture.pcap"):
+    result = fp.process_packet(packet)
+    if result:
+        print(result)  # QUIC: q13d1007h2_...
 ```
 
 ---

--- a/ja4plus/__init__.py
+++ b/ja4plus/__init__.py
@@ -25,6 +25,6 @@ from ja4plus.fingerprinters.ja4ssh import generate_ja4ssh
 from ja4plus.fingerprinters.ja4t import generate_ja4t
 from ja4plus.fingerprinters.ja4ts import generate_ja4ts
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __author__ = "ja4plus contributors"
 __license__ = "BSD-3-Clause"

--- a/ja4plus/fingerprinters/ja4h.py
+++ b/ja4plus/fingerprinters/ja4h.py
@@ -10,10 +10,12 @@ JA4H fingerprints HTTP requests based on:
 
 import hashlib
 import logging
-from scapy.all import IP, TCP, Raw
+from scapy.all import IP, IPv6, TCP, Raw
 
 logger = logging.getLogger(__name__)
-from ja4plus.utils.http_utils import extract_http_info
+from ja4plus.utils.http_utils import extract_http_info, is_http_request, parse_http_request
+from ja4plus.utils.tcp_stream import TCPStreamReassembler
+from ja4plus.utils.packet_utils import get_ip_layer
 from ja4plus.fingerprinters.base import BaseFingerprinter
 
 
@@ -21,23 +23,204 @@ class JA4HFingerprinter(BaseFingerprinter):
     """
     JA4H HTTP Fingerprinting implementation.
 
-    JA4H fingerprints HTTP requests based on method, headers, and cookies.
+    Supports HTTP requests spanning multiple TCP segments via
+    stream reassembly.
     """
+
+    def __init__(self):
+        super().__init__()
+        self.reassembler = TCPStreamReassembler(max_streams=100)
 
     def process_packet(self, packet):
         """
         Process a packet and extract JA4H fingerprint if applicable.
 
-        Args:
-            packet: A network packet to analyze
-
-        Returns:
-            The extracted fingerprint if successful, None otherwise
+        Accumulates TCP stream data and attempts HTTP parsing on each
+        new segment.
         """
-        fingerprint = generate_ja4h(packet)
+        if not (packet.haslayer(TCP) and packet.haslayer(Raw)):
+            return None
+
+        ip_layer = get_ip_layer(packet)
+        if ip_layer is None:
+            return None
+
+        tcp = packet[TCP]
+        raw_data = bytes(packet[Raw])
+
+        stream_key = f"{ip_layer.src}:{tcp.sport}-{ip_layer.dst}:{tcp.dport}"
+        seq = tcp.seq if hasattr(tcp, 'seq') else 0
+
+        self.reassembler.add_segment(stream_key, seq, raw_data)
+        stream_data = self.reassembler.get_stream(stream_key)
+
+        # Try to parse HTTP from reassembled stream
+        if not is_http_request(stream_data):
+            # Also try the single packet (backward compat)
+            fingerprint = generate_ja4h(packet)
+            if fingerprint:
+                self.add_fingerprint(fingerprint, packet)
+                return fingerprint
+            return None
+
+        # Check if headers are complete (double CRLF present)
+        if b"\r\n\r\n" not in stream_data:
+            return None
+
+        http_info = _extract_http_info_from_bytes(stream_data)
+        if not http_info:
+            return None
+
+        fingerprint = _generate_ja4h_from_info(http_info)
         if fingerprint:
             self.add_fingerprint(fingerprint, packet)
+            self.reassembler.remove_stream(stream_key)
             return fingerprint
+
+        return None
+
+    def reset(self):
+        super().reset()
+        self.reassembler = TCPStreamReassembler(max_streams=100)
+
+
+def _extract_http_info_from_bytes(data):
+    """Extract HTTP info from raw bytes, preserving original header name casing.
+
+    Mirrors extract_http_info() but operates on a bytes buffer instead of a
+    Scapy packet, so it works on reassembled TCP stream data.
+    """
+    import re
+    if not data:
+        return None
+    try:
+        text = data.decode('utf-8', errors='ignore')
+        request_line_match = re.match(
+            r'^(GET|POST|PUT|DELETE|HEAD|OPTIONS|CONNECT|TRACE|PATCH)\s+(\S+)\s+(HTTP/\d+\.\d+)',
+            text
+        )
+        if not request_line_match:
+            return None
+
+        method = request_line_match.group(1)
+        path = request_line_match.group(2)
+        version = request_line_match.group(3)
+
+        headers = {}
+        header_names = []
+        lines = text.split('\r\n')
+
+        for line in lines[1:]:
+            if not line or line.isspace():
+                break
+            header_match = re.match(r'^([^:]+):\s*(.*)$', line)
+            if header_match:
+                name = header_match.group(1).strip()
+                value = header_match.group(2).strip()
+                headers[name.lower()] = value
+                header_names.append(name)
+
+        cookies = {}
+        cookie_fields = []
+        cookie_values = []
+        if 'cookie' in headers:
+            for pair in headers['cookie'].split(';'):
+                if '=' in pair:
+                    k, v = pair.split('=', 1)
+                    k, v = k.strip(), v.strip()
+                    cookies[k] = v
+                    cookie_fields.append(k)
+                    cookie_values.append(v)
+
+        return {
+            'method': method,
+            'path': path,
+            'version': version,
+            'headers': header_names,
+            'cookies': cookies,
+            'cookie_fields': cookie_fields,
+            'cookie_values': cookie_values,
+            'language': headers.get('accept-language', ''),
+            'referer': headers.get('referer', ''),
+        }
+    except (ValueError, TypeError, UnicodeDecodeError) as e:
+        logger.debug(f"Could not parse HTTP from stream bytes: {e}")
+        return None
+
+
+def _convert_parsed_to_extract_format(parsed):
+    """Convert parse_http_request output to extract_http_info format."""
+    headers = parsed.get('headers', {})
+    header_names = list(headers.keys())
+    cookies = parsed.get('cookies', {})
+    cookie_fields = list(cookies.keys())
+
+    return {
+        'method': parsed.get('method', ''),
+        'path': parsed.get('path', ''),
+        'version': parsed.get('version', ''),
+        'headers': header_names,
+        'cookies': cookies,
+        'cookie_fields': cookie_fields,
+        'cookie_values': list(cookies.values()),
+        'language': headers.get('accept-language', ''),
+        'referer': headers.get('referer', ''),
+    }
+
+
+def _generate_ja4h_from_info(http_info):
+    """Generate JA4H from an http_info dict."""
+    if not http_info:
+        return None
+
+    try:
+        method = http_info.get('method', '').lower()
+        version = http_info.get('version', '').replace('HTTP/', '')
+        version_str = version.replace('.', '')
+
+        has_cookie = 'c' if http_info.get('cookie_fields', []) else 'n'
+        has_referer = 'r' if http_info.get('referer', '') else 'n'
+
+        header_count = 0
+        for header in http_info.get('headers', []):
+            if header.lower() not in ['cookie', 'referer']:
+                header_count += 1
+        header_count = min(header_count, 99)
+        header_count_str = f"{header_count:02d}"
+
+        language = http_info.get('language', '')
+        lang_code = '0000'
+        if language:
+            lang_clean = language.replace('-', '').replace(';', ',').lower().split(',')[0]
+            lang_clean = lang_clean[:4]
+            lang_code = f"{lang_clean}{'0' * (4 - len(lang_clean))}" if lang_clean else '0000'
+
+        part_a = f"{method[:2]}{version_str}{has_cookie}{has_referer}{header_count_str}{lang_code}"
+
+        headers = http_info.get('headers', [])
+        filtered_headers = [
+            h for h in headers
+            if not h.startswith(':')
+            and h.lower() != 'cookie'
+            and h.lower() != 'referer'
+            and h
+        ]
+        headers_str = ','.join(filtered_headers)
+        part_b = hashlib.sha256(headers_str.encode()).hexdigest()[:12] if headers_str else '000000000000'
+
+        cookie_fields = sorted(http_info.get('cookie_fields', []))
+        cookie_fields_str = ','.join(cookie_fields)
+        part_c = hashlib.sha256(cookie_fields_str.encode()).hexdigest()[:12] if cookie_fields_str else '000000000000'
+
+        cookie_dict = http_info.get('cookies', {})
+        sorted_cookie_pairs = sorted(cookie_dict.items())
+        cookie_values_str = ','.join(f"{k}={v}" for k, v in sorted_cookie_pairs)
+        part_d = hashlib.sha256(cookie_values_str.encode()).hexdigest()[:12] if cookie_values_str else '000000000000'
+
+        return f"{part_a}_{part_b}_{part_c}_{part_d}"
+
+    except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
+        logger.debug(f"Packet does not contain JA4H data: {e}")
         return None
 
 
@@ -51,85 +234,7 @@ def generate_ja4h(packet):
     Returns:
         JA4H fingerprint string if successful, None otherwise
     """
-    # Extract HTTP info
     http_info = extract_http_info(packet)
     if not http_info:
         return None
-
-    try:
-        # Part A: HTTP method, version, cookies, referer, header count, language
-        method = http_info.get('method', '').lower()
-        version = http_info.get('version', '').replace('HTTP/', '')
-
-        # Format version (e.g., "1.1" to "11", "2.0" to "20")
-        version_str = version.replace('.', '')
-
-        # Cookie indicator
-        has_cookie = 'c' if http_info.get('cookie_fields', []) else 'n'
-
-        # Referer indicator
-        has_referer = 'r' if http_info.get('referer', '') else 'n'
-
-        # Count of headers (excluding Cookie and Referer) - 2 digit format
-        header_count = 0
-        for header in http_info.get('headers', []):
-            if header.lower() not in ['cookie', 'referer']:
-                header_count += 1
-        header_count = min(header_count, 99)
-        header_count_str = f"{header_count:02d}"
-
-        # Extract language code per FoxIO spec:
-        # Replace hyphens, replace semicolons with commas, lowercase, take first,
-        # truncate to 4 chars, pad with zeros to 4 chars
-        language = http_info.get('language', '')
-        lang_code = '0000'
-        if language:
-            lang_clean = language.replace('-', '').replace(';', ',').lower().split(',')[0]
-            lang_clean = lang_clean[:4]
-            lang_code = f"{lang_clean}{'0' * (4 - len(lang_clean))}" if lang_clean else '0000'
-
-        part_a = f"{method[:2]}{version_str}{has_cookie}{has_referer}{header_count_str}{lang_code}"
-
-        # Part B: Header names hash - keep original order
-        # Per FoxIO spec: exclude pseudo-headers (starting with ':'),
-        # Cookie, Referer, and empty headers from the hash
-        headers = http_info.get('headers', [])
-        filtered_headers = [
-            h for h in headers
-            if not h.startswith(':')
-            and h.lower() != 'cookie'
-            and h.lower() != 'referer'
-            and h
-        ]
-        headers_str = ','.join(filtered_headers)
-        if headers_str:
-            part_b = hashlib.sha256(headers_str.encode()).hexdigest()[:12]
-        else:
-            part_b = '000000000000'
-
-        # Part C: Cookie field names hash (sorted alphabetically)
-        cookie_fields = sorted(http_info.get('cookie_fields', []))
-        cookie_fields_str = ','.join(cookie_fields)
-        if cookie_fields_str:
-            part_c = hashlib.sha256(cookie_fields_str.encode()).hexdigest()[:12]
-        else:
-            part_c = '000000000000'
-
-        # Part D: Cookie values hash - per FoxIO spec, hash the full
-        # "name=value" cookie strings sorted alphabetically by name
-        cookie_dict = http_info.get('cookies', {})
-        sorted_cookie_pairs = sorted(cookie_dict.items())
-        cookie_values_str = ','.join(f"{k}={v}" for k, v in sorted_cookie_pairs)
-        if cookie_values_str:
-            part_d = hashlib.sha256(cookie_values_str.encode()).hexdigest()[:12]
-        else:
-            part_d = '000000000000'
-
-        # Form the JA4H fingerprint
-        ja4h = f"{part_a}_{part_b}_{part_c}_{part_d}"
-
-        return ja4h
-
-    except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
-        logger.debug(f"Packet does not contain JA4H data: {e}")
-        return None
+    return _generate_ja4h_from_info(http_info)

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -8,7 +8,7 @@ Format: JA4L-C=<latency_us>_<ttl> and JA4L-S=<latency_us>_<ttl>
 
 import time
 import logging
-from scapy.all import IP, TCP, UDP
+from scapy.all import IP, IPv6, TCP, UDP
 
 logger = logging.getLogger(__name__)
 from ja4plus.fingerprinters.base import BaseFingerprinter
@@ -36,7 +36,7 @@ class JA4LFingerprinter(BaseFingerprinter):
         Returns:
             The extracted fingerprint if successful, None otherwise
         """
-        if IP not in packet or (TCP not in packet and UDP not in packet):
+        if (IP not in packet and IPv6 not in packet) or (TCP not in packet and UDP not in packet):
             return None
 
         if TCP in packet:
@@ -48,8 +48,12 @@ class JA4LFingerprinter(BaseFingerprinter):
             sport = packet[UDP].sport
             dport = packet[UDP].dport
 
-        src_ip = packet[IP].src
-        dst_ip = packet[IP].dst
+        from ja4plus.utils.packet_utils import get_ip_layer
+        ip_layer = get_ip_layer(packet)
+        if ip_layer is None:
+            return None
+        src_ip = ip_layer.src
+        dst_ip = ip_layer.dst
 
         # Normalize connection key (ordered src/dst)
         if src_ip < dst_ip or (src_ip == dst_ip and sport < dport):
@@ -169,7 +173,8 @@ def generate_ja4l(packet, conn=None):
     if not conn:
         return None
 
-    if not packet.haslayer(IP):
+    from ja4plus.utils.packet_utils import get_ip_layer as _get_ip, get_ttl
+    if _get_ip(packet) is None:
         return None
 
     try:
@@ -178,7 +183,9 @@ def generate_ja4l(packet, conn=None):
         if 'ttls' not in conn:
             conn['ttls'] = {}
 
-        ttl = packet[IP].ttl
+        ttl = get_ttl(packet)
+        if ttl is None:
+            return None
 
         # Use pcap timestamp if available (for offline analysis), else wall clock
         current_time = float(packet.time) if hasattr(packet, 'time') else time.time()
@@ -254,10 +261,12 @@ def _src_is_client(packet, conn):
     Returns:
         True if the source is the client, False otherwise
     """
-    if not packet.haslayer(IP):
+    from ja4plus.utils.packet_utils import get_ip_layer
+    ip_layer = get_ip_layer(packet)
+    if ip_layer is None:
         return False
 
-    src_ip = packet[IP].src
+    src_ip = ip_layer.src
 
     if conn.get('direction') == 'forward':
         conn_key = conn.get('conn_key', '')

--- a/ja4plus/fingerprinters/ja4ssh.py
+++ b/ja4plus/fingerprinters/ja4ssh.py
@@ -8,7 +8,7 @@ even when the content is encrypted. Also includes HASSH support.
 import hashlib
 import logging
 from collections import Counter
-from scapy.all import TCP, Raw, IP
+from scapy.all import TCP, Raw, IP, IPv6
 import time
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ class JA4SSHFingerprinter(BaseFingerprinter):
         Returns:
             The extracted fingerprint if a new one is generated, None otherwise
         """
-        if not (packet.haslayer(TCP) and packet.haslayer(IP)):
+        if not (packet.haslayer(TCP) and (packet.haslayer(IP) or packet.haslayer(IPv6))):
             return None
 
         # First check if this packet contains SSH data - do this BEFORE any other processing
@@ -60,7 +60,8 @@ class JA4SSHFingerprinter(BaseFingerprinter):
             return None
 
         tcp = packet[TCP]
-        ip = packet[IP]
+        from ja4plus.utils.packet_utils import get_ip_layer
+        ip = get_ip_layer(packet)
 
         # Create connection key
         src_ip = ip.src

--- a/ja4plus/fingerprinters/ja4ssh.py
+++ b/ja4plus/fingerprinters/ja4ssh.py
@@ -79,13 +79,14 @@ class JA4SSHFingerprinter(BaseFingerprinter):
             client_port, server_port = dst_port, src_port
             is_client_to_server = False
         else:
-            # SSH on non-standard port - determine direction by who initiated connection
-            # Use lower port as server (common convention) or analyze packet content
-            if src_port < dst_port:
+            # SSH on non-standard port - lower port is typically the server
+            if dst_port < src_port:
+                # dst has the lower port -> dst is server, src is client
                 client_ip, server_ip = src_ip, dst_ip
                 client_port, server_port = src_port, dst_port
                 is_client_to_server = True
             else:
+                # src has the lower port -> src is server, dst is client
                 client_ip, server_ip = dst_ip, src_ip
                 client_port, server_port = dst_port, src_port
                 is_client_to_server = False

--- a/ja4plus/fingerprinters/ja4x.py
+++ b/ja4plus/fingerprinters/ja4x.py
@@ -5,7 +5,7 @@ JA4X X.509 Certificate Fingerprinting implementation.
 import hashlib
 import logging
 import struct
-from scapy.all import IP, TCP, Raw
+from scapy.all import IP, IPv6, TCP, Raw
 
 logger = logging.getLogger(__name__)
 from cryptography import x509
@@ -59,78 +59,56 @@ class JA4XFingerprinter(BaseFingerprinter):
     def __init__(self):
         """Initialize the fingerprinter with TCP stream tracking."""
         super().__init__()
-        # Track TCP streams to reassemble fragmented certificate messages
-        self.streams = {}  # Use dict with bytes instead of defaultdict with bytearray
-        # Keep track of certificates we've already processed
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        self.reassembler = TCPStreamReassembler(max_streams=50, max_stream_bytes=1048576)
         self.processed_certs = set()
-        # Last cleanup time to prevent memory leaks
         self.last_cleanup = time.time()
     
     def process_packet(self, packet):
         """Process a packet and extract JA4X fingerprint if applicable."""
-        # Quick check if this might be a TLS handshake packet
         if not (TCP in packet and Raw in packet):
             return None
-        
-        # Get connection information
+
         try:
-            src_ip = packet[IP].src
-            dst_ip = packet[IP].dst
+            from ja4plus.utils.packet_utils import get_ip_layer
+            ip_layer = get_ip_layer(packet)
+            if ip_layer is None:
+                return None
+            src_ip = ip_layer.src
+            dst_ip = ip_layer.dst
             src_port = packet[TCP].sport
             dst_port = packet[TCP].dport
         except (IndexError, AttributeError):
             return None
-        
-        # Create a stream identifier
+
         stream_id = f"{src_ip}:{src_port}-{dst_ip}:{dst_port}"
-        
-        # Get raw data from packet
-        raw_data = bytes(packet[Raw])  # Ensure we have bytes, not Raw
-        
-        # Add data to the stream
-        if stream_id not in self.streams:
-            self.streams[stream_id] = b""
-        self.streams[stream_id] += raw_data  # Append bytes to existing stream data
-        
-        # Try to find and process certificate messages in the stream
-        fingerprint = self._find_certificates_in_stream(stream_id, packet)
-        
-        # Clean up old streams periodically (every 30 seconds)
+        raw_data = bytes(packet[Raw])
+        seq = packet[TCP].seq if hasattr(packet[TCP], 'seq') else 0
+
+        self.reassembler.add_segment(stream_id, seq, raw_data)
+        stream_data = self.reassembler.get_stream(stream_id)
+
+        fingerprint = self._find_certificates_in_stream_data(stream_id, stream_data, packet)
+
         current_time = time.time()
         if current_time - self.last_cleanup > 30:
-            # Keep only the last 50 streams to prevent memory leaks
-            if len(self.streams) > 50:
-                stream_ids = list(self.streams.keys())
-                for old_id in stream_ids[:-50]:
-                    del self.streams[old_id]
-            # Keep the processed certs set reasonable too
             if len(self.processed_certs) > 1000:
                 self.processed_certs = set(list(self.processed_certs)[-500:])
             self.last_cleanup = current_time
-        
+
         return fingerprint
     
-    def _find_certificates_in_stream(self, stream_id, packet):
+    def _find_certificates_in_stream_data(self, stream_id, stream_data, packet):
         """Find and process certificate messages in a TCP stream."""
         result = None
-        
-        # Safety check
-        if stream_id not in self.streams:
+
+        if not stream_data:
             return None
-            
-        stream_data = self.streams[stream_id]
-        
-        # Limit processing to reasonable size to avoid excessive CPU
-        MAX_STREAM_SIZE = 1024 * 1024  # 1MB limit
-        if len(stream_data) > MAX_STREAM_SIZE:
-            # Trim the stream data to the last part
-            self.streams[stream_id] = stream_data[-MAX_STREAM_SIZE:]
-            stream_data = self.streams[stream_id]
-        
+
         i = 0
         # Set a reasonable maximum search length to avoid hanging
-        max_search = min(len(stream_data), 200000)  # 200KB search limit (increased)
-        
+        max_search = min(len(stream_data), 200000)  # 200KB search limit
+
         # Look for TLS records with certificate messages
         while i < max_search - 10:
             # Check for TLS handshake record
@@ -138,12 +116,12 @@ class JA4XFingerprinter(BaseFingerprinter):
                 # Make sure we have enough data for the record header
                 if i + 5 < len(stream_data):
                     record_length = (stream_data[i+3] << 8) | stream_data[i+4]
-                    
+
                     # Sanity check the record length
                     if record_length < 4 or record_length > 65535:
                         i += 1
                         continue
-                    
+
                     # Check if we have the complete record
                     if i + 5 + record_length <= len(stream_data):
                         # Check if this is a certificate message
@@ -151,12 +129,12 @@ class JA4XFingerprinter(BaseFingerprinter):
                             # We found a certificate message, extract it
                             try:
                                 cert_data = self._extract_certificate(stream_data[i:i+5+record_length])
-                            
+
                                 if cert_data:
                                     for cert_bytes in cert_data:
                                         # Use hash of cert to avoid duplicates
                                         cert_hash = hashlib.sha256(cert_bytes).hexdigest()
-                                        
+
                                         if cert_hash not in self.processed_certs:
                                             try:
                                                 fingerprint = self.fingerprint_certificate(cert_bytes)
@@ -168,18 +146,18 @@ class JA4XFingerprinter(BaseFingerprinter):
                                                 logger.warning(f"Certificate error: {e}")
                             except (ValueError, IndexError, struct.error) as e:
                                 logger.debug(f"Certificate extraction failed: {e}")
-                        
+
                         # Move past this record
                         i += 5 + record_length
                         continue
-            
+
             # Move to next byte
             i += 1
-        
+
         # Trim the stream if we've processed a significant amount
         if i > 1000:
-            self.streams[stream_id] = stream_data[i:]
-        
+            self.reassembler.trim_stream(stream_id, i)
+
         return result
     
     def _extract_certificate(self, data):
@@ -300,6 +278,7 @@ class JA4XFingerprinter(BaseFingerprinter):
     def reset(self):
         """Reset the fingerprinter state."""
         self.fingerprints = []
-        self.streams = {}
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        self.reassembler = TCPStreamReassembler(max_streams=50, max_stream_bytes=1048576)
         self.processed_certs = set()
-        self.last_cleanup = time.time() 
+        self.last_cleanup = time.time()

--- a/ja4plus/fingerprinters/ja4x.py
+++ b/ja4plus/fingerprinters/ja4x.py
@@ -5,7 +5,7 @@ JA4X X.509 Certificate Fingerprinting implementation.
 import hashlib
 import logging
 import struct
-from scapy.all import IP, TCP, Raw
+from scapy.all import IP, IPv6, TCP, Raw
 
 logger = logging.getLogger(__name__)
 from cryptography import x509
@@ -74,8 +74,12 @@ class JA4XFingerprinter(BaseFingerprinter):
         
         # Get connection information
         try:
-            src_ip = packet[IP].src
-            dst_ip = packet[IP].dst
+            from ja4plus.utils.packet_utils import get_ip_layer
+            ip_layer = get_ip_layer(packet)
+            if ip_layer is None:
+                return None
+            src_ip = ip_layer.src
+            dst_ip = ip_layer.dst
             src_port = packet[TCP].sport
             dst_port = packet[TCP].dport
         except (IndexError, AttributeError):

--- a/ja4plus/utils/packet_utils.py
+++ b/ja4plus/utils/packet_utils.py
@@ -1,0 +1,39 @@
+"""
+Packet utility helpers for IPv4/IPv6 compatibility.
+"""
+
+from scapy.all import IP, IPv6
+
+
+def get_ip_layer(packet):
+    """
+    Return the IP or IPv6 layer from a packet, or None if neither is present.
+
+    Args:
+        packet: A scapy packet
+
+    Returns:
+        The IP or IPv6 layer, or None
+    """
+    if IP in packet:
+        return packet[IP]
+    if IPv6 in packet:
+        return packet[IPv6]
+    return None
+
+
+def get_ttl(packet):
+    """
+    Return the TTL (IPv4) or hop limit (IPv6) from a packet, or None.
+
+    Args:
+        packet: A scapy packet
+
+    Returns:
+        Integer TTL/hop-limit value, or None
+    """
+    if IP in packet:
+        return packet[IP].ttl
+    if IPv6 in packet:
+        return packet[IPv6].hlim
+    return None

--- a/ja4plus/utils/packet_utils.py
+++ b/ja4plus/utils/packet_utils.py
@@ -1,0 +1,24 @@
+"""Packet utility helpers for IPv4/IPv6 support."""
+
+from scapy.all import IP, IPv6
+
+
+def get_ip_layer(packet):
+    """Return the IP layer (v4 or v6) from a packet, or None.
+
+    Checks IPv4 first (most common), then IPv6.
+    """
+    if IP in packet:
+        return packet[IP]
+    if IPv6 in packet:
+        return packet[IPv6]
+    return None
+
+
+def get_ttl(packet):
+    """Return TTL (IPv4) or Hop Limit (IPv6), or None."""
+    if IP in packet:
+        return packet[IP].ttl
+    if IPv6 in packet:
+        return packet[IPv6].hlim
+    return None

--- a/ja4plus/utils/packet_utils.py
+++ b/ja4plus/utils/packet_utils.py
@@ -1,0 +1,22 @@
+"""
+Packet utility helpers for ja4plus fingerprinters.
+"""
+
+from scapy.all import IP, IPv6
+
+
+def get_ip_layer(packet):
+    """
+    Return the IP or IPv6 layer from a Scapy packet.
+
+    Args:
+        packet: A Scapy packet.
+
+    Returns:
+        The IP or IPv6 layer, or None if neither is present.
+    """
+    if IP in packet:
+        return packet[IP]
+    if IPv6 in packet:
+        return packet[IPv6]
+    return None

--- a/ja4plus/utils/quic_utils.py
+++ b/ja4plus/utils/quic_utils.py
@@ -1,0 +1,201 @@
+"""QUIC Initial packet parsing for JA4+ fingerprinting.
+
+Decrypts QUIC v1 (RFC 9001) and v2 (RFC 9369) Initial packets to
+extract the TLS ClientHello for JA4 fingerprinting.
+"""
+
+import hashlib
+import hmac
+import logging
+import struct
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
+from cryptography.hazmat.primitives import hashes
+
+logger = logging.getLogger(__name__)
+
+QUIC_V1_SALT = bytes.fromhex("38762cf7f55934b34d179ae6a4c80cadccbb7f0a")
+QUIC_V2_SALT = bytes.fromhex("0dede3def700a6db819381be6e269dcbf9bd2ed9")
+
+
+def _decode_varint(data):
+    """Decode a QUIC variable-length integer (RFC 9000 Section 16)."""
+    prefix = data[0] >> 6
+    length = 1 << prefix
+    val = data[0] & 0x3F
+    for i in range(1, length):
+        val = (val << 8) | data[i]
+    return val, length
+
+
+def hkdf_expand_label(secret, label, context, length):
+    """HKDF-Expand-Label as defined in TLS 1.3 (RFC 8446 Section 7.1)."""
+    full_label = b"tls13 " + label
+    hkdf_label = struct.pack("!H", length)
+    hkdf_label += struct.pack("B", len(full_label)) + full_label
+    hkdf_label += struct.pack("B", len(context)) + context
+    return HKDFExpand(
+        algorithm=hashes.SHA256(), length=length, info=hkdf_label
+    ).derive(secret)
+
+
+def derive_initial_secrets(dcid, version=1):
+    """Derive QUIC Initial client and server secrets from the DCID."""
+    salt = QUIC_V1_SALT if version == 1 else QUIC_V2_SALT
+    initial_secret = hmac.new(salt, dcid, hashlib.sha256).digest()
+    client_secret = hkdf_expand_label(initial_secret, b"client in", b"", 32)
+    server_secret = hkdf_expand_label(initial_secret, b"server in", b"", 32)
+    return client_secret, server_secret
+
+
+def derive_key_iv_hp(secret):
+    """Derive AES key, IV, and header protection key from a traffic secret."""
+    key = hkdf_expand_label(secret, b"quic key", b"", 16)
+    iv = hkdf_expand_label(secret, b"quic iv", b"", 12)
+    hp = hkdf_expand_label(secret, b"quic hp", b"", 16)
+    return key, iv, hp
+
+
+def _find_pn_offset(packet_bytes):
+    """Find the packet number offset in a QUIC Initial long header."""
+    pos = 5
+    dcid_len = packet_bytes[pos]
+    pos += 1 + dcid_len
+    scid_len = packet_bytes[pos]
+    pos += 1 + scid_len
+    token_len, consumed = _decode_varint(packet_bytes[pos:])
+    pos += consumed + token_len
+    _, consumed = _decode_varint(packet_bytes[pos:])
+    pos += consumed
+    return pos
+
+
+def remove_header_protection(packet_bytes, hp_key):
+    """Remove QUIC header protection to reveal the real packet number."""
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    pn_offset = _find_pn_offset(packet_bytes)
+    sample_offset = pn_offset + 4
+    sample = packet_bytes[sample_offset:sample_offset + 16]
+
+    cipher = Cipher(algorithms.AES(hp_key), modes.ECB())
+    encryptor = cipher.encryptor()
+    mask = encryptor.update(sample) + encryptor.finalize()
+
+    header = bytearray(packet_bytes)
+    header[0] ^= mask[0] & 0x0F
+    pn_length = (header[0] & 0x03) + 1
+
+    for i in range(pn_length):
+        header[pn_offset + i] ^= mask[1 + i]
+
+    pn = 0
+    for i in range(pn_length):
+        pn = (pn << 8) | header[pn_offset + i]
+
+    return bytes(header), pn, pn_length
+
+
+def decrypt_initial_payload(packet_bytes, pn, pn_length, pn_offset, key, iv):
+    """Decrypt a QUIC Initial packet payload using AES-128-GCM."""
+    nonce = bytearray(iv)
+    pn_bytes = pn.to_bytes(len(nonce), "big")
+    for i in range(len(nonce)):
+        nonce[i] ^= pn_bytes[i]
+
+    ad = packet_bytes[:pn_offset + pn_length]
+    ciphertext = packet_bytes[pn_offset + pn_length:]
+
+    aesgcm = AESGCM(key)
+    return aesgcm.decrypt(bytes(nonce), ciphertext, ad)
+
+
+def extract_crypto_frames(plaintext):
+    """Extract and reassemble CRYPTO frame data from decrypted QUIC payload."""
+    crypto_data = {}
+    pos = 0
+    while pos < len(plaintext):
+        frame_type = plaintext[pos]
+
+        if frame_type == 0x00:
+            pos += 1
+            continue
+        if frame_type == 0x01:
+            pos += 1
+            continue
+
+        if frame_type == 0x06:
+            pos += 1
+            offset, consumed = _decode_varint(plaintext[pos:])
+            pos += consumed
+            length, consumed = _decode_varint(plaintext[pos:])
+            pos += consumed
+            crypto_data[offset] = plaintext[pos:pos + length]
+            pos += length
+        else:
+            break
+
+    if not crypto_data:
+        return None
+    reassembled = bytearray()
+    for offset in sorted(crypto_data.keys()):
+        reassembled.extend(crypto_data[offset])
+    return bytes(reassembled)
+
+
+def parse_quic_initial(udp_payload):
+    """Parse a QUIC Initial packet and extract the TLS ClientHello."""
+    if len(udp_payload) < 20:
+        return None
+
+    first_byte = udp_payload[0]
+    if not (first_byte & 0x80):
+        return None
+
+    version = struct.unpack("!I", udp_payload[1:5])[0]
+    if version == 0:
+        return None
+
+    packet_type = (first_byte & 0x30) >> 4
+    if packet_type != 0x00:
+        return None
+
+    dcid_len = udp_payload[5]
+    dcid = udp_payload[6:6 + dcid_len]
+
+    quic_version = 2 if version == 0x6B3343CF else 1
+    client_secret, _ = derive_initial_secrets(dcid, quic_version)
+    key, iv, hp_key = derive_key_iv_hp(client_secret)
+
+    try:
+        unprotected, pn, pn_length = remove_header_protection(udp_payload, hp_key)
+        pn_offset = _find_pn_offset(udp_payload)
+
+        plaintext = decrypt_initial_payload(
+            unprotected, pn, pn_length, pn_offset, key, iv
+        )
+
+        client_hello_bytes = extract_crypto_frames(plaintext)
+        if not client_hello_bytes:
+            return None
+
+        if len(client_hello_bytes) < 4 or client_hello_bytes[0] != 0x01:
+            return None
+
+        ch_length = len(client_hello_bytes)
+        fake_record = (
+            bytes([0x16, 0x03, 0x01])
+            + struct.pack("!H", ch_length)
+            + client_hello_bytes
+        )
+
+        from ja4plus.utils.tls_utils import parse_tls_handshake
+        tls_info = parse_tls_handshake(fake_record)
+        if tls_info:
+            tls_info["is_quic"] = True
+        return tls_info
+
+    except Exception as e:
+        logger.debug(f"QUIC parsing failed: {e}")
+        return None

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -1,0 +1,88 @@
+"""Sequence-aware TCP stream reassembly for JA4+ fingerprinting.
+
+Used by JA4H (HTTP) and JA4X (certificates) to handle multi-segment
+payloads and out-of-order TCP delivery.
+"""
+
+import logging
+from collections import OrderedDict
+
+logger = logging.getLogger(__name__)
+
+
+class TCPStreamReassembler:
+    """Reassembles TCP streams using sequence numbers.
+
+    Handles out-of-order segments, duplicates, and overlaps.
+    Evicts oldest streams when max_streams is exceeded.
+    """
+
+    def __init__(self, max_streams=100, max_stream_bytes=1048576):
+        self.streams = OrderedDict()
+        self.max_streams = max_streams
+        self.max_stream_bytes = max_stream_bytes
+
+    def add_segment(self, key, seq, data):
+        """Add a TCP segment to a stream."""
+        if not data:
+            return
+
+        if key not in self.streams:
+            if len(self.streams) >= self.max_streams:
+                self.streams.popitem(last=False)
+            self.streams[key] = {"segments": [], "base_seq": seq}
+
+        stream = self.streams[key]
+
+        for existing_seq, existing_data in stream["segments"]:
+            if existing_seq == seq and len(existing_data) == len(data):
+                return
+
+        stream["segments"].append((seq, data))
+        self.streams.move_to_end(key)
+
+    def get_stream(self, key):
+        """Reassemble and return contiguous stream data from base_seq.
+
+        Returns data from the lowest sequence number up to the first gap.
+        """
+        if key not in self.streams:
+            return b""
+
+        stream = self.streams[key]
+        segments = sorted(stream["segments"], key=lambda s: s[0])
+
+        if not segments:
+            return b""
+
+        result = bytearray()
+        next_seq = segments[0][0]
+
+        for seq, data in segments:
+            if seq <= next_seq:
+                overlap = next_seq - seq
+                if overlap < len(data):
+                    result.extend(data[overlap:])
+                    next_seq = seq + len(data)
+            else:
+                break
+
+            if len(result) > self.max_stream_bytes:
+                result = result[:self.max_stream_bytes]
+                break
+
+        return bytes(result)
+
+    def remove_stream(self, key):
+        """Remove a stream from tracking."""
+        self.streams.pop(key, None)
+
+    def trim_stream(self, key, up_to_seq):
+        """Remove segments before up_to_seq to free memory."""
+        if key not in self.streams:
+            return
+        stream = self.streams[key]
+        stream["segments"] = [
+            (seq, data) for seq, data in stream["segments"]
+            if seq + len(data) > up_to_seq
+        ]

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -1,0 +1,119 @@
+"""
+TCP stream reassembly utilities for sequence-aware packet reassembly.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class TCPStreamReassembler:
+    """Sequence-aware TCP stream reassembler that handles out-of-order segments."""
+
+    def __init__(self, max_streams=50, max_stream_bytes=1048576):
+        """
+        Initialize the reassembler.
+
+        Args:
+            max_streams: Maximum number of concurrent streams to track.
+            max_stream_bytes: Maximum bytes to buffer per stream (default 1MB).
+        """
+        self.max_streams = max_streams
+        self.max_stream_bytes = max_stream_bytes
+        # Each stream: {'base_seq': int, 'data': bytes, 'segments': {offset: bytes}}
+        self._streams = {}
+
+    def add_segment(self, stream_id, seq, data):
+        """
+        Add a TCP segment to the reassembler.
+
+        Args:
+            stream_id: Unique stream identifier string.
+            seq: TCP sequence number of this segment.
+            data: Raw bytes of the segment payload.
+        """
+        if not data:
+            return
+
+        if stream_id not in self._streams:
+            # Evict oldest stream if at capacity
+            if len(self._streams) >= self.max_streams:
+                oldest = next(iter(self._streams))
+                del self._streams[oldest]
+            self._streams[stream_id] = {
+                'base_seq': seq,
+                'data': b'',
+                'segments': {},
+            }
+
+        stream = self._streams[stream_id]
+        base_seq = stream['base_seq']
+
+        # Compute byte offset from base sequence number (handles wrap-around)
+        offset = (seq - base_seq) & 0xFFFFFFFF
+
+        # Ignore absurdly large offsets (likely a new connection reusing the key)
+        if offset > self.max_stream_bytes:
+            return
+
+        # Store the segment keyed by offset
+        stream['segments'][offset] = data
+
+        # Reassemble contiguous data from offset 0
+        assembled = stream['data']
+        next_offset = len(assembled)
+
+        changed = True
+        while changed:
+            changed = False
+            if next_offset in stream['segments']:
+                chunk = stream['segments'].pop(next_offset)
+                assembled += chunk
+                next_offset = len(assembled)
+                changed = True
+
+        # Enforce per-stream size cap
+        if len(assembled) > self.max_stream_bytes:
+            assembled = assembled[-self.max_stream_bytes:]
+
+        stream['data'] = assembled
+
+    def get_stream(self, stream_id):
+        """
+        Return the currently assembled bytes for a stream.
+
+        Args:
+            stream_id: Unique stream identifier string.
+
+        Returns:
+            Assembled bytes, or b'' if stream is unknown.
+        """
+        stream = self._streams.get(stream_id)
+        if stream is None:
+            return b''
+        return stream['data']
+
+    def trim_stream(self, stream_id, offset):
+        """
+        Discard the first `offset` bytes of the assembled stream data.
+
+        Args:
+            stream_id: Unique stream identifier string.
+            offset: Number of bytes to discard from the front.
+        """
+        stream = self._streams.get(stream_id)
+        if stream is None:
+            return
+        if offset > 0 and offset <= len(stream['data']):
+            discarded = stream['data'][:offset]
+            stream['data'] = stream['data'][offset:]
+            # Advance base_seq by the number of bytes discarded
+            stream['base_seq'] = (stream['base_seq'] + len(discarded)) & 0xFFFFFFFF
+
+    def remove_stream(self, stream_id):
+        """Remove a stream entirely."""
+        self._streams.pop(stream_id, None)
+
+    def stream_count(self):
+        """Return the number of active streams."""
+        return len(self._streams)

--- a/ja4plus/utils/tls_utils.py
+++ b/ja4plus/utils/tls_utils.py
@@ -4,7 +4,8 @@ Enhanced TLS utility functions for JA4+ fingerprinting.
 
 import struct
 import logging
-from scapy.all import Raw
+from scapy.all import Raw, UDP
+from ja4plus.utils.quic_utils import parse_quic_initial
 
 logger = logging.getLogger(__name__)
 
@@ -13,13 +14,15 @@ def extract_tls_info(packet):
     """
     Extract TLS information from a packet.
 
+    Checks for QUIC Initial packets on UDP before falling through
+    to standard TLS record parsing on TCP.
+
     Args:
         packet: A network packet
 
     Returns:
         Dictionary with TLS handshake information or None if not applicable
     """
-    # Special handling for test packets with embedded TLS info
     if hasattr(packet, 'tls_info'):
         return packet.tls_info
 
@@ -28,6 +31,12 @@ def extract_tls_info(packet):
 
     try:
         raw_data = bytes(packet[Raw])
+
+        if UDP in packet:
+            quic_info = parse_quic_initial(raw_data)
+            if quic_info:
+                return quic_info
+
         return parse_tls_handshake(raw_data)
     except (ValueError, TypeError, AttributeError) as e:
         logger.debug(f"Packet does not contain TLS data: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ja4plus"
-version = "0.3.0"
+version = "0.4.0"
 description = "JA4+ network fingerprinting library for TLS, TCP, HTTP, SSH, and X.509 analysis"
 readme = "README.md"
 license = {text = "BSD-3-Clause AND LicenseRef-FoxIO-1.1"}

--- a/tests/test_ipv6_support.py
+++ b/tests/test_ipv6_support.py
@@ -1,0 +1,73 @@
+"""Tests that fingerprinters work with IPv6 packets."""
+
+import unittest
+import time
+from scapy.all import IPv6, IP, TCP, UDP, Raw
+
+
+def _build_tls_client_hello():
+    ch = bytearray()
+    ch += (0x0303).to_bytes(2, "big")
+    ch += b"\x00" * 32
+    ch += b"\x00"
+    ch += b"\x00\x02\x13\x01"
+    ch += b"\x01\x00"
+    hostname = b"test.com"
+    sni_entry = b"\x00" + len(hostname).to_bytes(2, "big") + hostname
+    sni_list = len(sni_entry).to_bytes(2, "big") + sni_entry
+    ext_data = b"\x00\x00" + len(sni_list).to_bytes(2, "big") + sni_list
+    ch += len(ext_data).to_bytes(2, "big") + ext_data
+    hs = b"\x01" + len(ch).to_bytes(3, "big") + bytes(ch)
+    return b"\x16\x03\x01" + len(hs).to_bytes(2, "big") + hs
+
+
+class TestJA4TIPv6(unittest.TestCase):
+    def test_ja4t_ipv6(self):
+        from ja4plus.fingerprinters.ja4t import generate_ja4t
+        pkt = IPv6(src="::1", dst="::2") / TCP(sport=12345, dport=443, flags="S", window=65535, options=[("MSS", 1460)])
+        result = generate_ja4t(pkt)
+        self.assertIsNotNone(result, "JA4T should work with IPv6")
+
+
+class TestJA4TSIPv6(unittest.TestCase):
+    def test_ja4ts_ipv6(self):
+        from ja4plus.fingerprinters.ja4ts import generate_ja4ts
+        pkt = IPv6(src="::1", dst="::2") / TCP(sport=443, dport=12345, flags="SA", window=14600, options=[("MSS", 1460)])
+        result = generate_ja4ts(pkt)
+        self.assertIsNotNone(result, "JA4TS should work with IPv6")
+
+
+class TestJA4LIPv6(unittest.TestCase):
+    def test_ja4l_ipv6_handshake(self):
+        from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+        fp = JA4LFingerprinter()
+        syn = IPv6(src="::1", dst="::2", hlim=64) / TCP(sport=12345, dport=443, flags="S")
+        result = fp.process_packet(syn)
+        self.assertIsNone(result)
+        time.sleep(0.002)
+        synack = IPv6(src="::2", dst="::1", hlim=128) / TCP(sport=443, dport=12345, flags="SA")
+        result = fp.process_packet(synack)
+        self.assertIsNotNone(result, "JA4L should work with IPv6 SYN-ACK")
+        self.assertTrue(result.startswith("JA4L-S="))
+
+
+class TestJA4SSHIPv6(unittest.TestCase):
+    def test_ja4ssh_ipv6(self):
+        from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+        fp = JA4SSHFingerprinter(packet_count=1)
+        pkt = IPv6(src="::1", dst="::2") / TCP(sport=12345, dport=22) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        result = fp.process_packet(pkt)
+        # Should not crash due to missing IP layer — that's the key test
+
+
+class TestJA4XIPv6(unittest.TestCase):
+    def test_ja4x_ipv6_no_crash(self):
+        from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
+        fp = JA4XFingerprinter()
+        pkt = IPv6(src="::1", dst="::2") / TCP(sport=12345, dport=443, seq=100) / Raw(load=b"\x16\x03\x01\x00\x05\x0b\x00\x00\x01\x00")
+        result = fp.process_packet(pkt)
+        # May return None (not enough data), but must not crash
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ja4h_reassembly.py
+++ b/tests/test_ja4h_reassembly.py
@@ -1,0 +1,31 @@
+"""Tests for JA4H TCP stream reassembly."""
+
+import unittest
+from scapy.all import IP, TCP, Raw
+
+from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
+
+
+class TestJA4HReassembly(unittest.TestCase):
+
+    def test_single_packet_still_works(self):
+        fp = JA4HFingerprinter()
+        http_data = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: test\r\n\r\n"
+        pkt = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=12345, dport=80, seq=100) / Raw(load=http_data)
+        result = fp.process_packet(pkt)
+        self.assertIsNotNone(result, "Single-packet HTTP should produce fingerprint")
+
+    def test_multi_segment_http(self):
+        fp = JA4HFingerprinter()
+        part1 = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n"
+        part2 = b"User-Agent: Mozilla/5.0\r\nAccept: text/html\r\n\r\n"
+        pkt1 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=12345, dport=80, seq=100) / Raw(load=part1)
+        pkt2 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=12345, dport=80, seq=100 + len(part1)) / Raw(load=part2)
+        result1 = fp.process_packet(pkt1)
+        result2 = fp.process_packet(pkt2)
+        self.assertTrue(result1 is not None or result2 is not None,
+                        "Multi-segment HTTP should produce fingerprint")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ja4ssh_direction.py
+++ b/tests/test_ja4ssh_direction.py
@@ -1,0 +1,51 @@
+"""Tests for JA4SSH client/server direction on non-standard ports."""
+
+import unittest
+from scapy.all import IP, TCP, Raw
+
+from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+
+
+class TestSSHDirectionNonStandardPort(unittest.TestCase):
+
+    def test_lower_port_is_server(self):
+        """Port 2222 (lower) should be server, 50000 (higher) should be client."""
+        fp = JA4SSHFingerprinter(packet_count=1)
+        pkt = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
+            sport=50000, dport=2222
+        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        fp.process_packet(pkt)
+        self.assertEqual(len(fp.connections), 1)
+        conn = list(fp.connections.values())[0]
+        self.assertEqual(conn["client_ip"], "10.0.0.1",
+                         "Higher port (50000) should be client")
+        self.assertEqual(conn["server_ip"], "10.0.0.2",
+                         "Lower port (2222) should be server")
+
+    def test_standard_port_22_unchanged(self):
+        fp = JA4SSHFingerprinter(packet_count=1)
+        pkt = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
+            sport=50000, dport=22
+        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        fp.process_packet(pkt)
+        conn = list(fp.connections.values())[0]
+        self.assertEqual(conn["client_ip"], "10.0.0.1")
+        self.assertEqual(conn["server_ip"], "10.0.0.2")
+
+    def test_server_to_client_nonstandard(self):
+        fp = JA4SSHFingerprinter(packet_count=1)
+        pkt1 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
+            sport=50000, dport=2222
+        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        fp.process_packet(pkt1)
+        pkt2 = IP(src="10.0.0.2", dst="10.0.0.1") / TCP(
+            sport=2222, dport=50000
+        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9p1\r\n")
+        fp.process_packet(pkt2)
+        conn = list(fp.connections.values())[0]
+        self.assertIsNotNone(conn["client_id"])
+        self.assertIsNotNone(conn["server_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ja4x_deep.py
+++ b/tests/test_ja4x_deep.py
@@ -299,7 +299,7 @@ class TestJA4XFingerprinterClass(unittest.TestCase):
         fp.fingerprint_certificate(cert)
         fp.reset()
         self.assertEqual(len(fp.get_fingerprints()), 0)
-        self.assertEqual(fp.reassembler.stream_count(), 0)
+        self.assertEqual(len(fp.reassembler.streams), 0)
         self.assertEqual(len(fp.processed_certs), 0)
 
     def test_get_cert_details(self):

--- a/tests/test_ja4x_deep.py
+++ b/tests/test_ja4x_deep.py
@@ -299,7 +299,7 @@ class TestJA4XFingerprinterClass(unittest.TestCase):
         fp.fingerprint_certificate(cert)
         fp.reset()
         self.assertEqual(len(fp.get_fingerprints()), 0)
-        self.assertEqual(len(fp.streams), 0)
+        self.assertEqual(fp.reassembler.stream_count(), 0)
         self.assertEqual(len(fp.processed_certs), 0)
 
     def test_get_cert_details(self):

--- a/tests/test_ja4x_reassembly.py
+++ b/tests/test_ja4x_reassembly.py
@@ -1,0 +1,36 @@
+"""Tests for JA4X TCP stream reassembly with out-of-order segments."""
+
+import unittest
+from scapy.all import IP, TCP, Raw
+
+from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
+
+
+class TestJA4XReassembly(unittest.TestCase):
+
+    def test_in_order_still_works(self):
+        fp = JA4XFingerprinter()
+        data = b"\x16\x03\x01\x00\x05\x0b\x00\x00\x01\x00"
+        pkt = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=443, dport=12345, seq=100) / Raw(load=data)
+        result = fp.process_packet(pkt)
+        # May return None (not enough cert data), but should not crash
+
+    def test_out_of_order_segments(self):
+        fp = JA4XFingerprinter()
+        tls_header = b"\x16\x03\x01\x00\x0a"
+        tls_body = b"\x0b\x00\x00\x06\x00\x00\x03\x00\x00\x00"
+        part1 = tls_header + tls_body[:5]
+        part2 = tls_body[5:]
+        pkt2 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
+            sport=443, dport=12345, seq=100 + len(part1)
+        ) / Raw(load=part2)
+        fp.process_packet(pkt2)
+        pkt1 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
+            sport=443, dport=12345, seq=100
+        ) / Raw(load=part1)
+        result = fp.process_packet(pkt1)
+        # Should not crash; reassembly should handle ordering
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_packet_utils.py
+++ b/tests/test_packet_utils.py
@@ -1,0 +1,55 @@
+"""Tests for IPv4/IPv6 packet utility helpers."""
+
+import unittest
+from scapy.all import IP, TCP, Raw, IPv6
+
+
+class TestGetIPLayer(unittest.TestCase):
+
+    def test_ipv4_packet(self):
+        from ja4plus.utils.packet_utils import get_ip_layer
+        pkt = IP(src="1.2.3.4", dst="5.6.7.8") / TCP()
+        layer = get_ip_layer(pkt)
+        self.assertIsNotNone(layer)
+        self.assertEqual(layer.src, "1.2.3.4")
+
+    def test_ipv6_packet(self):
+        from ja4plus.utils.packet_utils import get_ip_layer
+        pkt = IPv6(src="::1", dst="::2") / TCP()
+        layer = get_ip_layer(pkt)
+        self.assertIsNotNone(layer)
+        self.assertEqual(layer.src, "::1")
+
+    def test_no_ip_returns_none(self):
+        from ja4plus.utils.packet_utils import get_ip_layer
+        pkt = TCP()
+        layer = get_ip_layer(pkt)
+        self.assertIsNone(layer)
+
+    def test_ipv4_preferred_when_both(self):
+        from ja4plus.utils.packet_utils import get_ip_layer
+        pkt = IPv6(src="::1", dst="::2") / IP(src="1.2.3.4") / TCP()
+        layer = get_ip_layer(pkt)
+        self.assertIsNotNone(layer)
+
+
+class TestGetTTL(unittest.TestCase):
+
+    def test_ipv4_ttl(self):
+        from ja4plus.utils.packet_utils import get_ttl
+        pkt = IP(ttl=128) / TCP()
+        self.assertEqual(get_ttl(pkt), 128)
+
+    def test_ipv6_hlim(self):
+        from ja4plus.utils.packet_utils import get_ttl
+        pkt = IPv6(hlim=64) / TCP()
+        self.assertEqual(get_ttl(pkt), 64)
+
+    def test_no_ip_returns_none(self):
+        from ja4plus.utils.packet_utils import get_ttl
+        pkt = TCP()
+        self.assertIsNone(get_ttl(pkt))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quic_integration.py
+++ b/tests/test_quic_integration.py
@@ -1,0 +1,55 @@
+"""Integration tests for QUIC support in extract_tls_info."""
+
+import unittest
+from unittest.mock import patch
+from scapy.all import IP, UDP, TCP, Raw
+
+from ja4plus.utils.tls_utils import extract_tls_info
+
+
+class TestExtractTlsInfoQuicPath(unittest.TestCase):
+
+    def _make_udp_packet(self, payload):
+        return IP(src="10.0.0.1", dst="10.0.0.2") / UDP(sport=12345, dport=443) / Raw(load=payload)
+
+    @patch("ja4plus.utils.tls_utils.parse_quic_initial")
+    def test_udp_triggers_quic(self, mock_quic):
+        mock_quic.return_value = {
+            "type": "client_hello", "is_quic": True,
+            "version": 0x0303, "ciphers": [0x1301], "extensions": [],
+        }
+        result = extract_tls_info(self._make_udp_packet(b"\xC0" + b"\x00" * 50))
+        mock_quic.assert_called_once()
+        self.assertTrue(result["is_quic"])
+
+    @patch("ja4plus.utils.tls_utils.parse_quic_initial")
+    def test_quic_none_falls_through(self, mock_quic):
+        mock_quic.return_value = None
+        result = extract_tls_info(self._make_udp_packet(b"\x00" * 50))
+        self.assertIsNone(result)
+
+    @patch("ja4plus.utils.tls_utils.parse_quic_initial")
+    def test_tcp_skips_quic(self, mock_quic):
+        pkt = IP() / TCP(sport=12345, dport=443) / Raw(load=b"\x16\x03\x01" + b"\x00" * 50)
+        extract_tls_info(pkt)
+        mock_quic.assert_not_called()
+
+
+class TestQuicJA4Integration(unittest.TestCase):
+
+    def test_quic_ja4_starts_with_q(self):
+        from ja4plus.fingerprinters.ja4 import generate_ja4
+        tls_info = {
+            "type": "client_hello", "is_quic": True, "is_dtls": False,
+            "version": 0x0303, "supported_versions": [0x0304],
+            "sni": "example.com", "ciphers": [0x1301, 0x1302, 0x1303],
+            "extensions": [0x0000, 0x000A, 0x000B, 0x002B, 0x0010],
+            "alpn_protocols": ["h2"], "signature_algorithms": [0x0804],
+        }
+        result = generate_ja4(tls_info)
+        self.assertIsNotNone(result)
+        self.assertTrue(result.startswith("q"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quic_utils.py
+++ b/tests/test_quic_utils.py
@@ -1,0 +1,127 @@
+"""Tests for QUIC Initial packet parsing utilities."""
+
+import unittest
+
+
+class TestDecodeVarint(unittest.TestCase):
+
+    def test_1byte(self):
+        from ja4plus.utils.quic_utils import _decode_varint
+        val, consumed = _decode_varint(b"\x25")
+        self.assertEqual(val, 37)
+        self.assertEqual(consumed, 1)
+
+    def test_2byte(self):
+        from ja4plus.utils.quic_utils import _decode_varint
+        val, consumed = _decode_varint(b"\x7b\xbd")
+        self.assertEqual(val, 15293)
+        self.assertEqual(consumed, 2)
+
+    def test_4byte(self):
+        from ja4plus.utils.quic_utils import _decode_varint
+        val, consumed = _decode_varint(b"\x9d\x7f\x3e\x7d")
+        self.assertEqual(val, 494878333)
+        self.assertEqual(consumed, 4)
+
+    def test_zero(self):
+        from ja4plus.utils.quic_utils import _decode_varint
+        val, consumed = _decode_varint(b"\x00")
+        self.assertEqual(val, 0)
+        self.assertEqual(consumed, 1)
+
+
+class TestHKDFExpandLabel(unittest.TestCase):
+
+    def test_output_length(self):
+        from ja4plus.utils.quic_utils import hkdf_expand_label
+        result = hkdf_expand_label(b"\x00" * 32, b"quic key", b"", 16)
+        self.assertEqual(len(result), 16)
+
+    def test_iv_length(self):
+        from ja4plus.utils.quic_utils import hkdf_expand_label
+        result = hkdf_expand_label(b"\x00" * 32, b"quic iv", b"", 12)
+        self.assertEqual(len(result), 12)
+
+
+class TestDeriveInitialSecrets(unittest.TestCase):
+
+    DCID = bytes.fromhex("8394c8f03e515708")
+
+    def test_secret_lengths(self):
+        from ja4plus.utils.quic_utils import derive_initial_secrets
+        cs, ss = derive_initial_secrets(self.DCID, version=1)
+        self.assertEqual(len(cs), 32)
+        self.assertEqual(len(ss), 32)
+
+    def test_key_iv_hp_lengths(self):
+        from ja4plus.utils.quic_utils import derive_initial_secrets, derive_key_iv_hp
+        cs, _ = derive_initial_secrets(self.DCID, version=1)
+        key, iv, hp = derive_key_iv_hp(cs)
+        self.assertEqual(len(key), 16)
+        self.assertEqual(len(iv), 12)
+        self.assertEqual(len(hp), 16)
+
+
+class TestFindPnOffset(unittest.TestCase):
+
+    def test_minimal_initial(self):
+        from ja4plus.utils.quic_utils import _find_pn_offset
+        packet = bytearray()
+        packet.append(0xC0)
+        packet += b"\x00\x00\x00\x01"
+        packet.append(8)
+        packet += b"\x00" * 8
+        packet.append(0)
+        packet.append(0)
+        packet += b"\x40\x02"
+        packet += b"\x00" * 20
+        self.assertEqual(_find_pn_offset(bytes(packet)), 18)
+
+
+class TestParseQuicInitial(unittest.TestCase):
+
+    def test_too_short(self):
+        from ja4plus.utils.quic_utils import parse_quic_initial
+        self.assertIsNone(parse_quic_initial(b"\x00" * 10))
+
+    def test_short_header(self):
+        from ja4plus.utils.quic_utils import parse_quic_initial
+        self.assertIsNone(parse_quic_initial(b"\x40" + b"\x00" * 30))
+
+    def test_version_negotiation(self):
+        from ja4plus.utils.quic_utils import parse_quic_initial
+        pkt = bytearray(b"\xC0") + b"\x00\x00\x00\x00" + b"\x00" * 30
+        self.assertIsNone(parse_quic_initial(bytes(pkt)))
+
+    def test_non_initial_type(self):
+        from ja4plus.utils.quic_utils import parse_quic_initial
+        pkt = bytearray()
+        pkt.append(0xC0 | (0x02 << 4))
+        pkt += b"\x00\x00\x00\x01" + b"\x00" * 30
+        self.assertIsNone(parse_quic_initial(bytes(pkt)))
+
+
+class TestExtractCryptoFrames(unittest.TestCase):
+
+    def test_single_crypto_frame(self):
+        from ja4plus.utils.quic_utils import extract_crypto_frames
+        result = extract_crypto_frames(b"\x06\x00\x05hello")
+        self.assertEqual(result, b"hello")
+
+    def test_padding_then_crypto(self):
+        from ja4plus.utils.quic_utils import extract_crypto_frames
+        result = extract_crypto_frames(b"\x00\x06\x00\x03abc")
+        self.assertEqual(result, b"abc")
+
+    def test_no_crypto_returns_none(self):
+        from ja4plus.utils.quic_utils import extract_crypto_frames
+        self.assertIsNone(extract_crypto_frames(b"\x00\x00\x00"))
+
+    def test_multiple_frames_reassembled(self):
+        from ja4plus.utils.quic_utils import extract_crypto_frames
+        result = extract_crypto_frames(b"\x06\x00\x03abc\x06\x03\x03def")
+        self.assertEqual(result, b"abcdef")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tcp_stream.py
+++ b/tests/test_tcp_stream.py
@@ -1,0 +1,76 @@
+"""Tests for TCP stream reassembly."""
+
+import unittest
+
+
+class TestTCPStreamReassembler(unittest.TestCase):
+
+    def test_in_order_reassembly(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        r = TCPStreamReassembler()
+        key = "10.0.0.1:1234-10.0.0.2:443"
+        r.add_segment(key, seq=100, data=b"hello")
+        r.add_segment(key, seq=105, data=b" world")
+        self.assertEqual(r.get_stream(key), b"hello world")
+
+    def test_out_of_order_reassembly(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=105, data=b" world")
+        r.add_segment(key, seq=100, data=b"hello")
+        self.assertEqual(r.get_stream(key), b"hello world")
+
+    def test_duplicate_segment_ignored(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=100, data=b"hello")
+        r.add_segment(key, seq=100, data=b"hello")
+        self.assertEqual(r.get_stream(key), b"hello")
+
+    def test_overlapping_segment(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=100, data=b"hello world")
+        r.add_segment(key, seq=105, data=b" world!")
+        result = r.get_stream(key)
+        self.assertTrue(result.startswith(b"hello world"))
+
+    def test_gap_in_stream(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=100, data=b"hello")
+        r.add_segment(key, seq=200, data=b"world")
+        self.assertEqual(r.get_stream(key), b"hello")
+
+    def test_remove_stream(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=100, data=b"hello")
+        r.remove_stream(key)
+        self.assertEqual(r.get_stream(key), b"")
+
+    def test_max_streams_cleanup(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        r = TCPStreamReassembler(max_streams=3)
+        r.add_segment("s1", seq=0, data=b"a")
+        r.add_segment("s2", seq=0, data=b"b")
+        r.add_segment("s3", seq=0, data=b"c")
+        r.add_segment("s4", seq=0, data=b"d")
+        self.assertLessEqual(len(r.streams), 3)
+
+    def test_max_stream_size(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+        r = TCPStreamReassembler(max_stream_bytes=10)
+        key = "stream1"
+        r.add_segment(key, seq=0, data=b"a" * 20)
+        result = r.get_stream(key)
+        self.assertLessEqual(len(result), 20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **QUIC Initial packet parsing** (RFC 9001/9369) — auto-detected on UDP, decrypts Initial packets to extract TLS ClientHello, produces `q` protocol prefix in JA4 fingerprints
- **IPv6 support** — all fingerprinters (JA4L, JA4SSH, JA4X) now handle both IPv4 and IPv6 via new `packet_utils` helpers
- **TCP stream reassembly** — new sequence-aware `TCPStreamReassembler` used by JA4H (multi-segment HTTP) and JA4X (out-of-order certificate delivery)
- **Bug fix: JA4SSH direction detection** — lower port now correctly identified as server on non-standard SSH ports
- **Documentation** — `docs/implementation_notes.md` documenting all undocumented spec deviations for Go port reference

## New files

| File | Purpose |
|------|---------|
| `ja4plus/utils/quic_utils.py` | QUIC v1/v2 Initial decryption pipeline |
| `ja4plus/utils/tcp_stream.py` | Sequence-aware TCP stream reassembly |
| `ja4plus/utils/packet_utils.py` | IPv4/IPv6 abstraction helpers |
| `docs/implementation_notes.md` | Spec deviation documentation |
| 6 new test files | 48 new tests |

## Test plan

- [x] All 473 tests pass (425 original + 48 new)
- [ ] Cross-validate QUIC fingerprints against Go implementation
- [ ] Test with real QUIC pcap captures (e.g. Chrome → google.com)
- [ ] Verify IPv6 fingerprints match IPv4 for same TLS ClientHello

🤖 Generated with [Claude Code](https://claude.com/claude-code)