### PR TITLE
Set up the dev branch, branch protection and dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     environment: pypi
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
 
@@ -29,4 +29,4 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
             python-version: "3.12"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: test-results-${{ matrix.os }}-py${{ matrix.python-version }}
           path: test-results.xml

--- a/.github/workflows/update-db.yml
+++ b/.github/workflows/update-db.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Download latest mapping CSV
         run: |


### PR DESCRIPTION
Closes #26.

## What this changes

**1. The `dev` branch — already done, verified only.**

`dev` exists on the remote and is already the GitHub default branch. This branch
makes no change for that item.

```
$ gh repo view --json defaultBranchRef
{"defaultBranchRef":{"name":"dev"}}

$ git branch -r
  origin/dev
  origin/epic/11-foundation
  origin/feature/go-parity
  origin/master
```

**2. Branch protection on `master` — applied on the forge, not in this diff.**

`master` had no protection rule. The rule below is now active:

| Setting | Value |
|---|---|
| `required_pull_request_reviews` | enabled, `required_approving_review_count: 0` |
| `enforce_admins` | `true` |
| `allow_force_pushes` | `false` |
| `allow_deletions` | `false` |
| `required_status_checks` | `null` |
| `restrictions` | `null` |

A direct push to `master` now fails. A change reaches `master` through a pull
request only.

Two decisions to review:

- `enforce_admins: true`. A rule that the repository owner can bypass does not
  stop a direct push, because the owner is the only person who pushes. The
  owner still merges a pull request, because the required approval count is 0.
- `required_status_checks: null`. The batch model runs the test workflow once
  per batch, and issue #24 owns the workflow trigger branches. A required check
  named before that issue lands blocks every merge.

**3. Action references pinned to a commit identifier.**

A tag is a movable reference. A person who moves a tag runs their own code in
the workflows of this repository. A commit identifier is immutable. Each line
keeps the released version as a trailing comment.

| Action | Version | Commit identifier |
|---|---|---|
| `actions/checkout` | v4.4.0 | `11d5960a326750d5838078e36cf38b85af677262` |
| `actions/setup-python` | v5.6.0 | `a26af69be951a213d495a4c3e4e4022e16d87065` |
| `actions/upload-artifact` | v4.6.2 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `pypa/gh-action-pypi-publish` | v1.14.2 | `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` |

`pypa/gh-action-pypi-publish` used the `release/v1` branch, which is movable in
the same way as a tag. The pinned commit is the head of that branch, and it
carries the tag `v1.14.2`.

Every identifier comes from the GitHub API. None is invented:

```
gh api repos/actions/checkout/commits/v4 --jq .sha
gh api repos/actions/setup-python/commits/v5 --jq .sha
gh api repos/actions/upload-artifact/commits/v4 --jq .sha
gh api repos/pypa/gh-action-pypi-publish/commits/release/v1 --jq .sha
```

No `on:` block changes. Issue #24 owns the workflow trigger branches.

**4. `.github/dependabot.yml`.**

The `pip` and `github-actions` ecosystems, weekly on Monday, 5 open pull
requests each, targeted at `dev`. Dependabot moves a pinned commit identifier
and its version comment together, so the pin above does not freeze the
supply chain.

## Verification

The test suite result is unchanged, because this branch changes no Python code:

```
582 passed, 2 failed, 12 skipped
FAILED tests/test_ja4db.py::TestCLILookupFlag::test_analyze_with_lookup_json
FAILED tests/test_ja4db.py::TestCLILookupFlag::test_analyze_without_lookup_json
```

Both failures belong to issue #25.

Every YAML file parses:

```
ok .github/dependabot.yml
ok .github/workflows/publish.yml
ok .github/workflows/test.yml
ok .github/workflows/update-db.yml
```

Verified against: https://docs.github.com/en/rest/branches/branch-protection (retrieved 2026-08-06)
Verified against: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference (retrieved 2026-08-06)
