### PR TITLE
feat: port Go library features — JA4D, QUIC JA4S, cleanup API, raw fingerprint fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .omc/
 .claude/
 .gstack/
+.worktrees/

--- a/ja4plus/fingerprinters/__init__.py
+++ b/ja4plus/fingerprinters/__init__.py
@@ -10,6 +10,7 @@ from .ja4x import JA4XFingerprinter
 from .ja4ssh import JA4SSHFingerprinter
 from .ja4t import JA4TFingerprinter
 from .ja4ts import JA4TSFingerprinter
+from .ja4d import JA4DFingerprinter
 
 __all__ = [
     'JA4Fingerprinter',
@@ -19,5 +20,6 @@ __all__ = [
     'JA4XFingerprinter',
     'JA4SSHFingerprinter',
     'JA4TFingerprinter',
-    'JA4TSFingerprinter'
+    'JA4TSFingerprinter',
+    'JA4DFingerprinter',
 ] 

--- a/ja4plus/fingerprinters/base.py
+++ b/ja4plus/fingerprinters/base.py
@@ -46,4 +46,20 @@ class BaseFingerprinter:
     
     def reset(self):
         """Reset the fingerprinter state."""
-        self.fingerprints = [] 
+        self.fingerprints = []
+
+    def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
+        """
+        Remove internal state for the given completed or evicted connection.
+
+        Stateless fingerprinters (JA4, JA4T, JA4TS, JA4D) use this no-op.
+        Stateful subclasses override to evict per-connection data and prevent
+        memory leaks in long-running monitors.
+
+        Args:
+            src_ip:   Source IP address string
+            src_port: Source port (int)
+            dst_ip:   Destination IP address string
+            dst_port: Destination port (int)
+            proto:    Protocol string, e.g. 'tcp' or 'udp'
+        """

--- a/ja4plus/fingerprinters/ja4.py
+++ b/ja4plus/fingerprinters/ja4.py
@@ -242,11 +242,7 @@ def get_raw_fingerprint(tls_info, original_order=False):
         else:
             raw_ja4 = f"{part_a}_{cipher_list}_{ext_list}"
         
-        # Add suffix to indicate format
-        if original_order:
-            return f"JA4_ro = {raw_ja4}"
-        else:
-            return f"JA4_r = {raw_ja4}"
+        return raw_ja4
             
     except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
         logger.debug(f"Failed to generate JA4 fingerprint: {e}")

--- a/ja4plus/fingerprinters/ja4d.py
+++ b/ja4plus/fingerprinters/ja4d.py
@@ -1,0 +1,207 @@
+"""
+JA4D DHCP Fingerprinting implementation.
+
+Format: {msg_type}{max_msg_size}{request_ip}{fqdn}_{option_list}_{param_list}
+
+Section a: 5-char message type abbreviation + 4-digit max message size +
+           'i'/'n' for requested IP + 'd'/'n' for FQDN
+Section b: DHCP options present (hyphen-separated decimal), skipping 53/255/50/81
+Section c: Parameter Request List contents from option 55 (hyphen-separated decimal)
+"""
+
+import logging
+
+from scapy.all import UDP
+
+logger = logging.getLogger(__name__)
+
+from ja4plus.fingerprinters.base import BaseFingerprinter
+
+# DHCP message type (option 53) to 5-character abbreviation.
+DHCP_MESSAGE_TYPES = {
+    1:  "disco",  # DHCPDISCOVER
+    2:  "offer",  # DHCPOFFER
+    3:  "reqst",  # DHCPREQUEST
+    4:  "decln",  # DHCPDECLINE
+    5:  "dpack",  # DHCPACK
+    6:  "dpnak",  # DHCPNAK
+    7:  "relse",  # DHCPRELEASE
+    8:  "infor",  # DHCPINFORM
+    9:  "frenw",  # DHCPFORCERENEW
+    10: "lqery",  # DHCPLEASEQUERY
+    11: "lunas",  # DHCPLEASEUNASSIGNED
+    12: "lunkn",  # DHCPLEASEUNKNOWN
+    13: "lactv",  # DHCPLEASEACTIVE
+    14: "blklq",  # DHCPBULKLEASEQUERY
+    15: "lqdon",  # DHCPLEASEQUERYDONE
+    16: "actlq",  # DHCPACTIVELEASEQUERY
+    17: "lqsta",  # DHCPLEASEQUERYSTATUS
+    18: "dhtls",  # DHCPTLS
+}
+
+# Options to skip in section b (already encoded in section a or terminal).
+DHCP_SKIP_OPTIONS = {53, 255, 50, 81}
+
+# DHCP magic cookie
+_DHCP_MAGIC = b'\x63\x82\x53\x63'
+
+# UDP ports used by DHCP
+_DHCP_PORTS = {67, 68}
+
+
+def build_option_list(option_codes):
+    """
+    Format DHCP option codes as hyphen-separated decimals, skipping
+    options in DHCP_SKIP_OPTIONS. Returns '00' if nothing remains.
+
+    Args:
+        option_codes: list of integer option codes in wire order
+
+    Returns:
+        Hyphen-separated string of option codes, or '00'
+    """
+    parts = [str(code) for code in option_codes if code not in DHCP_SKIP_OPTIONS]
+    return '-'.join(parts) if parts else "00"
+
+
+def build_param_list(params):
+    """
+    Format the Parameter Request List (option 55) as hyphen-separated
+    decimals. Returns '00' if empty.
+
+    Args:
+        params: list of integer parameter codes
+
+    Returns:
+        Hyphen-separated string, or '00'
+    """
+    if not params:
+        return "00"
+    return '-'.join(str(p) for p in params)
+
+
+def _parse_dhcp_options(raw_payload):
+    """
+    Parse DHCP options from a raw UDP payload (BOOTP + magic cookie + options).
+
+    Returns a dict with keys:
+        msg_type, max_msg_size, has_request_ip, has_fqdn,
+        option_codes (in wire order), param_list
+    or None if the payload doesn't look like a valid DHCP message.
+    """
+    # BOOTP fixed header is 236 bytes; magic cookie is 4 bytes
+    header_size = 236 + 4
+    if len(raw_payload) < header_size:
+        return None
+
+    # Verify magic cookie
+    if raw_payload[236:240] != _DHCP_MAGIC:
+        return None
+
+    msg_type = 0
+    max_msg_size = 0
+    has_request_ip = False
+    has_fqdn = False
+    option_codes = []
+    param_list = []
+
+    pos = 240  # start of options
+    while pos < len(raw_payload):
+        opt_code = raw_payload[pos]
+        pos += 1
+
+        if opt_code == 255:  # End
+            option_codes.append(255)
+            break
+        if opt_code == 0:    # Pad
+            continue
+
+        if pos >= len(raw_payload):
+            break
+        opt_len = raw_payload[pos]
+        pos += 1
+
+        opt_data = raw_payload[pos:pos + opt_len]
+        pos += opt_len
+
+        option_codes.append(opt_code)
+
+        if opt_code == 53 and opt_len >= 1:   # Message Type
+            msg_type = opt_data[0]
+        elif opt_code == 57 and opt_len >= 2:  # Max Message Size
+            max_msg_size = (opt_data[0] << 8) | opt_data[1]
+        elif opt_code == 50:                   # Requested IP Address
+            has_request_ip = True
+        elif opt_code == 81:                   # Client FQDN
+            has_fqdn = True
+        elif opt_code == 55:                   # Parameter Request List
+            param_list = list(opt_data)
+
+    if msg_type == 0:
+        return None
+
+    return {
+        'msg_type': msg_type,
+        'max_msg_size': max_msg_size,
+        'has_request_ip': has_request_ip,
+        'has_fqdn': has_fqdn,
+        'option_codes': option_codes,
+        'param_list': param_list,
+    }
+
+
+def generate_ja4d(packet):
+    """
+    Generate a JA4D fingerprint from a packet.
+
+    Args:
+        packet: A Scapy packet potentially containing a DHCPv4 message
+
+    Returns:
+        A JA4D fingerprint string or None if the packet is not applicable
+    """
+    udp = packet.getlayer(UDP)
+    if udp is None:
+        return None
+
+    if (udp.sport not in _DHCP_PORTS and udp.dport not in _DHCP_PORTS):
+        return None
+
+    # Get raw UDP payload
+    raw_payload = bytes(udp.payload)
+    parsed = _parse_dhcp_options(raw_payload)
+    if parsed is None:
+        return None
+
+    msg_type = parsed['msg_type']
+    max_msg_size = min(parsed['max_msg_size'], 9999)
+    has_request_ip = parsed['has_request_ip']
+    has_fqdn = parsed['has_fqdn']
+
+    # Section a
+    msg_type_str = DHCP_MESSAGE_TYPES.get(msg_type, f"{msg_type:05d}")
+    request_ip_flag = "i" if has_request_ip else "n"
+    fqdn_flag = "d" if has_fqdn else "n"
+    section_a = f"{msg_type_str}{max_msg_size:04d}{request_ip_flag}{fqdn_flag}"
+
+    # Section b
+    section_b = build_option_list(parsed['option_codes'])
+
+    # Section c
+    section_c = build_param_list(parsed['param_list'])
+
+    return f"{section_a}_{section_b}_{section_c}"
+
+
+class JA4DFingerprinter(BaseFingerprinter):
+    """Fingerprinter for JA4D (DHCP)."""
+
+    def process_packet(self, packet):
+        """Process a packet and extract JA4D fingerprint if applicable."""
+        fingerprint = generate_ja4d(packet)
+        if fingerprint:
+            self.add_fingerprint(fingerprint, packet)
+        return fingerprint
+
+    def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
+        """No-op: JA4D is stateless (per-packet fingerprinter)."""

--- a/ja4plus/fingerprinters/ja4h.py
+++ b/ja4plus/fingerprinters/ja4h.py
@@ -83,6 +83,14 @@ class JA4HFingerprinter(BaseFingerprinter):
         super().reset()
         self.reassembler = TCPStreamReassembler(max_streams=100)
 
+    def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
+        """Remove TCP stream buffer for the given connection."""
+        stream_key = f"{src_ip}:{src_port}-{dst_ip}:{dst_port}"
+        self.reassembler.remove_stream(stream_key)
+        # Also try reverse direction
+        rev_key = f"{dst_ip}:{dst_port}-{src_ip}:{src_port}"
+        self.reassembler.remove_stream(rev_key)
+
 
 def _extract_http_info_from_bytes(data):
     """Extract HTTP info from raw bytes, preserving original header name casing.

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -90,6 +90,14 @@ class JA4LFingerprinter(BaseFingerprinter):
         super().reset()
         self.connections = {}
 
+    def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
+        """Remove stored timing state for the given connection."""
+        # JA4L normalizes the key so we must try both orderings
+        fwd = f"{proto}_{src_ip}:{src_port}_{dst_ip}:{dst_port}"
+        rev = f"{proto}_{dst_ip}:{dst_port}_{src_ip}:{src_port}"
+        self.connections.pop(fwd, None)
+        self.connections.pop(rev, None)
+
     def calculate_distance(self, latency_us, propagation_factor=1.6):
         """
         Calculate the physical distance based on JA4L latency.

--- a/ja4plus/fingerprinters/ja4s.py
+++ b/ja4plus/fingerprinters/ja4s.py
@@ -4,10 +4,13 @@ JA4S TLS Server Hello Fingerprinting implementation.
 
 import hashlib
 import logging
-from scapy.all import IP, TCP, Raw
+import struct
+
+from scapy.all import IP, IPv6, TCP, UDP, Raw
 
 logger = logging.getLogger(__name__)
 from ja4plus.utils.tls_utils import extract_tls_info, is_grease_value
+from ja4plus.utils.quic_utils import parse_quic_server_initial, parse_quic_initial
 from ja4plus.fingerprinters.base import BaseFingerprinter
 
 
@@ -15,13 +18,25 @@ class JA4SFingerprinter(BaseFingerprinter):
     """
     JA4S TLS Server Hello Fingerprinting implementation.
 
-    JA4S fingerprints server responses in TLS handshakes.
+    JA4S fingerprints server responses in TLS handshakes, including QUIC.
+    For QUIC, tracks the client's Destination Connection ID (DCID) from
+    client Initial packets, then uses it to decrypt server Initial packets.
+
     Format: <proto><version><ext_count><alpn>_<cipher>_<ext_hash>
     """
+
+    def __init__(self):
+        super().__init__()
+        # Maps "srcIP:srcPort-dstIP:dstPort" -> client DCID bytes
+        self._quic_dcids = {}
 
     def process_packet(self, packet):
         """
         Process a packet and extract JA4S fingerprint if applicable.
+
+        Handles:
+        - TCP/TLS ServerHello (existing path)
+        - QUIC Server Initial: requires a prior Client Initial in the same flow
 
         Args:
             packet: A network packet to analyze
@@ -29,10 +44,134 @@ class JA4SFingerprinter(BaseFingerprinter):
         Returns:
             The extracted fingerprint if successful, None otherwise
         """
+        # Try QUIC path first (UDP packets)
+        udp = packet.getlayer(UDP)
+        if udp is not None:
+            udp_payload = bytes(udp.payload)
+            if udp_payload:
+                src_ip, dst_ip = _get_ip_pair(packet)
+                src_port = int(udp.sport)
+                dst_port = int(udp.dport)
+
+                fwd_key = f"{src_ip}:{src_port}-{dst_ip}:{dst_port}"
+                rev_key = f"{dst_ip}:{dst_port}-{src_ip}:{src_port}"
+
+                # Check if this is a QUIC Client Initial — capture its DCID
+                if _is_quic_client_initial(udp_payload):
+                    dcid = _extract_dcid(udp_payload)
+                    if dcid is not None:
+                        self._quic_dcids[fwd_key] = dcid
+                    return None
+
+                # Try to decode as QUIC Server Initial using the stored client DCID
+                if rev_key in self._quic_dcids:
+                    client_dcid = self._quic_dcids[rev_key]
+                    tls_info = parse_quic_server_initial(udp_payload, client_dcid)
+                    if tls_info and tls_info.get('handshake_type') == 'server_hello':
+                        fingerprint = _generate_ja4s_from_tls_info(tls_info)
+                        if fingerprint:
+                            self.add_fingerprint(fingerprint, packet)
+                            return fingerprint
+
+        # TCP/TLS path
         fingerprint = generate_ja4s(packet)
         if fingerprint:
             self.add_fingerprint(fingerprint, packet)
             return fingerprint
+        return None
+
+    def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
+        """Remove stored QUIC DCID state for the given connection."""
+        fwd = f"{src_ip}:{src_port}-{dst_ip}:{dst_port}"
+        rev = f"{dst_ip}:{dst_port}-{src_ip}:{src_port}"
+        self._quic_dcids.pop(fwd, None)
+        self._quic_dcids.pop(rev, None)
+
+    def reset(self):
+        """Reset all state."""
+        super().reset()
+        self._quic_dcids = {}
+
+
+def _get_ip_pair(packet):
+    """Extract (src_ip, dst_ip) as strings from a packet."""
+    ip = packet.getlayer(IP) or packet.getlayer(IPv6)
+    if ip:
+        return str(ip.src), str(ip.dst)
+    return "0.0.0.0", "0.0.0.0"
+
+
+def _is_quic_client_initial(udp_payload):
+    """Return True if the UDP payload looks like a QUIC v1/v2 client Initial."""
+    if len(udp_payload) < 6:
+        return False
+    first_byte = udp_payload[0]
+    if not (first_byte & 0x80):
+        return False
+    version = struct.unpack("!I", udp_payload[1:5])[0]
+    if version == 0:
+        return False
+    packet_type = (first_byte & 0x30) >> 4
+    is_v2 = version == 0x6B3343CF
+    if is_v2:
+        return packet_type == 0x01
+    return packet_type == 0x00
+
+
+def _extract_dcid(udp_payload):
+    """Extract the Destination Connection ID bytes from a QUIC long header."""
+    if len(udp_payload) < 6:
+        return None
+    dcid_len = udp_payload[5]
+    if 6 + dcid_len > len(udp_payload):
+        return None
+    return udp_payload[6:6 + dcid_len]
+
+
+def _generate_ja4s_from_tls_info(tls_info):
+    """
+    Generate a JA4S fingerprint from an already-parsed tls_info dict.
+    Shared by the TCP path (via generate_ja4s) and the QUIC server path.
+    """
+    try:
+        proto = 'q' if tls_info.get('is_quic') else 'd' if tls_info.get('is_dtls') else 't'
+
+        version = tls_info.get('version')
+        supported_versions = tls_info.get('supported_versions', [])
+        if supported_versions:
+            non_grease = [v for v in supported_versions if not is_grease_value(v)]
+            if non_grease:
+                version = non_grease[0]
+
+        version_str = _version_to_str(version)
+        extensions = tls_info.get('extensions', [])
+        ext_count = f"{min(len(extensions), 99):02d}"
+
+        alpn_protocols = tls_info.get('alpn_protocols', [])
+        if not alpn_protocols:
+            for ext_id, ext_data in tls_info.get('extension_data', {}).items():
+                if ext_id == 0x0010 and 'protocols' in ext_data and ext_data['protocols']:
+                    alpn_protocols = ext_data['protocols']
+                    break
+
+        alpn_value = _get_alpn_value(alpn_protocols)
+        part_a = f"{proto}{version_str}{ext_count}{alpn_value}"
+
+        cipher = tls_info.get('cipher')
+        if cipher is None:
+            return None
+        cipher_str = f"{cipher:04x}"
+
+        if extensions:
+            ext_str = ','.join([f"{e:04x}" for e in extensions])
+            extensions_hash = hashlib.sha256(ext_str.encode()).hexdigest()[:12]
+        else:
+            extensions_hash = '000000000000'
+
+        return f"{part_a}_{cipher_str}_{extensions_hash}"
+
+    except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
+        logger.debug(f"JA4S generation from tls_info failed: {e}")
         return None
 
 
@@ -46,67 +185,10 @@ def generate_ja4s(packet):
     Returns:
         A JA4S fingerprint string or None if not applicable
     """
-    # Extract TLS info
     tls_info = extract_tls_info(packet)
     if not tls_info or tls_info.get('handshake_type') != 'server_hello':
         return None
-
-    try:
-        # Protocol indicator (t for TCP/TLS, q for QUIC, d for DTLS)
-        proto = 'q' if tls_info.get('is_quic') else 'd' if tls_info.get('is_dtls') else 't'
-
-        # Get TLS version - check supported_versions first (for TLS 1.3)
-        version = tls_info.get('version')
-        supported_versions = tls_info.get('supported_versions', [])
-        if supported_versions:
-            non_grease = [v for v in supported_versions if not is_grease_value(v)]
-            if non_grease:
-                version = non_grease[0]
-
-        version_str = _version_to_str(version)
-
-        # Get extensions - JA4S INCLUDES GREASE values per FoxIO spec
-        # (unlike JA4 client which excludes them)
-        extensions = tls_info.get('extensions', [])
-        ext_count = f"{min(len(extensions), 99):02d}"
-
-        # Extract ALPN - use first and last character of first protocol
-        alpn_protocols = tls_info.get('alpn_protocols', [])
-        if not alpn_protocols:
-            # Check extension_data for backward compatibility
-            for ext_id, ext_data in tls_info.get('extension_data', {}).items():
-                if ext_id == 0x0010 and 'protocols' in ext_data and ext_data['protocols']:
-                    alpn_protocols = ext_data['protocols']
-                    break
-
-        alpn_value = _get_alpn_value(alpn_protocols)
-
-        # Form part_a of the fingerprint
-        part_a = f"{proto}{version_str}{ext_count}{alpn_value}"
-
-        # Get selected cipher
-        cipher = tls_info.get('cipher')
-        if cipher is None:
-            return None
-        cipher_str = f"{cipher:04x}"
-
-        # Hash the extensions as comma-separated hex values
-        # JA4S extensions are NOT sorted - they maintain original order per spec
-        # JA4S INCLUDES GREASE values in the hash per FoxIO spec
-        if extensions:
-            ext_str = ','.join([f"{e:04x}" for e in extensions])
-            extensions_hash = hashlib.sha256(ext_str.encode()).hexdigest()[:12]
-        else:
-            extensions_hash = '000000000000'
-
-        # Form the complete JA4S fingerprint
-        ja4s = f"{part_a}_{cipher_str}_{extensions_hash}"
-
-        return ja4s
-
-    except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
-        logger.debug(f"Packet does not contain JA4S data: {e}")
-        return None
+    return _generate_ja4s_from_tls_info(tls_info)
 
 
 def _version_to_str(version):

--- a/ja4plus/fingerprinters/ja4ssh.py
+++ b/ja4plus/fingerprinters/ja4ssh.py
@@ -273,7 +273,15 @@ class JA4SSHFingerprinter(BaseFingerprinter):
         super().reset()
         self.hassh_fingerprints = []
         self.connections = {}
-        
+
+    def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
+        """Remove stored SSH session state for the given connection."""
+        # JA4SSH stores state as client:port-server:port (client is higher port)
+        fwd = f"{src_ip}:{src_port}-{dst_ip}:{dst_port}"
+        rev = f"{dst_ip}:{dst_port}-{src_ip}:{src_port}"
+        self.connections.pop(fwd, None)
+        self.connections.pop(rev, None)
+
     def interpret_fingerprint(self, fingerprint):
         """
         Interpret a JA4SSH fingerprint to determine session type.

--- a/ja4plus/fingerprinters/ja4x.py
+++ b/ja4plus/fingerprinters/ja4x.py
@@ -63,7 +63,14 @@ class JA4XFingerprinter(BaseFingerprinter):
         self.reassembler = TCPStreamReassembler(max_streams=50, max_stream_bytes=1048576)
         self.processed_certs = set()
         self.last_cleanup = time.time()
-    
+
+    def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
+        """Remove TCP stream buffer for the given connection."""
+        stream_key = f"{src_ip}:{src_port}-{dst_ip}:{dst_port}"
+        self.reassembler.remove_stream(stream_key)
+        rev_key = f"{dst_ip}:{dst_port}-{src_ip}:{src_port}"
+        self.reassembler.remove_stream(rev_key)
+
     def process_packet(self, packet):
         """Process a packet and extract JA4X fingerprint if applicable."""
         if not (TCP in packet and Raw in packet):

--- a/ja4plus/utils/quic_utils.py
+++ b/ja4plus/utils/quic_utils.py
@@ -144,6 +144,82 @@ def extract_crypto_frames(plaintext):
     return bytes(reassembled)
 
 
+def parse_quic_server_initial(udp_payload, client_dcid):
+    """
+    Parse a QUIC Server Initial packet and extract the TLS ServerHello.
+
+    The client_dcid is the Destination Connection ID from the *client's*
+    Initial packet, needed to derive the server's decryption keys.
+
+    Args:
+        udp_payload: Raw bytes of the UDP payload (server → client)
+        client_dcid: bytes — the DCID the client sent in its Initial
+
+    Returns:
+        A tls_info dict with is_quic=True and handshake_type='server_hello',
+        or None if the packet is not a QUIC Initial or decryption fails.
+    """
+    if len(udp_payload) < 5 or not client_dcid:
+        return None
+
+    first_byte = udp_payload[0]
+    if not (first_byte & 0x80):
+        return None  # short header
+
+    version = struct.unpack("!I", udp_payload[1:5])[0]
+    if version == 0:
+        return None  # version negotiation
+
+    quic_version = None
+    packet_type = (first_byte & 0x30) >> 4
+    is_v2 = version == 0x6B3343CF
+    if is_v2:
+        if packet_type != 0x01:
+            return None
+        quic_version = 2
+    else:
+        if packet_type != 0x00:
+            return None
+        quic_version = 1
+
+    # Derive server keys using the CLIENT's original DCID
+    _, server_secret = derive_initial_secrets(bytes(client_dcid), quic_version)
+    key, iv, hp_key = derive_key_iv_hp(server_secret)
+
+    try:
+        unprotected, pn, pn_length = remove_header_protection(udp_payload, hp_key)
+        pn_offset = _find_pn_offset(udp_payload)
+
+        plaintext = decrypt_initial_payload(
+            unprotected, pn, pn_length, pn_offset, key, iv
+        )
+
+        server_hello_bytes = extract_crypto_frames(plaintext)
+        if not server_hello_bytes:
+            return None
+
+        # Must be a ServerHello (handshake type 0x02)
+        if len(server_hello_bytes) < 1 or server_hello_bytes[0] != 0x02:
+            return None
+
+        sh_length = len(server_hello_bytes)
+        fake_record = (
+            bytes([0x16, 0x03, 0x01])
+            + struct.pack("!H", sh_length)
+            + server_hello_bytes
+        )
+
+        from ja4plus.utils.tls_utils import parse_tls_handshake
+        tls_info = parse_tls_handshake(fake_record)
+        if tls_info:
+            tls_info["is_quic"] = True
+        return tls_info
+
+    except Exception as e:
+        logger.debug(f"QUIC server Initial parsing failed: {e}")
+        return None
+
+
 def parse_quic_initial(udp_payload):
     """Parse a QUIC Initial packet and extract the TLS ClientHello."""
     if len(udp_payload) < 20:

--- a/tests/test_cleanup_connection.py
+++ b/tests/test_cleanup_connection.py
@@ -1,0 +1,122 @@
+"""Tests for the cleanup_connection() API on stateful fingerprinters."""
+import unittest
+
+from scapy.all import IP, TCP, UDP, Raw
+
+
+class TestBaseFingerprinterCleanup(unittest.TestCase):
+    def test_base_has_cleanup_connection(self):
+        from ja4plus.fingerprinters.base import BaseFingerprinter
+        # The base class must have the method (no-op default)
+        fp = BaseFingerprinter.__new__(BaseFingerprinter)
+        fp.fingerprints = []
+        self.assertTrue(hasattr(fp, 'cleanup_connection'))
+
+    def test_base_cleanup_is_noop(self):
+        from ja4plus.fingerprinters.base import BaseFingerprinter
+        fp = BaseFingerprinter.__new__(BaseFingerprinter)
+        fp.fingerprints = []
+        # Must not raise
+        fp.cleanup_connection("1.2.3.4", 1234, "5.6.7.8", 443, "tcp")
+
+
+class TestJA4LCleanup(unittest.TestCase):
+    def _make_syn(self, src="10.0.0.1", dst="10.0.0.2", sport=12345, dport=443):
+        return IP(src=src, dst=dst) / TCP(sport=sport, dport=dport, flags="S")
+
+    def test_cleanup_removes_connection(self):
+        from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+        fp = JA4LFingerprinter()
+        fp.process_packet(self._make_syn())
+        self.assertGreater(len(fp.connections), 0)
+
+        fp.cleanup_connection("10.0.0.1", 12345, "10.0.0.2", 443, "tcp")
+        self.assertEqual(len(fp.connections), 0)
+
+    def test_cleanup_nonexistent_is_safe(self):
+        from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+        fp = JA4LFingerprinter()
+        # No-op on empty state
+        fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 200, "tcp")
+
+    def test_cleanup_both_directions(self):
+        """Cleanup should work regardless of argument order (fwd/rev key)."""
+        from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+        fp = JA4LFingerprinter()
+        fp.process_packet(self._make_syn(src="10.0.0.1", dst="10.0.0.2"))
+        # Call with dst/src reversed — should still clean up
+        fp.cleanup_connection("10.0.0.2", 443, "10.0.0.1", 12345, "tcp")
+        self.assertEqual(len(fp.connections), 0)
+
+
+class TestJA4SSHCleanup(unittest.TestCase):
+    def _make_ssh_pkt(self, src="10.0.0.1", dst="10.0.0.2", sport=54321, dport=22):
+        return (IP(src=src, dst=dst) /
+                TCP(sport=sport, dport=dport, flags="PA") /
+                Raw(load=b"SSH-2.0-OpenSSH_8.0\r\n"))
+
+    def test_cleanup_removes_connection(self):
+        from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+        fp = JA4SSHFingerprinter()
+        fp.process_packet(self._make_ssh_pkt())
+        self.assertGreater(len(fp.connections), 0)
+
+        fp.cleanup_connection("10.0.0.1", 54321, "10.0.0.2", 22, "tcp")
+        self.assertEqual(len(fp.connections), 0)
+
+    def test_cleanup_nonexistent_is_safe(self):
+        from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+        fp = JA4SSHFingerprinter()
+        fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 22, "tcp")
+
+
+class TestJA4HCleanup(unittest.TestCase):
+    def _make_http_pkt(self, src="10.0.0.1", dst="10.0.0.2", sport=54321, dport=80):
+        payload = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        return (IP(src=src, dst=dst) /
+                TCP(sport=sport, dport=dport, seq=1, flags="PA") /
+                Raw(load=payload))
+
+    def test_cleanup_removes_stream(self):
+        from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
+        fp = JA4HFingerprinter()
+        fp.process_packet(self._make_http_pkt())
+        stream_key = "10.0.0.1:54321-10.0.0.2:80"
+        # Stream may have been processed and removed by reassembler already,
+        # but cleanup should not raise regardless
+        fp.cleanup_connection("10.0.0.1", 54321, "10.0.0.2", 80, "tcp")
+
+    def test_cleanup_nonexistent_is_safe(self):
+        from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
+        fp = JA4HFingerprinter()
+        fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 80, "tcp")
+
+
+class TestJA4XCleanup(unittest.TestCase):
+    def test_cleanup_removes_stream(self):
+        from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
+        fp = JA4XFingerprinter()
+        # Manually inject a stream to verify removal
+        stream_key = "10.0.0.1:54321-10.0.0.2:443"
+        fp.reassembler.streams[stream_key] = bytearray(b"dummy")
+        self.assertIn(stream_key, fp.reassembler.streams)
+
+        fp.cleanup_connection("10.0.0.1", 54321, "10.0.0.2", 443, "tcp")
+        self.assertNotIn(stream_key, fp.reassembler.streams)
+
+    def test_cleanup_nonexistent_is_safe(self):
+        from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
+        fp = JA4XFingerprinter()
+        fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 443, "tcp")
+
+
+class TestJA4SCleanup(unittest.TestCase):
+    def test_cleanup_already_covered_in_quic_tests(self):
+        """Covered by test_quic_utils.py::TestJA4SQUICTracking."""
+        from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+        fp = JA4SFingerprinter()
+        fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 443, "udp")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -315,7 +315,9 @@ class TestJA4Comprehensive(unittest.TestCase):
         packet = IP() / TCP(sport=12345, dport=443) / Raw(load=raw)
         raw_fp = self.fp.get_raw_fingerprint(packet)
         self.assertIsNotNone(raw_fp)
-        self.assertTrue(raw_fp.startswith("JA4_r"))
+        # Returns clean fingerprint string (no "JA4_r = " prefix)
+        self.assertFalse(raw_fp.startswith("JA4_"))
+        self.assertIn("_", raw_fp)
 
     def test_ssl30_version(self):
         """SSL 3.0 should produce 's3' version string."""

--- a/tests/test_ja4_deep.py
+++ b/tests/test_ja4_deep.py
@@ -387,13 +387,17 @@ class TestJA4RawFingerprint(unittest.TestCase):
         info = _tls_info(ciphers=[0xC02F, 0x1301], sni="test.com")
         raw = get_raw_fingerprint(info, original_order=False)
         self.assertIsNotNone(raw)
-        self.assertTrue(raw.startswith("JA4_r = "))
+        # Returns clean fingerprint string (no "JA4_r = " prefix)
+        self.assertFalse(raw.startswith("JA4_"))
+        self.assertIn("_", raw)
 
     def test_raw_original_order_format(self):
         info = _tls_info(ciphers=[0xC02F, 0x1301], sni="test.com")
         raw = get_raw_fingerprint(info, original_order=True)
         self.assertIsNotNone(raw)
-        self.assertTrue(raw.startswith("JA4_ro = "))
+        # Returns clean fingerprint string (no "JA4_ro = " prefix)
+        self.assertFalse(raw.startswith("JA4_"))
+        self.assertIn("_", raw)
 
     def test_raw_contains_cipher_hex(self):
         info = _tls_info(ciphers=[0x1301, 0xC02F])
@@ -441,7 +445,9 @@ class TestJA4FingerprinterClass(unittest.TestCase):
         fp = JA4Fingerprinter()
         result = fp.get_raw_fingerprint(packet)
         self.assertIsNotNone(result)
-        self.assertTrue(result.startswith("JA4_r"))
+        # Returns clean fingerprint string (no "JA4_r = " prefix)
+        self.assertFalse(result.startswith("JA4_"))
+        self.assertIn("_", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_ja4d.py
+++ b/tests/test_ja4d.py
@@ -1,0 +1,270 @@
+"""Tests for JA4D DHCP fingerprinting."""
+import struct
+import unittest
+
+from scapy.all import IP, UDP, Raw
+
+from ja4plus.fingerprinters.ja4d import (
+    JA4DFingerprinter,
+    build_option_list,
+    build_param_list,
+    generate_ja4d,
+    DHCP_MESSAGE_TYPES,
+    DHCP_SKIP_OPTIONS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build raw DHCPv4 packets
+# ---------------------------------------------------------------------------
+
+DHCP_MAGIC = b'\x63\x82\x53\x63'
+
+
+def _build_dhcp_payload(msg_type, options=None, max_msg_size=None,
+                        request_ip=None, fqdn=False, param_request=None):
+    """Build a minimal DHCPv4 UDP payload (BOOTP + DHCP options)."""
+    # Minimal BOOTP fixed header (236 bytes)
+    bootp = bytearray(236)
+    bootp[0] = 1  # op = BOOTREQUEST
+    # Add the DHCP magic cookie
+    payload = bytes(bootp) + DHCP_MAGIC
+
+    # Build options
+    opts = bytearray()
+
+    # Option 53: Message Type
+    opts += bytes([53, 1, msg_type])
+
+    # Option 57: Maximum DHCP Message Size
+    if max_msg_size is not None:
+        opts += bytes([57, 2]) + struct.pack('!H', max_msg_size)
+
+    # Option 50: Requested IP Address (flag only — 4 zero bytes)
+    if request_ip:
+        opts += bytes([50, 4, 0, 0, 0, 0])
+
+    # Option 81: Client FQDN (flag only — minimal 3-byte data)
+    if fqdn:
+        opts += bytes([81, 3, 0, 0, 0])
+
+    # Option 55: Parameter Request List
+    if param_request:
+        opts += bytes([55, len(param_request)]) + bytes(param_request)
+
+    # Extra options
+    if options:
+        for opt_code in options:
+            if opt_code not in (53, 57, 50, 81, 55, 255):
+                opts += bytes([opt_code, 0])  # zero-length option
+
+    # End option
+    opts += bytes([255])
+
+    return payload + bytes(opts)
+
+
+def _make_dhcp_packet(msg_type, src_ip="192.168.1.100", dst_ip="255.255.255.255",
+                      sport=68, dport=67, **kwargs):
+    """Build a Scapy packet wrapping a DHCPv4 payload."""
+    raw = _build_dhcp_payload(msg_type, **kwargs)
+    return IP(src=src_ip, dst=dst_ip) / UDP(sport=sport, dport=dport) / Raw(load=raw)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+class TestDHCPMessageTypes(unittest.TestCase):
+    """All 18 message type abbreviations must be exactly 5 characters."""
+
+    def test_all_18_types_present(self):
+        for code in range(1, 19):
+            self.assertIn(code, DHCP_MESSAGE_TYPES, f"Missing message type {code}")
+
+    def test_all_abbreviations_are_5_chars(self):
+        for code, abbrev in DHCP_MESSAGE_TYPES.items():
+            self.assertEqual(len(abbrev), 5,
+                             f"Type {code} abbreviation '{abbrev}' is not 5 chars")
+
+    def test_known_mappings(self):
+        expected = {
+            1: "disco", 2: "offer", 3: "reqst", 4: "decln",
+            5: "dpack", 6: "dpnak", 7: "relse", 8: "infor",
+            9: "frenw", 10: "lqery", 18: "dhtls",
+        }
+        for code, abbrev in expected.items():
+            self.assertEqual(DHCP_MESSAGE_TYPES[code], abbrev)
+
+
+class TestBuildOptionList(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(build_option_list([]), "00")
+
+    def test_all_skipped(self):
+        self.assertEqual(build_option_list([53, 255, 50, 81]), "00")
+
+    def test_single_option(self):
+        self.assertEqual(build_option_list([53, 61, 255]), "61")
+
+    def test_multiple_options(self):
+        self.assertEqual(
+            build_option_list([53, 61, 57, 60, 12, 55, 255]),
+            "61-57-60-12-55"
+        )
+
+    def test_with_skipped_mixed(self):
+        self.assertEqual(build_option_list([53, 50, 61, 81, 57, 255]), "61-57")
+
+    def test_skip_set_respected(self):
+        # Option 57 (max msg size) is NOT in the skip set, so it should appear
+        self.assertIn("57", build_option_list([53, 57, 61, 255]))
+
+
+class TestBuildParamList(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(build_param_list([]), "00")
+
+    def test_single(self):
+        self.assertEqual(build_param_list([1]), "1")
+
+    def test_multiple(self):
+        self.assertEqual(
+            build_param_list([1, 3, 6, 15, 26, 28, 51, 58, 59]),
+            "1-3-6-15-26-28-51-58-59"
+        )
+
+
+class TestGenerateJA4D(unittest.TestCase):
+    """Tests for the generate_ja4d() function."""
+
+    def test_discover_no_extras(self):
+        """DHCPDISCOVER with no optional fields."""
+        pkt = _make_dhcp_packet(msg_type=1)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        # Section a: disco + 0000 (no max size) + n (no req IP) + n (no FQDN)
+        parts = result.split('_')
+        self.assertEqual(len(parts), 3)
+        self.assertTrue(parts[0].startswith("disco"))
+        self.assertEqual(parts[0][5:9], "0000")  # no max msg size
+        self.assertEqual(parts[0][9], "n")        # no requested IP
+        self.assertEqual(parts[0][10], "n")       # no FQDN
+
+    def test_discover_with_max_size(self):
+        pkt = _make_dhcp_packet(msg_type=1, max_msg_size=1500)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        parts = result.split('_')
+        self.assertEqual(parts[0][5:9], "1500")
+
+    def test_discover_with_request_ip_flag(self):
+        pkt = _make_dhcp_packet(msg_type=1, request_ip=True)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        parts = result.split('_')
+        self.assertEqual(parts[0][9], "i")
+
+    def test_discover_with_fqdn_flag(self):
+        pkt = _make_dhcp_packet(msg_type=1, fqdn=True)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        parts = result.split('_')
+        self.assertEqual(parts[0][10], "d")
+
+    def test_offer_message_type(self):
+        pkt = _make_dhcp_packet(msg_type=2, sport=67, dport=68)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        self.assertTrue(result.startswith("offer"))
+
+    def test_request_message_type(self):
+        pkt = _make_dhcp_packet(msg_type=3)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        self.assertTrue(result.startswith("reqst"))
+
+    def test_param_request_list_in_section_c(self):
+        params = [1, 3, 6, 15]
+        pkt = _make_dhcp_packet(msg_type=1, param_request=params)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        parts = result.split('_')
+        self.assertEqual(parts[2], "1-3-6-15")
+
+    def test_no_param_request_section_c_is_00(self):
+        pkt = _make_dhcp_packet(msg_type=1)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        parts = result.split('_')
+        self.assertEqual(parts[2], "00")
+
+    def test_extra_options_appear_in_section_b(self):
+        pkt = _make_dhcp_packet(msg_type=1, options=[61, 12])
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        parts = result.split('_')
+        self.assertIn("61", parts[1])
+        self.assertIn("12", parts[1])
+
+    def test_skip_options_absent_from_section_b(self):
+        pkt = _make_dhcp_packet(msg_type=1, options=[61])
+        result = generate_ja4d(pkt)
+        parts = result.split('_')
+        # 53 (msg type), 255 (end) are added by the builder but must not appear
+        self.assertNotIn("53", parts[1].split('-'))
+        self.assertNotIn("255", parts[1].split('-'))
+
+    def test_max_msg_size_capped_at_9999(self):
+        pkt = _make_dhcp_packet(msg_type=1, max_msg_size=65535)
+        result = generate_ja4d(pkt)
+        parts = result.split('_')
+        self.assertEqual(parts[0][5:9], "9999")
+
+    def test_non_dhcp_port_returns_none(self):
+        raw = _build_dhcp_payload(msg_type=1)
+        pkt = IP() / UDP(sport=1234, dport=5678) / Raw(load=raw)
+        self.assertIsNone(generate_ja4d(pkt))
+
+    def test_tcp_packet_returns_none(self):
+        from scapy.all import TCP
+        pkt = IP() / TCP(sport=68, dport=67)
+        self.assertIsNone(generate_ja4d(pkt))
+
+    def test_unknown_message_type_uses_numeric(self):
+        pkt = _make_dhcp_packet(msg_type=99)
+        result = generate_ja4d(pkt)
+        self.assertIsNotNone(result)
+        # Unknown type: zero-padded to 5 digits
+        self.assertTrue(result.startswith("00099"))
+
+
+class TestJA4DFingerprinter(unittest.TestCase):
+    def setUp(self):
+        self.fp = JA4DFingerprinter()
+
+    def test_process_packet_returns_fingerprint(self):
+        pkt = _make_dhcp_packet(msg_type=1)
+        result = self.fp.process_packet(pkt)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(self.fp.get_fingerprints()), 1)
+
+    def test_reset_clears_state(self):
+        pkt = _make_dhcp_packet(msg_type=1)
+        self.fp.process_packet(pkt)
+        self.fp.reset()
+        self.assertEqual(len(self.fp.get_fingerprints()), 0)
+
+    def test_non_dhcp_returns_none(self):
+        from scapy.all import TCP
+        pkt = IP() / TCP(sport=12345, dport=443)
+        result = self.fp.process_packet(pkt)
+        self.assertIsNone(result)
+
+    def test_cleanup_connection_is_noop(self):
+        """JA4D is stateless — cleanup should not raise."""
+        self.fp.cleanup_connection("1.2.3.4", 68, "255.255.255.255", 67, "udp")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_quic_utils.py
+++ b/tests/test_quic_utils.py
@@ -151,5 +151,126 @@ class TestExtractCryptoFrames(unittest.TestCase):
         self.assertEqual(result, b"abcdef")
 
 
+class TestParseQuicServerInitial(unittest.TestCase):
+    """Tests for parse_quic_server_initial() — the server-side QUIC Initial decoder."""
+
+    def test_too_short_returns_none(self):
+        from ja4plus.utils.quic_utils import parse_quic_server_initial
+        self.assertIsNone(parse_quic_server_initial(b"\x00" * 4, b"\x01" * 8))
+
+    def test_empty_client_dcid_returns_none(self):
+        from ja4plus.utils.quic_utils import parse_quic_server_initial
+        self.assertIsNone(parse_quic_server_initial(b"\xC0" + b"\x00" * 40, b""))
+
+    def test_short_header_returns_none(self):
+        from ja4plus.utils.quic_utils import parse_quic_server_initial
+        # Short header: bit 7 clear
+        pkt = b"\x40" + b"\x00\x00\x00\x01" + b"\x00" * 40
+        self.assertIsNone(parse_quic_server_initial(pkt, b"\x01" * 8))
+
+    def test_version_negotiation_returns_none(self):
+        from ja4plus.utils.quic_utils import parse_quic_server_initial
+        pkt = b"\xC0" + b"\x00\x00\x00\x00" + b"\x00" * 40
+        self.assertIsNone(parse_quic_server_initial(pkt, b"\x01" * 8))
+
+    def test_wrong_packet_type_returns_none(self):
+        from ja4plus.utils.quic_utils import parse_quic_server_initial
+        # QUIC v1 Handshake type (0x02 in bits 4-5), not Initial (0x00)
+        first_byte = 0xC0 | (0x02 << 4)
+        pkt = bytes([first_byte]) + b"\x00\x00\x00\x01" + b"\x00" * 40
+        self.assertIsNone(parse_quic_server_initial(pkt, b"\x01" * 8))
+
+    def test_invalid_encrypted_data_returns_none(self):
+        """A structurally valid but undecryptable packet returns None (not an exception)."""
+        from ja4plus.utils.quic_utils import parse_quic_server_initial
+        import struct
+
+        # Build a minimal QUIC v1 Initial long header (server direction)
+        dcid = b"\x01" * 8   # fake DCID
+        scid = b"\x02" * 4   # fake SCID
+        payload = b"\x00" * 80  # garbage (will fail AES-GCM decryption)
+
+        pkt = bytearray()
+        pkt.append(0xC0)                         # long header, Initial type
+        pkt += struct.pack("!I", 0x00000001)     # QUIC v1
+        pkt.append(len(dcid))
+        pkt += dcid
+        pkt.append(len(scid))
+        pkt += scid
+        pkt.append(0)                            # token length = 0
+        # payload length as varint (2-byte form for safety)
+        pkt.append(0x40 | (len(payload) >> 8))
+        pkt.append(len(payload) & 0xFF)
+        pkt += payload
+
+        client_dcid = b"\xAA" * 8
+        result = parse_quic_server_initial(bytes(pkt), client_dcid)
+        # Decryption fails on garbage ciphertext — must return None, not raise
+        self.assertIsNone(result)
+
+
+class TestJA4SQUICTracking(unittest.TestCase):
+    """Tests for JA4SFingerprinter DCID state tracking."""
+
+    def _make_quic_client_initial(self, dcid=b"\xAB" * 8, sport=54321, dport=443):
+        """Build a fake QUIC v1 client Initial UDP packet with a known DCID."""
+        import struct
+        from scapy.all import IP, UDP, Raw
+
+        pkt = bytearray()
+        pkt.append(0xC0)                         # long header, Initial (type 0x00)
+        pkt += struct.pack("!I", 0x00000001)     # QUIC v1
+        pkt.append(len(dcid))
+        pkt += dcid
+        pkt.append(0)                            # SCID length = 0
+        pkt.append(0)                            # token length = 0
+        pkt += b"\x40\x01"                      # payload length = 1 (varint)
+        pkt += b"\x00"                           # dummy payload (will fail to parse ClientHello)
+
+        return (IP(src="10.0.0.1", dst="10.0.0.2") /
+                UDP(sport=sport, dport=dport) /
+                Raw(load=bytes(pkt)))
+
+    def test_client_initial_does_not_produce_ja4s(self):
+        """Client Initial packet should not generate a JA4S fingerprint."""
+        from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+        fp = JA4SFingerprinter()
+        result = fp.process_packet(self._make_quic_client_initial())
+        self.assertIsNone(result)
+
+    def test_dcid_captured_from_client_initial(self):
+        """Fingerprinter captures the DCID from a client Initial for later server decryption."""
+        from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+        fp = JA4SFingerprinter()
+        dcid = b"\xDE\xAD\xBE\xEF" * 2
+        pkt = self._make_quic_client_initial(dcid=dcid, sport=54321, dport=443)
+        fp.process_packet(pkt)
+        # Check internal state: the forward connection key should map to the DCID
+        conn_key = "10.0.0.1:54321-10.0.0.2:443"
+        self.assertIn(conn_key, fp._quic_dcids)
+        self.assertEqual(fp._quic_dcids[conn_key], dcid)
+
+    def test_cleanup_connection_removes_dcid(self):
+        """cleanup_connection() removes the stored DCID for that flow."""
+        from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+        fp = JA4SFingerprinter()
+        dcid = b"\xDE\xAD\xBE\xEF" * 2
+        pkt = self._make_quic_client_initial(dcid=dcid, sport=54321, dport=443)
+        fp.process_packet(pkt)
+
+        fp.cleanup_connection("10.0.0.1", 54321, "10.0.0.2", 443, "udp")
+        self.assertNotIn("10.0.0.1:54321-10.0.0.2:443", fp._quic_dcids)
+        self.assertNotIn("10.0.0.2:443-10.0.0.1:54321", fp._quic_dcids)
+
+    def test_reset_clears_dcid_state(self):
+        """reset() clears all stored DCID state."""
+        from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+        fp = JA4SFingerprinter()
+        pkt = self._make_quic_client_initial()
+        fp.process_packet(pkt)
+        fp.reset()
+        self.assertEqual(fp._quic_dcids, {})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- **JA4D**: New DHCP fingerprinter ported from Go — 18 message types, option/param list builder, format `{msg_type}{max_size}{req_ip}{fqdn}_{options}_{params}`
- **QUIC JA4S**: JA4S can now fingerprint QUIC Server Initials by tracking client DCIDs and decrypting server packets (server-side HKDF key derivation was already present in `quic_utils.py`)
- **Connection cleanup API**: Added `cleanup_connection(src_ip, src_port, dst_ip, dst_port, proto)` to all fingerprinters — no-op default on `BaseFingerprinter`, per-connection eviction on stateful fingerprinters (JA4L, JA4SSH, JA4H, JA4X, JA4S) to prevent memory leaks in long-running monitors
- **JA4 raw fingerprint fix**: Removed `"JA4_r = "` / `"JA4_ro = "` label prefixes from `get_raw_fingerprint()` return values — now returns clean data strings matching Go behavior

## Test Plan

- [x] 52 new tests added (529 total, up from 477)
- [x] `tests/test_ja4d.py` — 30 tests covering all message types, option/param list building, section format, flags, edge cases
- [x] `tests/test_cleanup_connection.py` — 12 tests covering all stateful fingerprinters
- [x] `tests/test_quic_utils.py` — QUIC server Initial parsing + JA4S DCID state tracking
- [x] Full suite passes: `529 passed, 86 subtests passed`