### PR TITLE
style: apply ruff format across the package and the test suite

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Commits that changed formatting only. `git blame` skips every commit here.
+#
+# Enable the file once per clone:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style: apply ruff format to the package and the test suite
+b42e38573e2ae148e69c345815c27feecd0f05b5

--- a/ja4plus/__init__.py
+++ b/ja4plus/__init__.py
@@ -30,6 +30,7 @@ from ja4plus.fingerprinters.ja4ts import generate_ja4ts
 from ja4plus.fingerprinters.ja4d import generate_ja4d
 from ja4plus.fingerprinters.ja4d6 import generate_ja4d6
 
+
 def compute_ja4x_from_der(cert_der_bytes):
     """Compute the JA4X fingerprint for a DER-encoded X.509 certificate.
 

--- a/ja4plus/cli.py
+++ b/ja4plus/cli.py
@@ -27,8 +27,16 @@ from ja4plus.fingerprinters.ja4d import JA4DFingerprinter
 from ja4plus.fingerprinters.ja4d6 import JA4D6Fingerprinter
 
 VALID_TYPES = [
-    "ja4", "ja4s", "ja4h", "ja4l", "ja4t", "ja4ts", "ja4x", "ja4ssh",
-    "ja4d", "ja4d6",
+    "ja4",
+    "ja4s",
+    "ja4h",
+    "ja4l",
+    "ja4t",
+    "ja4ts",
+    "ja4x",
+    "ja4ssh",
+    "ja4d",
+    "ja4d6",
 ]
 
 ALL_FINGERPRINTERS = {
@@ -77,6 +85,7 @@ def _get_packet_source(packet):
             dst_ip = packet[IP].dst
         elif packet.haslayer(IPv6):
             from scapy.all import IPv6 as IPv6Layer
+
             src_ip = packet[IPv6Layer].src
             dst_ip = packet[IPv6Layer].dst
 
@@ -146,6 +155,7 @@ def _init_lookup(args):
         return None
     try:
         from ja4plus.ja4db import JA4DBClient
+
         return JA4DBClient()
     except Exception as e:
         print(f"Warning: could not initialize ja4db lookup: {e}", file=sys.stderr)
@@ -193,8 +203,8 @@ def cmd_analyze(args):
                     try:
                         result = fp.process_packet(packet)
                         if result:
-                            raw = getattr(fp, 'last_raw', None)
-                            raw_oo = getattr(fp, 'last_raw_original_order', None)
+                            raw = getattr(fp, "last_raw", None)
+                            raw_oo = getattr(fp, "last_raw_original_order", None)
                             row_batch.append((source, fp_type, result, raw, raw_oo))
                     except Exception:
                         pass
@@ -249,8 +259,8 @@ def cmd_live(args):
             try:
                 result = fp.process_packet(packet)
                 if result:
-                    raw = getattr(fp, 'last_raw', None)
-                    raw_oo = getattr(fp, 'last_raw_original_order', None)
+                    raw = getattr(fp, "last_raw", None)
+                    raw_oo = getattr(fp, "last_raw_original_order", None)
                     row_batch.append((source, fp_type, result, raw, raw_oo))
             except Exception:
                 pass
@@ -260,6 +270,7 @@ def cmd_live(args):
 
     try:
         from scapy.all import sniff
+
         sniff(
             prn=process_packet,
             iface=args.interface if args.interface != "any" else None,
@@ -294,6 +305,7 @@ def cmd_cert(args):
 
             cert = cx509.load_pem_x509_certificate(cert_bytes, default_backend())
             from cryptography.hazmat.primitives.serialization import Encoding
+
             cert_bytes = cert.public_bytes(Encoding.DER)
         except Exception as e:
             print(f"Error parsing PEM certificate: {e}", file=sys.stderr)
@@ -338,6 +350,7 @@ def cmd_db(args):
         print(f"Entries:  {len(db)}")
         if os.path.exists(_BUNDLED_CSV):
             import time
+
             mtime = os.path.getmtime(_BUNDLED_CSV)
             print(f"Updated:  {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(mtime))}")
         print(f"Source:   {_MAPPING_URL}")
@@ -347,6 +360,7 @@ def cmd_db(args):
     print(f"Downloading latest fingerprint database from FoxIO...")
     try:
         import urllib.request
+
         data = urllib.request.urlopen(_MAPPING_URL, timeout=15).read().decode("utf-8")
     except Exception as e:
         print(f"Error: could not download database: {e}", file=sys.stderr)
@@ -355,12 +369,18 @@ def cmd_db(args):
     # Validate it's a real CSV with expected headers
     lines = data.strip().split("\n")
     if len(lines) < 2 or "Application" not in lines[0]:
-        print("Error: downloaded file does not look like a valid ja4plus-mapping.csv", file=sys.stderr)
+        print(
+            "Error: downloaded file does not look like a valid ja4plus-mapping.csv", file=sys.stderr
+        )
         sys.exit(1)
 
     # Count entries
     reader = csv_mod.DictReader(lines)
-    entry_count = sum(1 for row in reader if any(row.get(f, "").strip() for f in ("ja4", "ja4s", "ja4h", "ja4x", "ja4t")))
+    entry_count = sum(
+        1
+        for row in reader
+        if any(row.get(f, "").strip() for f in ("ja4", "ja4s", "ja4h", "ja4x", "ja4t"))
+    )
 
     # Write to bundled location
     os.makedirs(os.path.dirname(_BUNDLED_CSV), exist_ok=True)
@@ -375,9 +395,7 @@ def main():
         prog="ja4plus",
         description="JA4+ Network Fingerprinting Tool",
     )
-    parser.add_argument(
-        "--version", action="version", version=f"ja4plus {__version__}"
-    )
+    parser.add_argument("--version", action="version", version=f"ja4plus {__version__}")
     parser.add_argument(
         "--format",
         choices=["table", "json", "csv"],
@@ -401,31 +419,27 @@ def main():
     subparsers.required = True
 
     # analyze subcommand
-    analyze_parser = subparsers.add_parser(
-        "analyze", help="Fingerprint packets in a PCAP file"
-    )
+    analyze_parser = subparsers.add_parser("analyze", help="Fingerprint packets in a PCAP file")
     analyze_parser.add_argument("pcap_file", help="Path to the PCAP file")
 
     # live subcommand
-    live_parser = subparsers.add_parser(
-        "live", help="Live capture from a network interface"
-    )
+    live_parser = subparsers.add_parser("live", help="Live capture from a network interface")
     live_parser.add_argument("interface", help="Network interface (e.g. eth0, any)")
 
     # cert subcommand
-    cert_parser = subparsers.add_parser(
-        "cert", help="Fingerprint an X.509 certificate"
-    )
+    cert_parser = subparsers.add_parser("cert", help="Fingerprint an X.509 certificate")
     cert_parser.add_argument("cert_file", help="Path to certificate file (DER or PEM)")
 
     # db subcommand
-    db_parser = subparsers.add_parser(
-        "db", help="Manage the fingerprint identification database"
-    )
+    db_parser = subparsers.add_parser("db", help="Manage the fingerprint identification database")
     db_sub = db_parser.add_subparsers(dest="db_command", metavar="ACTION")
     db_sub.required = True
-    db_update_parser = db_sub.add_parser("update", help="Download latest fingerprint database from FoxIO")
-    db_update_parser.add_argument("--force", action="store_true", help="Update even if already up to date")
+    db_update_parser = db_sub.add_parser(
+        "update", help="Download latest fingerprint database from FoxIO"
+    )
+    db_update_parser.add_argument(
+        "--force", action="store_true", help="Update even if already up to date"
+    )
     db_sub.add_parser("info", help="Show database location and entry count")
 
     args = parser.parse_args()

--- a/ja4plus/collector.py
+++ b/ja4plus/collector.py
@@ -4,7 +4,9 @@ DEPRECATED: Use the `ja4plus` CLI command instead.
 This module is kept for backward compatibility and will be removed in v0.4.0.
 Run `ja4plus --help` for usage.
 """
+
 import warnings
+
 warnings.warn(
     "collector.py is deprecated. Use the 'ja4plus' CLI command instead.",
     DeprecationWarning,
@@ -35,10 +37,12 @@ max_packets = 0
 start_time = 0
 timeout_seconds = 0
 
+
 def signal_handler(signum, frame):
     """Handle termination signals gracefully"""
     sys.stderr.write("Received signal, shutting down gracefully...\n")
     sys.exit(0)
+
 
 def main():
     """Main collector function"""
@@ -47,14 +51,18 @@ def main():
     parser = argparse.ArgumentParser(description="JA4+ Network Fingerprinting Collector")
     parser.add_argument("--interface", "-i", default="any", help="Network interface to capture on")
     parser.add_argument("--filter", "-f", default="tcp or udp", help="BPF filter expression")
-    parser.add_argument("--fingerprinters", default="ja4,ja4s,ja4h,ja4t,ja4ts,ja4x,ja4ssh",
-                       help="Comma-separated list of fingerprinters to enable")
-    parser.add_argument("--max-packets", type=int, default=0,
-                       help="Maximum packets to process (0 = unlimited)")
-    parser.add_argument("--timeout", type=float, default=0,
-                       help="Timeout in seconds (0 = no timeout)")
-    parser.add_argument("--output", choices=["json", "text"], default="json",
-                       help="Output format")
+    parser.add_argument(
+        "--fingerprinters",
+        default="ja4,ja4s,ja4h,ja4t,ja4ts,ja4x,ja4ssh",
+        help="Comma-separated list of fingerprinters to enable",
+    )
+    parser.add_argument(
+        "--max-packets", type=int, default=0, help="Maximum packets to process (0 = unlimited)"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=0, help="Timeout in seconds (0 = no timeout)"
+    )
+    parser.add_argument("--output", choices=["json", "text"], default="json", help="Output format")
 
     args = parser.parse_args()
 
@@ -75,7 +83,7 @@ def main():
         "ja4t": JA4TFingerprinter(),
         "ja4ts": JA4TSFingerprinter(),
         "ja4x": JA4XFingerprinter(),
-        "ja4ssh": JA4SSHFingerprinter()
+        "ja4ssh": JA4SSHFingerprinter(),
     }
 
     enabled_fps = args.fingerprinters.split(",")
@@ -107,7 +115,7 @@ def main():
 
         results = {
             "@timestamp": int(time.time() * 1000),  # Elasticsearch expects milliseconds
-            "ja4plus": {}
+            "ja4plus": {},
         }
 
         # Apply each enabled fingerprinter
@@ -145,6 +153,7 @@ def main():
 
                 # Add port information if available
                 from scapy.all import TCP, UDP
+
                 if packet.haslayer(TCP):
                     tcp_layer = packet[TCP]
                     if "source" in results:
@@ -185,20 +194,25 @@ def main():
             sys.exit(0)
 
     try:
-        sys.stderr.write(f"Starting JA4+ collection on interface '{args.interface}' with filter '{args.filter}'\n")
+        sys.stderr.write(
+            f"Starting JA4+ collection on interface '{args.interface}' with filter '{args.filter}'\n"
+        )
         sys.stderr.write(f"Enabled fingerprinters: {', '.join(fingerprinters.keys())}\n")
 
         # Start sniffing
-        sniff(prn=process_packet,
-              filter=args.filter,
-              iface=args.interface if args.interface != "any" else None,
-              store=0)
+        sniff(
+            prn=process_packet,
+            filter=args.filter,
+            iface=args.interface if args.interface != "any" else None,
+            store=0,
+        )
 
     except KeyboardInterrupt:
         sys.stderr.write("Interrupted by user\n")
     except Exception as e:
         sys.stderr.write(f"Error during packet capture: {e}\n")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/ja4plus/fingerprinters/__init__.py
+++ b/ja4plus/fingerprinters/__init__.py
@@ -13,13 +13,13 @@ from .ja4ts import JA4TSFingerprinter
 from .ja4d import JA4DFingerprinter
 
 __all__ = [
-    'JA4Fingerprinter',
-    'JA4SFingerprinter',
-    'JA4HFingerprinter',
-    'JA4LFingerprinter',
-    'JA4XFingerprinter',
-    'JA4SSHFingerprinter',
-    'JA4TFingerprinter',
-    'JA4TSFingerprinter',
-    'JA4DFingerprinter',
-] 
+    "JA4Fingerprinter",
+    "JA4SFingerprinter",
+    "JA4HFingerprinter",
+    "JA4LFingerprinter",
+    "JA4XFingerprinter",
+    "JA4SSHFingerprinter",
+    "JA4TFingerprinter",
+    "JA4TSFingerprinter",
+    "JA4DFingerprinter",
+]

--- a/ja4plus/fingerprinters/base.py
+++ b/ja4plus/fingerprinters/base.py
@@ -9,41 +9,38 @@ logger = logging.getLogger(__name__)
 
 class BaseFingerprinter:
     """Base class for all JA4+ fingerprinters."""
-    
+
     def __init__(self):
         """Initialize the fingerprinter."""
         self.fingerprints = []
-    
+
     def process_packet(self, packet):
         """
         Process a packet and extract fingerprint if applicable.
         This method should be overridden by subclasses.
-        
+
         Args:
             packet: A network packet to analyze
-            
+
         Returns:
             The extracted fingerprint if successful, None otherwise
         """
         raise NotImplementedError("Subclasses must implement this method.")
-    
+
     def add_fingerprint(self, fingerprint, packet):
         """
         Add a fingerprint to the collection.
-        
+
         Args:
             fingerprint: The extracted fingerprint
             packet: The packet that generated this fingerprint
         """
-        self.fingerprints.append({
-            'fingerprint': fingerprint,
-            'packet': packet
-        })
-    
+        self.fingerprints.append({"fingerprint": fingerprint, "packet": packet})
+
     def get_fingerprints(self):
         """Return all collected fingerprints."""
         return self.fingerprints
-    
+
     def reset(self):
         """Reset the fingerprinter state."""
         self.fingerprints = []

--- a/ja4plus/fingerprinters/ja4.py
+++ b/ja4plus/fingerprinters/ja4.py
@@ -54,216 +54,224 @@ def compute_alpn_value(first_alpn_bytes):
     hex_str = first_alpn_bytes.hex()  # always lowercase
     return hex_str[0] + hex_str[-1]
 
+
 def generate_ja4(tls_info):
     """
     Generate a JA4 fingerprint from TLS Client Hello info.
-    
+
     Args:
         tls_info: A dictionary with TLS handshake information
-        
+
     Returns:
         A JA4 fingerprint string or None if not applicable
     """
-    if not tls_info or tls_info.get('type') != 'client_hello':
+    if not tls_info or tls_info.get("type") != "client_hello":
         return None
-        
+
     try:
         # Determine protocol type (q=QUIC, d=DTLS, t=TLS over TCP)
-        proto = 'q' if tls_info.get('is_quic') else 'd' if tls_info.get('is_dtls') else 't'
-        
+        proto = "q" if tls_info.get("is_quic") else "d" if tls_info.get("is_dtls") else "t"
+
         # Get TLS version - prioritize supported_versions extension (0x002b)
-        version = tls_info.get('version')
-        supported_versions = tls_info.get('supported_versions', [])
-        
+        version = tls_info.get("version")
+        supported_versions = tls_info.get("supported_versions", [])
+
         # Filter out GREASE values
         supported_versions = [v for v in supported_versions if not is_grease_value(v)]
-        
+
         if supported_versions:
             # Use highest supported version
             version = max(supported_versions)
-        
+
         # Convert version to string format
         if version == 0x0304:  # TLS 1.3
-            version_str = '13'
+            version_str = "13"
         elif version == 0x0303:  # TLS 1.2
-            version_str = '12'
+            version_str = "12"
         elif version == 0x0302:  # TLS 1.1
-            version_str = '11'
+            version_str = "11"
         elif version == 0x0301:  # TLS 1.0
-            version_str = '10'
+            version_str = "10"
         elif version == 0x0300:  # SSL 3.0
-            version_str = 's3'
+            version_str = "s3"
         elif version == 0x0200:  # SSL 2.0
-            version_str = 's2'
-        elif version == 0xfeff:  # DTLS 1.0
-            version_str = 'd1'
-        elif version == 0xfefd:  # DTLS 1.2
-            version_str = 'd2'
-        elif version == 0xfefc:  # DTLS 1.3
-            version_str = 'd3'
+            version_str = "s2"
+        elif version == 0xFEFF:  # DTLS 1.0
+            version_str = "d1"
+        elif version == 0xFEFD:  # DTLS 1.2
+            version_str = "d2"
+        elif version == 0xFEFC:  # DTLS 1.3
+            version_str = "d3"
         else:
-            version_str = '00'
-            
+            version_str = "00"
+
         # SNI type - 'd' if SNI exists, 'i' if not
-        sni = tls_info.get('sni')
-        sni_type = 'd' if sni else 'i'
-        
+        sni = tls_info.get("sni")
+        sni_type = "d" if sni else "i"
+
         # Get cipher suites - filter out GREASE values
-        ciphers = [c for c in tls_info.get('ciphers', []) if not is_grease_value(c)]
+        ciphers = [c for c in tls_info.get("ciphers", []) if not is_grease_value(c)]
         cipher_count = min(len(ciphers), 99)  # Cap at 99
         cipher_count_str = f"{cipher_count:02d}"
-        
+
         # Get extensions - filter out GREASE values
-        extensions = [e for e in tls_info.get('extensions', []) if not is_grease_value(e)]
+        extensions = [e for e in tls_info.get("extensions", []) if not is_grease_value(e)]
         ext_count = min(len(extensions), 99)  # Cap at 99
         ext_count_str = f"{ext_count:02d}"
-        
+
         # ALPN value per FoxIO spec PR #277: see compute_alpn_value().
         # Prefer the raw bytes (full byte fidelity) and fall back to the
         # decoded string for backward-compat callers that only set
         # alpn_protocols.
-        alpn_raw = tls_info.get('alpn_raw') or []
-        alpn_protocols = tls_info.get('alpn_protocols', [])
+        alpn_raw = tls_info.get("alpn_raw") or []
+        alpn_protocols = tls_info.get("alpn_protocols", [])
         if alpn_raw:
             alpn_value = compute_alpn_value(alpn_raw[0])
         elif alpn_protocols and alpn_protocols[0]:
-            alpn_value = compute_alpn_value(alpn_protocols[0].encode('latin-1', errors='replace'))
+            alpn_value = compute_alpn_value(alpn_protocols[0].encode("latin-1", errors="replace"))
         else:
-            alpn_value = '00'
-        
+            alpn_value = "00"
+
         # Form part_a of the fingerprint
         part_a = f"{proto}{version_str}{sni_type}{cipher_count_str}{ext_count_str}{alpn_value}"
-        
+
         # Generate cipher hash - sort ciphers first
         if ciphers:
             sorted_ciphers = sorted(ciphers)
-            cipher_str = ','.join([f"{c:04x}" for c in sorted_ciphers])
+            cipher_str = ",".join([f"{c:04x}" for c in sorted_ciphers])
             cipher_hash = hashlib.sha256(cipher_str.encode()).hexdigest()[:12]
         else:
-            cipher_hash = '000000000000'
-        
+            cipher_hash = "000000000000"
+
         # Generate extension hash
         # 1. Remove SNI (0x0000) and ALPN (0x0010) from extensions for hashing
         filtered_extensions = [e for e in extensions if e != 0x0000 and e != 0x0010]
-        
+
         # 2. Sort filtered extensions
         sorted_extensions = sorted(filtered_extensions)
-        
+
         # 3. Get signature algorithms in original order
-        sig_algs = tls_info.get('signature_algorithms', [])
-        
+        sig_algs = tls_info.get("signature_algorithms", [])
+
         # 4. Form extension string - sorted extensions + underscore + sig algorithms if present
-        ext_str = ','.join([f"{e:04x}" for e in sorted_extensions])
+        ext_str = ",".join([f"{e:04x}" for e in sorted_extensions])
         if sig_algs:
-            sig_alg_str = ','.join([f"{s:04x}" for s in sig_algs])
+            sig_alg_str = ",".join([f"{s:04x}" for s in sig_algs])
             ext_str = f"{ext_str}_{sig_alg_str}"
-            
+
         # 5. Generate extension hash
         if ext_str:
             ext_hash = hashlib.sha256(ext_str.encode()).hexdigest()[:12]
         else:
-            ext_hash = '000000000000'
-        
+            ext_hash = "000000000000"
+
         # Form the complete JA4 fingerprint
         ja4 = f"{part_a}_{cipher_hash}_{ext_hash}"
-        
+
         return ja4
-        
+
     except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
         logger.debug(f"Failed to generate JA4 fingerprint: {e}")
         return None
 
+
 def get_raw_fingerprint(tls_info, original_order=False):
     """
     Generate a raw JA4 fingerprint with all values visible.
-    
+
     Args:
         tls_info: A dictionary with TLS handshake information
         original_order: Whether to maintain original ordering (True) or sort (False)
-        
+
     Returns:
         A raw JA4 fingerprint string or None if not applicable
     """
-    if not tls_info or tls_info.get('type') != 'client_hello':
+    if not tls_info or tls_info.get("type") != "client_hello":
         return None
-        
+
     try:
         # Get the same components as in generate_ja4
-        proto = 'q' if tls_info.get('is_quic') else 'd' if tls_info.get('is_dtls') else 't'
-        
+        proto = "q" if tls_info.get("is_quic") else "d" if tls_info.get("is_dtls") else "t"
+
         # Version
-        version = tls_info.get('version')
-        supported_versions = tls_info.get('supported_versions', [])
+        version = tls_info.get("version")
+        supported_versions = tls_info.get("supported_versions", [])
         supported_versions = [v for v in supported_versions if not is_grease_value(v)]
-        
+
         if supported_versions:
             version = max(supported_versions)
-            
+
         # Map version to string format (same as in generate_ja4)
         if version == 0x0304:  # TLS 1.3
-            version_str = '13'
+            version_str = "13"
         elif version == 0x0303:  # TLS 1.2
-            version_str = '12'
+            version_str = "12"
         elif version == 0x0302:  # TLS 1.1
-            version_str = '11'
+            version_str = "11"
         elif version == 0x0301:  # TLS 1.0
-            version_str = '10'
+            version_str = "10"
         elif version == 0x0300:  # SSL 3.0
-            version_str = 's3'
+            version_str = "s3"
         elif version == 0x0200:  # SSL 2.0
-            version_str = 's2'
-        elif version == 0xfeff:  # DTLS 1.0
-            version_str = 'd1'
-        elif version == 0xfefd:  # DTLS 1.2
-            version_str = 'd2'
-        elif version == 0xfefc:  # DTLS 1.3
-            version_str = 'd3'
+            version_str = "s2"
+        elif version == 0xFEFF:  # DTLS 1.0
+            version_str = "d1"
+        elif version == 0xFEFD:  # DTLS 1.2
+            version_str = "d2"
+        elif version == 0xFEFC:  # DTLS 1.3
+            version_str = "d3"
         else:
-            version_str = '00'
-            
+            version_str = "00"
+
         # SNI
-        sni = tls_info.get('sni')
-        sni_type = 'd' if sni else 'i'
-        
+        sni = tls_info.get("sni")
+        sni_type = "d" if sni else "i"
+
         # Ciphers - filter GREASE
-        ciphers = [c for c in tls_info.get('ciphers', []) if not is_grease_value(c)]
+        ciphers = [c for c in tls_info.get("ciphers", []) if not is_grease_value(c)]
         cipher_count = min(len(ciphers), 99)
         cipher_count_str = f"{cipher_count:02d}"
-        
+
         # Extensions - filter GREASE
-        extensions = [e for e in tls_info.get('extensions', []) if not is_grease_value(e)]
+        extensions = [e for e in tls_info.get("extensions", []) if not is_grease_value(e)]
         ext_count = min(len(extensions), 99)
         ext_count_str = f"{ext_count:02d}"
-        
+
         # ALPN per FoxIO spec PR #277 — same path as generate_ja4
-        alpn_raw = tls_info.get('alpn_raw') or []
-        alpn_protocols = tls_info.get('alpn_protocols', [])
+        alpn_raw = tls_info.get("alpn_raw") or []
+        alpn_protocols = tls_info.get("alpn_protocols", [])
         if alpn_raw:
             alpn_value = compute_alpn_value(alpn_raw[0])
         elif alpn_protocols and alpn_protocols[0]:
-            alpn_value = compute_alpn_value(alpn_protocols[0].encode('latin-1', errors='replace'))
+            alpn_value = compute_alpn_value(alpn_protocols[0].encode("latin-1", errors="replace"))
         else:
-            alpn_value = '00'
-        
+            alpn_value = "00"
+
         # First part of fingerprint
         part_a = f"{proto}{version_str}{sni_type}{cipher_count_str}{ext_count_str}{alpn_value}"
-        
+
         # Cipher list - either sorted or original
         if original_order:
-            cipher_list = ','.join([f"{c:04x}" for c in tls_info.get('ciphers', []) if not is_grease_value(c)])
+            cipher_list = ",".join(
+                [f"{c:04x}" for c in tls_info.get("ciphers", []) if not is_grease_value(c)]
+            )
         else:
-            cipher_list = ','.join([f"{c:04x}" for c in sorted(ciphers)])
-        
+            cipher_list = ",".join([f"{c:04x}" for c in sorted(ciphers)])
+
         # Extension list - either with or without SNI/ALPN based on original_order
         if original_order:
-            ext_list = ','.join([f"{e:04x}" for e in tls_info.get('extensions', []) if not is_grease_value(e)])
+            ext_list = ",".join(
+                [f"{e:04x}" for e in tls_info.get("extensions", []) if not is_grease_value(e)]
+            )
         else:
-            ext_list = ','.join([f"{e:04x}" for e in sorted([e for e in extensions if e != 0x0000 and e != 0x0010])])
-        
+            ext_list = ",".join(
+                [f"{e:04x}" for e in sorted([e for e in extensions if e != 0x0000 and e != 0x0010])]
+            )
+
         # Signature algorithms
-        sig_algs = tls_info.get('signature_algorithms', [])
-        sig_alg_list = ','.join([f"{s:04x}" for s in sig_algs])
-        
+        sig_algs = tls_info.get("signature_algorithms", [])
+        sig_alg_list = ",".join([f"{s:04x}" for s in sig_algs])
+
         # Final format
         if sig_algs:
             if original_order:
@@ -272,12 +280,13 @@ def get_raw_fingerprint(tls_info, original_order=False):
                 raw_ja4 = f"{part_a}_{cipher_list}_{ext_list}_{sig_alg_list}"
         else:
             raw_ja4 = f"{part_a}_{cipher_list}_{ext_list}"
-        
+
         return raw_ja4
-            
+
     except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
         logger.debug(f"Failed to generate JA4 fingerprint: {e}")
         return None
+
 
 class JA4Fingerprinter(BaseFingerprinter):
     """Fingerprinter for JA4 (TLS Client Hello).
@@ -318,12 +327,14 @@ class JA4Fingerprinter(BaseFingerprinter):
             raw_oo = get_raw_fingerprint(tls_info, original_order=True)
             self.last_raw = raw
             self.last_raw_original_order = raw_oo
-            self.fingerprints.append({
-                'fingerprint': fingerprint,
-                'raw': raw,
-                'raw_original_order': raw_oo,
-                'packet': packet,
-            })
+            self.fingerprints.append(
+                {
+                    "fingerprint": fingerprint,
+                    "raw": raw,
+                    "raw_original_order": raw_oo,
+                    "packet": packet,
+                }
+            )
 
         return fingerprint
 
@@ -353,6 +364,7 @@ class JA4Fingerprinter(BaseFingerprinter):
 
         # Track DCID -> 5-tuple for cleanup_connection.
         from ja4plus.utils.packet_utils import get_ip_layer
+
         ip = get_ip_layer(packet)
         if ip is not None:
             tuple_key = f"{ip.src}:{int(udp.sport)}-{ip.dst}:{int(udp.dport)}"

--- a/ja4plus/fingerprinters/ja4d.py
+++ b/ja4plus/fingerprinters/ja4d.py
@@ -19,15 +19,15 @@ from ja4plus.fingerprinters.base import BaseFingerprinter
 
 # DHCP message type (option 53) to 5-character abbreviation.
 DHCP_MESSAGE_TYPES = {
-    1:  "disco",  # DHCPDISCOVER
-    2:  "offer",  # DHCPOFFER
-    3:  "reqst",  # DHCPREQUEST
-    4:  "decln",  # DHCPDECLINE
-    5:  "dpack",  # DHCPACK
-    6:  "dpnak",  # DHCPNAK
-    7:  "relse",  # DHCPRELEASE
-    8:  "infor",  # DHCPINFORM
-    9:  "frenw",  # DHCPFORCERENEW
+    1: "disco",  # DHCPDISCOVER
+    2: "offer",  # DHCPOFFER
+    3: "reqst",  # DHCPREQUEST
+    4: "decln",  # DHCPDECLINE
+    5: "dpack",  # DHCPACK
+    6: "dpnak",  # DHCPNAK
+    7: "relse",  # DHCPRELEASE
+    8: "infor",  # DHCPINFORM
+    9: "frenw",  # DHCPFORCERENEW
     10: "lqery",  # DHCPLEASEQUERY
     11: "lunas",  # DHCPLEASEUNASSIGNED
     12: "lunkn",  # DHCPLEASEUNKNOWN
@@ -45,7 +45,7 @@ DHCP_MESSAGE_TYPES = {
 DHCP_SKIP_OPTIONS = {0, 53, 50, 81}
 
 # DHCP magic cookie
-_DHCP_MAGIC = b'\x63\x82\x53\x63'
+_DHCP_MAGIC = b"\x63\x82\x53\x63"
 
 # UDP ports used by DHCP
 _DHCP_PORTS = {67, 68}
@@ -63,7 +63,7 @@ def build_option_list(option_codes):
         Hyphen-separated string of option codes, or '00'
     """
     parts = [str(code) for code in option_codes if code not in DHCP_SKIP_OPTIONS]
-    return '-'.join(parts) if parts else "00"
+    return "-".join(parts) if parts else "00"
 
 
 def build_param_list(params):
@@ -79,7 +79,7 @@ def build_param_list(params):
     """
     if not params:
         return "00"
-    return '-'.join(str(p) for p in params)
+    return "-".join(str(p) for p in params)
 
 
 def _parse_dhcp_options(raw_payload):
@@ -114,7 +114,7 @@ def _parse_dhcp_options(raw_payload):
 
         if opt_code == 255:  # End marker — terminate; do not record
             break
-        if opt_code == 0:    # Pad
+        if opt_code == 0:  # Pad
             continue
 
         if pos >= len(raw_payload):
@@ -122,32 +122,32 @@ def _parse_dhcp_options(raw_payload):
         opt_len = raw_payload[pos]
         pos += 1
 
-        opt_data = raw_payload[pos:pos + opt_len]
+        opt_data = raw_payload[pos : pos + opt_len]
         pos += opt_len
 
         option_codes.append(opt_code)
 
-        if opt_code == 53 and opt_len >= 1:   # Message Type
+        if opt_code == 53 and opt_len >= 1:  # Message Type
             msg_type = opt_data[0]
         elif opt_code == 57 and opt_len >= 2:  # Max Message Size
             max_msg_size = (opt_data[0] << 8) | opt_data[1]
-        elif opt_code == 50:                   # Requested IP Address
+        elif opt_code == 50:  # Requested IP Address
             has_request_ip = True
-        elif opt_code == 81:                   # Client FQDN
+        elif opt_code == 81:  # Client FQDN
             has_fqdn = True
-        elif opt_code == 55:                   # Parameter Request List
+        elif opt_code == 55:  # Parameter Request List
             param_list = list(opt_data)
 
     if msg_type == 0:
         return None
 
     return {
-        'msg_type': msg_type,
-        'max_msg_size': max_msg_size,
-        'has_request_ip': has_request_ip,
-        'has_fqdn': has_fqdn,
-        'option_codes': option_codes,
-        'param_list': param_list,
+        "msg_type": msg_type,
+        "max_msg_size": max_msg_size,
+        "has_request_ip": has_request_ip,
+        "has_fqdn": has_fqdn,
+        "option_codes": option_codes,
+        "param_list": param_list,
     }
 
 
@@ -165,7 +165,7 @@ def generate_ja4d(packet):
     if udp is None:
         return None
 
-    if (udp.sport not in _DHCP_PORTS and udp.dport not in _DHCP_PORTS):
+    if udp.sport not in _DHCP_PORTS and udp.dport not in _DHCP_PORTS:
         return None
 
     # Get raw UDP payload
@@ -174,10 +174,10 @@ def generate_ja4d(packet):
     if parsed is None:
         return None
 
-    msg_type = parsed['msg_type']
-    max_msg_size = min(parsed['max_msg_size'], 9999)
-    has_request_ip = parsed['has_request_ip']
-    has_fqdn = parsed['has_fqdn']
+    msg_type = parsed["msg_type"]
+    max_msg_size = min(parsed["max_msg_size"], 9999)
+    has_request_ip = parsed["has_request_ip"]
+    has_fqdn = parsed["has_fqdn"]
 
     # Section a
     msg_type_str = DHCP_MESSAGE_TYPES.get(msg_type, f"{msg_type:05d}")
@@ -186,10 +186,10 @@ def generate_ja4d(packet):
     section_a = f"{msg_type_str}{max_msg_size:04d}{request_ip_flag}{fqdn_flag}"
 
     # Section b
-    section_b = build_option_list(parsed['option_codes'])
+    section_b = build_option_list(parsed["option_codes"])
 
     # Section c
-    section_c = build_param_list(parsed['param_list'])
+    section_c = build_param_list(parsed["param_list"])
 
     return f"{section_a}_{section_b}_{section_c}"
 

--- a/ja4plus/fingerprinters/ja4d6.py
+++ b/ja4plus/fingerprinters/ja4d6.py
@@ -29,15 +29,15 @@ from ja4plus.fingerprinters.base import BaseFingerprinter
 
 # DHCPv6 message type to 5-char abbreviation (RFC 8415 + extensions).
 DHCPV6_MESSAGE_TYPES = {
-    1:  "solct",  # SOLICIT
-    2:  "advrt",  # ADVERTISE
-    3:  "reqst",  # REQUEST
-    4:  "confm",  # CONFIRM
-    5:  "renew",  # RENEW
-    6:  "rebnd",  # REBIND
-    7:  "reply",  # REPLY
-    8:  "relse",  # RELEASE
-    9:  "decln",  # DECLINE
+    1: "solct",  # SOLICIT
+    2: "advrt",  # ADVERTISE
+    3: "reqst",  # REQUEST
+    4: "confm",  # CONFIRM
+    5: "renew",  # RENEW
+    6: "rebnd",  # REBIND
+    7: "reply",  # REPLY
+    8: "relse",  # RELEASE
+    9: "decln",  # DECLINE
     10: "recon",  # RECONFIGURE
     11: "inreq",  # INFORMATION-REQUEST
     12: "rlayf",  # RELAY-FORW
@@ -74,11 +74,11 @@ DHCPV6_MESSAGE_TYPES = {
 # starting after a fixed-size header. Option 17 (Vendor-specific Information)
 # carries enterprise-specific sub-options keyed by enterprise-number.
 _DHCPV6_NESTED_OPTIONS = {
-    3:  12,   # IA_NA:  IAID(4) + T1(4) + T2(4) = 12 bytes header
-    4:  4,    # IA_TA:  IAID(4) = 4 bytes header
-    25: 12,   # IA_PD:  IAID(4) + T1(4) + T2(4) = 12 bytes header
-    5:  24,   # IA Address (within IA_NA/IA_TA): addr(16)+pref-lt(4)+valid-lt(4) = 24
-    26: 25,   # IA Prefix (within IA_PD): pref-lt(4)+valid-lt(4)+plen(1)+prefix(16) = 25
+    3: 12,  # IA_NA:  IAID(4) + T1(4) + T2(4) = 12 bytes header
+    4: 4,  # IA_TA:  IAID(4) = 4 bytes header
+    25: 12,  # IA_PD:  IAID(4) + T1(4) + T2(4) = 12 bytes header
+    5: 24,  # IA Address (within IA_NA/IA_TA): addr(16)+pref-lt(4)+valid-lt(4) = 24
+    26: 25,  # IA Prefix (within IA_PD): pref-lt(4)+valid-lt(4)+plen(1)+prefix(16) = 25
 }
 
 
@@ -134,7 +134,7 @@ def _parse_dhcpv6_payload(payload):
         pos += 4
         if pos + opt_len > end:
             break
-        opt_data = payload[pos:pos + opt_len]
+        opt_data = payload[pos : pos + opt_len]
         pos += opt_len
 
         if opt_code == 1:  # Client Identifier — DUID is the entire data
@@ -187,8 +187,7 @@ def generate_ja4d6(packet):
         return None
 
     # DHCPv6 client port = 546, server port = 547
-    if 546 not in (int(udp.sport), int(udp.dport)) and \
-       547 not in (int(udp.sport), int(udp.dport)):
+    if 546 not in (int(udp.sport), int(udp.dport)) and 547 not in (int(udp.sport), int(udp.dport)):
         return None
 
     payload = bytes(udp.payload)

--- a/ja4plus/fingerprinters/ja4h.py
+++ b/ja4plus/fingerprinters/ja4h.py
@@ -27,20 +27,20 @@ def _http_version_to_str(version):
     to length 2 with trailing zeros so the result fits the fixed format.
     """
     if not version:
-        return '11'
-    v = version.replace('HTTP/', '').strip()
+        return "11"
+    v = version.replace("HTTP/", "").strip()
     # Normalize: HTTP/2 and HTTP/3 are version strings without the minor
     # part; map them to 20 / 30 explicitly.
-    if v == '2' or v == '2.0':
-        return '20'
-    if v == '3' or v == '3.0':
-        return '30'
-    digits = v.replace('.', '')
+    if v == "2" or v == "2.0":
+        return "20"
+    if v == "3" or v == "3.0":
+        return "30"
+    digits = v.replace(".", "")
     if len(digits) >= 2:
         return digits[:2]
     if len(digits) == 1:
-        return digits + '0'
-    return '11'
+        return digits + "0"
+    return "11"
 
 
 class JA4HFingerprinter(BaseFingerprinter):
@@ -73,7 +73,7 @@ class JA4HFingerprinter(BaseFingerprinter):
         raw_data = bytes(packet[Raw])
 
         stream_key = f"{ip_layer.src}:{tcp.sport}-{ip_layer.dst}:{tcp.dport}"
-        seq = tcp.seq if hasattr(tcp, 'seq') else 0
+        seq = tcp.seq if hasattr(tcp, "seq") else 0
 
         self.reassembler.add_segment(stream_key, seq, raw_data)
         stream_data = self.reassembler.get_stream(stream_key)
@@ -123,13 +123,14 @@ def _extract_http_info_from_bytes(data):
     Scapy packet, so it works on reassembled TCP stream data.
     """
     import re
+
     if not data:
         return None
     try:
-        text = data.decode('utf-8', errors='ignore')
+        text = data.decode("utf-8", errors="ignore")
         request_line_match = re.match(
-            r'^(GET|POST|PUT|DELETE|HEAD|OPTIONS|CONNECT|TRACE|PATCH)\s+(\S+)\s+(HTTP/\d+\.\d+)',
-            text
+            r"^(GET|POST|PUT|DELETE|HEAD|OPTIONS|CONNECT|TRACE|PATCH)\s+(\S+)\s+(HTTP/\d+\.\d+)",
+            text,
         )
         if not request_line_match:
             return None
@@ -140,12 +141,12 @@ def _extract_http_info_from_bytes(data):
 
         headers = {}
         header_names = []
-        lines = text.split('\r\n')
+        lines = text.split("\r\n")
 
         for line in lines[1:]:
             if not line or line.isspace():
                 break
-            header_match = re.match(r'^([^:]+):\s*(.*)$', line)
+            header_match = re.match(r"^([^:]+):\s*(.*)$", line)
             if header_match:
                 name = header_match.group(1).strip()
                 value = header_match.group(2).strip()
@@ -155,25 +156,25 @@ def _extract_http_info_from_bytes(data):
         cookies = {}
         cookie_fields = []
         cookie_values = []
-        if 'cookie' in headers:
-            for pair in headers['cookie'].split(';'):
-                if '=' in pair:
-                    k, v = pair.split('=', 1)
+        if "cookie" in headers:
+            for pair in headers["cookie"].split(";"):
+                if "=" in pair:
+                    k, v = pair.split("=", 1)
                     k, v = k.strip(), v.strip()
                     cookies[k] = v
                     cookie_fields.append(k)
                     cookie_values.append(v)
 
         return {
-            'method': method,
-            'path': path,
-            'version': version,
-            'headers': header_names,
-            'cookies': cookies,
-            'cookie_fields': cookie_fields,
-            'cookie_values': cookie_values,
-            'language': headers.get('accept-language', ''),
-            'referer': headers.get('referer', ''),
+            "method": method,
+            "path": path,
+            "version": version,
+            "headers": header_names,
+            "cookies": cookies,
+            "cookie_fields": cookie_fields,
+            "cookie_values": cookie_values,
+            "language": headers.get("accept-language", ""),
+            "referer": headers.get("referer", ""),
         }
     except (ValueError, TypeError, UnicodeDecodeError) as e:
         logger.debug(f"Could not parse HTTP from stream bytes: {e}")
@@ -182,21 +183,21 @@ def _extract_http_info_from_bytes(data):
 
 def _convert_parsed_to_extract_format(parsed):
     """Convert parse_http_request output to extract_http_info format."""
-    headers = parsed.get('headers', {})
+    headers = parsed.get("headers", {})
     header_names = list(headers.keys())
-    cookies = parsed.get('cookies', {})
+    cookies = parsed.get("cookies", {})
     cookie_fields = list(cookies.keys())
 
     return {
-        'method': parsed.get('method', ''),
-        'path': parsed.get('path', ''),
-        'version': parsed.get('version', ''),
-        'headers': header_names,
-        'cookies': cookies,
-        'cookie_fields': cookie_fields,
-        'cookie_values': list(cookies.values()),
-        'language': headers.get('accept-language', ''),
-        'referer': headers.get('referer', ''),
+        "method": parsed.get("method", ""),
+        "path": parsed.get("path", ""),
+        "version": parsed.get("version", ""),
+        "headers": header_names,
+        "cookies": cookies,
+        "cookie_fields": cookie_fields,
+        "cookie_values": list(cookies.values()),
+        "language": headers.get("accept-language", ""),
+        "referer": headers.get("referer", ""),
     }
 
 
@@ -206,50 +207,58 @@ def _generate_ja4h_from_info(http_info):
         return None
 
     try:
-        method = http_info.get('method', '').lower()
-        version_str = _http_version_to_str(http_info.get('version', ''))
+        method = http_info.get("method", "").lower()
+        version_str = _http_version_to_str(http_info.get("version", ""))
 
-        has_cookie = 'c' if http_info.get('cookie_fields', []) else 'n'
-        has_referer = 'r' if http_info.get('referer', '') else 'n'
+        has_cookie = "c" if http_info.get("cookie_fields", []) else "n"
+        has_referer = "r" if http_info.get("referer", "") else "n"
 
         header_count = 0
-        for header in http_info.get('headers', []):
-            if header.lower() not in ['cookie', 'referer']:
+        for header in http_info.get("headers", []):
+            if header.lower() not in ["cookie", "referer"]:
                 header_count += 1
         header_count = min(header_count, 99)
         header_count_str = f"{header_count:02d}"
 
-        language = http_info.get('language', '')
-        lang_code = '0000'
+        language = http_info.get("language", "")
+        lang_code = "0000"
         if language:
-            lang_clean = language.replace('-', '').replace(';', ',').lower().split(',')[0]
+            lang_clean = language.replace("-", "").replace(";", ",").lower().split(",")[0]
             lang_clean = lang_clean[:4]
-            lang_code = f"{lang_clean}{'0' * (4 - len(lang_clean))}" if lang_clean else '0000'
+            lang_code = f"{lang_clean}{'0' * (4 - len(lang_clean))}" if lang_clean else "0000"
 
         part_a = f"{method[:2]}{version_str}{has_cookie}{has_referer}{header_count_str}{lang_code}"
 
-        headers = http_info.get('headers', [])
+        headers = http_info.get("headers", [])
         filtered_headers = [
-            h for h in headers
-            if not h.startswith(':')
-            and h.lower() != 'cookie'
-            and h.lower() != 'referer'
-            and h
+            h
+            for h in headers
+            if not h.startswith(":") and h.lower() != "cookie" and h.lower() != "referer" and h
         ]
-        headers_str = ','.join(filtered_headers)
-        part_b = hashlib.sha256(headers_str.encode()).hexdigest()[:12] if headers_str else '000000000000'
+        headers_str = ",".join(filtered_headers)
+        part_b = (
+            hashlib.sha256(headers_str.encode()).hexdigest()[:12] if headers_str else "000000000000"
+        )
 
-        cookie_fields = sorted(http_info.get('cookie_fields', []))
-        cookie_fields_str = ','.join(cookie_fields)
-        part_c = hashlib.sha256(cookie_fields_str.encode()).hexdigest()[:12] if cookie_fields_str else '000000000000'
+        cookie_fields = sorted(http_info.get("cookie_fields", []))
+        cookie_fields_str = ",".join(cookie_fields)
+        part_c = (
+            hashlib.sha256(cookie_fields_str.encode()).hexdigest()[:12]
+            if cookie_fields_str
+            else "000000000000"
+        )
 
         # Cookie-VALUES hash: pairs sorted by NAME only (FoxIO PR #288).
         # We sort by key explicitly so the ordering doesn't depend on tuple
         # tie-breaking when two cookies happen to have identical names.
-        cookie_dict = http_info.get('cookies', {})
+        cookie_dict = http_info.get("cookies", {})
         sorted_cookie_pairs = sorted(cookie_dict.items(), key=lambda kv: kv[0])
-        cookie_values_str = ','.join(f"{k}={v}" for k, v in sorted_cookie_pairs)
-        part_d = hashlib.sha256(cookie_values_str.encode()).hexdigest()[:12] if cookie_values_str else '000000000000'
+        cookie_values_str = ",".join(f"{k}={v}" for k, v in sorted_cookie_pairs)
+        part_d = (
+            hashlib.sha256(cookie_values_str.encode()).hexdigest()[:12]
+            if cookie_values_str
+            else "000000000000"
+        )
 
         return f"{part_a}_{part_b}_{part_c}_{part_d}"
 

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -40,15 +40,16 @@ class JA4LFingerprinter(BaseFingerprinter):
             return None
 
         if TCP in packet:
-            proto = 'tcp'
+            proto = "tcp"
             sport = packet[TCP].sport
             dport = packet[TCP].dport
         else:
-            proto = 'udp'
+            proto = "udp"
             sport = packet[UDP].sport
             dport = packet[UDP].dport
 
         from ja4plus.utils.packet_utils import get_ip_layer
+
         ip_layer = get_ip_layer(packet)
         if ip_layer is None:
             return None
@@ -58,29 +59,27 @@ class JA4LFingerprinter(BaseFingerprinter):
         # Normalize connection key (ordered src/dst)
         if src_ip < dst_ip or (src_ip == dst_ip and sport < dport):
             conn_key = f"{proto}_{src_ip}:{sport}_{dst_ip}:{dport}"
-            direction = 'forward'
+            direction = "forward"
         else:
             conn_key = f"{proto}_{dst_ip}:{dport}_{src_ip}:{sport}"
-            direction = 'reverse'
+            direction = "reverse"
 
         if conn_key not in self.connections:
             self.connections[conn_key] = {
-                'proto': proto,
-                'direction': direction,
-                'conn_key': conn_key,
-                'timestamps': {},
-                'ttls': {}
+                "proto": proto,
+                "direction": direction,
+                "conn_key": conn_key,
+                "timestamps": {},
+                "ttls": {},
             }
 
         conn = self.connections[conn_key]
         fingerprint = generate_ja4l(packet, conn)
 
         if fingerprint:
-            self.fingerprints.append({
-                'fingerprint': fingerprint,
-                'packet': packet,
-                'connection': conn_key
-            })
+            self.fingerprints.append(
+                {"fingerprint": fingerprint, "packet": packet, "connection": conn_key}
+            )
             return fingerprint
 
         return None
@@ -182,21 +181,22 @@ def generate_ja4l(packet, conn=None):
         return None
 
     from ja4plus.utils.packet_utils import get_ip_layer as _get_ip, get_ttl
+
     if _get_ip(packet) is None:
         return None
 
     try:
-        if 'timestamps' not in conn:
-            conn['timestamps'] = {}
-        if 'ttls' not in conn:
-            conn['ttls'] = {}
+        if "timestamps" not in conn:
+            conn["timestamps"] = {}
+        if "ttls" not in conn:
+            conn["ttls"] = {}
 
         ttl = get_ttl(packet)
         if ttl is None:
             return None
 
         # Use pcap timestamp if available (for offline analysis), else wall clock
-        current_time = float(packet.time) if hasattr(packet, 'time') else time.time()
+        current_time = float(packet.time) if hasattr(packet, "time") else time.time()
 
         # Handle TCP protocol
         if packet.haslayer(TCP):
@@ -204,27 +204,27 @@ def generate_ja4l(packet, conn=None):
 
             # SYN packet (point A) - client initiates
             if tcp_flags & 0x02 == 0x02 and not tcp_flags & 0x10:
-                conn['timestamps']['A'] = current_time
-                conn['ttls']['client'] = ttl
+                conn["timestamps"]["A"] = current_time
+                conn["ttls"]["client"] = ttl
                 return None
 
             # SYN-ACK packet (point B) - server responds
             elif tcp_flags & 0x12 == 0x12:
-                conn['timestamps']['B'] = current_time
-                conn['ttls']['server'] = ttl
+                conn["timestamps"]["B"] = current_time
+                conn["ttls"]["server"] = ttl
 
-                if 'A' in conn['timestamps']:
+                if "A" in conn["timestamps"]:
                     # Per FoxIO spec: use raw time difference (not divided by 2)
-                    diff = conn['timestamps']['B'] - conn['timestamps']['A']
+                    diff = conn["timestamps"]["B"] - conn["timestamps"]["A"]
                     latency = max(1, int(diff * 1000000))
                     return f"JA4L-S={latency}_{ttl}"
 
             # ACK packet (point C) - client completes handshake
             elif tcp_flags & 0x10 == 0x10 and not tcp_flags & 0x02:
-                conn['timestamps']['C'] = current_time
+                conn["timestamps"]["C"] = current_time
 
-                if 'B' in conn['timestamps']:
-                    diff = conn['timestamps']['C'] - conn['timestamps']['B']
+                if "B" in conn["timestamps"]:
+                    diff = conn["timestamps"]["C"] - conn["timestamps"]["B"]
                     latency = max(1, int(diff * 1000000))
                     return f"JA4L-C={latency}_{ttl}"
 
@@ -234,8 +234,9 @@ def generate_ja4l(packet, conn=None):
         # lexicographic conn_key direction (which produced silent failures
         # for server-first capture orderings — the previous code only
         # advanced state when direction was 'forward').
-        elif packet.haslayer(UDP) and conn.get('proto') == 'udp':
+        elif packet.haslayer(UDP) and conn.get("proto") == "udp":
             from ja4plus.utils.packet_utils import get_ip_layer
+
             ip_layer = get_ip_layer(packet)
             if ip_layer is None:
                 return None
@@ -244,29 +245,28 @@ def generate_ja4l(packet, conn=None):
             dport = int(packet[UDP].dport)
 
             # Lock in the client identity on the first packet.
-            if 'client_endpoint' not in conn:
-                conn['client_endpoint'] = (src_ip, sport, dport)
-            client_ip, client_sport, client_dport = conn['client_endpoint']
-            is_client = (src_ip == client_ip and sport == client_sport
-                         and dport == client_dport)
+            if "client_endpoint" not in conn:
+                conn["client_endpoint"] = (src_ip, sport, dport)
+            client_ip, client_sport, client_dport = conn["client_endpoint"]
+            is_client = src_ip == client_ip and sport == client_sport and dport == client_dport
 
-            if 'A' not in conn['timestamps'] and is_client:
-                conn['timestamps']['A'] = current_time
-                conn['ttls']['client'] = ttl
+            if "A" not in conn["timestamps"] and is_client:
+                conn["timestamps"]["A"] = current_time
+                conn["ttls"]["client"] = ttl
 
-            elif 'A' in conn['timestamps'] and not is_client and 'B' not in conn['timestamps']:
-                conn['timestamps']['B'] = current_time
-                conn['ttls']['server'] = ttl
-                diff = conn['timestamps']['B'] - conn['timestamps']['A']
+            elif "A" in conn["timestamps"] and not is_client and "B" not in conn["timestamps"]:
+                conn["timestamps"]["B"] = current_time
+                conn["ttls"]["server"] = ttl
+                diff = conn["timestamps"]["B"] - conn["timestamps"]["A"]
                 latency = max(1, int(diff * 1000000))
                 return f"JA4L-S={latency}_{ttl}"
 
-            elif 'B' in conn['timestamps'] and is_client and 'C' not in conn['timestamps']:
-                conn['timestamps']['C'] = current_time
+            elif "B" in conn["timestamps"] and is_client and "C" not in conn["timestamps"]:
+                conn["timestamps"]["C"] = current_time
 
-            elif 'C' in conn['timestamps'] and not is_client and 'D' not in conn['timestamps']:
-                conn['timestamps']['D'] = current_time
-                diff = conn['timestamps']['D'] - conn['timestamps']['C']
+            elif "C" in conn["timestamps"] and not is_client and "D" not in conn["timestamps"]:
+                conn["timestamps"]["D"] = current_time
+                diff = conn["timestamps"]["D"] - conn["timestamps"]["C"]
                 latency = max(1, int(diff * 1000000))
                 return f"JA4L-C={latency}_{conn['ttls'].get('client', ttl)}"
 
@@ -288,17 +288,18 @@ def _src_is_client(packet, conn):
         True if the source is the client, False otherwise
     """
     from ja4plus.utils.packet_utils import get_ip_layer
+
     ip_layer = get_ip_layer(packet)
     if ip_layer is None:
         return False
 
     src_ip = ip_layer.src
 
-    if conn.get('direction') == 'forward':
-        conn_key = conn.get('conn_key', '')
-        parts = conn_key.split('_')
+    if conn.get("direction") == "forward":
+        conn_key = conn.get("conn_key", "")
+        parts = conn_key.split("_")
         if len(parts) >= 2:
-            client_part = parts[1].split(':')[0]
+            client_part = parts[1].split(":")[0]
             return src_ip == client_part
 
     return False

--- a/ja4plus/fingerprinters/ja4s.py
+++ b/ja4plus/fingerprinters/ja4s.py
@@ -69,7 +69,7 @@ class JA4SFingerprinter(BaseFingerprinter):
                 if rev_key in self._quic_dcids:
                     client_dcid = self._quic_dcids[rev_key]
                     tls_info = parse_quic_server_initial(udp_payload, client_dcid)
-                    if tls_info and tls_info.get('handshake_type') == 'server_hello':
+                    if tls_info and tls_info.get("handshake_type") == "server_hello":
                         fingerprint = _generate_ja4s_from_tls_info(tls_info)
                         if fingerprint:
                             self._record(fingerprint, tls_info, packet)
@@ -77,8 +77,9 @@ class JA4SFingerprinter(BaseFingerprinter):
 
         # TCP/TLS path
         from ja4plus.utils.tls_utils import extract_tls_info as _extract
+
         tls_info = _extract(packet)
-        if not tls_info or tls_info.get('handshake_type') != 'server_hello':
+        if not tls_info or tls_info.get("handshake_type") != "server_hello":
             return None
         fingerprint = _generate_ja4s_from_tls_info(tls_info)
         if fingerprint:
@@ -92,12 +93,14 @@ class JA4SFingerprinter(BaseFingerprinter):
         raw_oo = _generate_ja4s_raw_from_tls_info(tls_info, original_order=True)
         self.last_raw = raw
         self.last_raw_original_order = raw_oo
-        self.fingerprints.append({
-            'fingerprint': fingerprint,
-            'raw': raw,
-            'raw_original_order': raw_oo,
-            'packet': packet,
-        })
+        self.fingerprints.append(
+            {
+                "fingerprint": fingerprint,
+                "raw": raw,
+                "raw_original_order": raw_oo,
+                "packet": packet,
+            }
+        )
 
     def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
         """Remove stored QUIC DCID state for the given connection."""
@@ -146,7 +149,7 @@ def _extract_dcid(udp_payload):
     dcid_len = udp_payload[5]
     if 6 + dcid_len > len(udp_payload):
         return None
-    return udp_payload[6:6 + dcid_len]
+    return udp_payload[6 : 6 + dcid_len]
 
 
 def _generate_ja4s_from_tls_info(tls_info):
@@ -155,40 +158,40 @@ def _generate_ja4s_from_tls_info(tls_info):
     Shared by the TCP path (via generate_ja4s) and the QUIC server path.
     """
     try:
-        proto = 'q' if tls_info.get('is_quic') else 'd' if tls_info.get('is_dtls') else 't'
+        proto = "q" if tls_info.get("is_quic") else "d" if tls_info.get("is_dtls") else "t"
 
-        version = tls_info.get('version')
-        supported_versions = tls_info.get('supported_versions', [])
+        version = tls_info.get("version")
+        supported_versions = tls_info.get("supported_versions", [])
         if supported_versions:
             non_grease = [v for v in supported_versions if not is_grease_value(v)]
             if non_grease:
                 version = non_grease[0]
 
         version_str = _version_to_str(version)
-        extensions = tls_info.get('extensions', [])
+        extensions = tls_info.get("extensions", [])
         ext_count = f"{min(len(extensions), 99):02d}"
 
-        alpn_protocols = tls_info.get('alpn_protocols', [])
-        alpn_raw = tls_info.get('alpn_raw') or []
+        alpn_protocols = tls_info.get("alpn_protocols", [])
+        alpn_raw = tls_info.get("alpn_raw") or []
         if not alpn_protocols:
-            for ext_id, ext_data in tls_info.get('extension_data', {}).items():
-                if ext_id == 0x0010 and 'protocols' in ext_data and ext_data['protocols']:
-                    alpn_protocols = ext_data['protocols']
+            for ext_id, ext_data in tls_info.get("extension_data", {}).items():
+                if ext_id == 0x0010 and "protocols" in ext_data and ext_data["protocols"]:
+                    alpn_protocols = ext_data["protocols"]
                     break
 
         alpn_value = _get_alpn_value(alpn_protocols, alpn_raw)
         part_a = f"{proto}{version_str}{ext_count}{alpn_value}"
 
-        cipher = tls_info.get('cipher')
+        cipher = tls_info.get("cipher")
         if cipher is None:
             return None
         cipher_str = f"{cipher:04x}"
 
         if extensions:
-            ext_str = ','.join([f"{e:04x}" for e in extensions])
+            ext_str = ",".join([f"{e:04x}" for e in extensions])
             extensions_hash = hashlib.sha256(ext_str.encode()).hexdigest()[:12]
         else:
-            extensions_hash = '000000000000'
+            extensions_hash = "000000000000"
 
         return f"{part_a}_{cipher_str}_{extensions_hash}"
 
@@ -206,38 +209,38 @@ def _generate_ja4s_raw_from_tls_info(tls_info, original_order=False):
     ComputeJA4SRaw / ComputeJA4SRawOriginalOrder.
     """
     try:
-        proto = 'q' if tls_info.get('is_quic') else 'd' if tls_info.get('is_dtls') else 't'
+        proto = "q" if tls_info.get("is_quic") else "d" if tls_info.get("is_dtls") else "t"
 
-        version = tls_info.get('version')
-        supported_versions = tls_info.get('supported_versions', [])
+        version = tls_info.get("version")
+        supported_versions = tls_info.get("supported_versions", [])
         if supported_versions:
             non_grease = [v for v in supported_versions if not is_grease_value(v)]
             if non_grease:
                 version = non_grease[0]
         version_str = _version_to_str(version)
 
-        extensions = tls_info.get('extensions', [])
+        extensions = tls_info.get("extensions", [])
         ext_count = f"{min(len(extensions), 99):02d}"
 
-        alpn_protocols = tls_info.get('alpn_protocols', [])
-        alpn_raw = tls_info.get('alpn_raw') or []
+        alpn_protocols = tls_info.get("alpn_protocols", [])
+        alpn_raw = tls_info.get("alpn_raw") or []
         if not alpn_protocols:
-            for ext_id, ext_data in tls_info.get('extension_data', {}).items():
-                if ext_id == 0x0010 and 'protocols' in ext_data and ext_data['protocols']:
-                    alpn_protocols = ext_data['protocols']
+            for ext_id, ext_data in tls_info.get("extension_data", {}).items():
+                if ext_id == 0x0010 and "protocols" in ext_data and ext_data["protocols"]:
+                    alpn_protocols = ext_data["protocols"]
                     break
         alpn_value = _get_alpn_value(alpn_protocols, alpn_raw)
         part_a = f"{proto}{version_str}{ext_count}{alpn_value}"
 
-        cipher = tls_info.get('cipher')
+        cipher = tls_info.get("cipher")
         if cipher is None:
             return None
         cipher_str = f"{cipher:04x}"
 
         if original_order:
-            ext_list = ','.join(f"{e:04x}" for e in extensions)
+            ext_list = ",".join(f"{e:04x}" for e in extensions)
         else:
-            ext_list = ','.join(f"{e:04x}" for e in sorted(extensions))
+            ext_list = ",".join(f"{e:04x}" for e in sorted(extensions))
 
         return f"{part_a}_{cipher_str}_{ext_list}"
     except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
@@ -256,7 +259,7 @@ def generate_ja4s(packet):
         A JA4S fingerprint string or None if not applicable
     """
     tls_info = extract_tls_info(packet)
-    if not tls_info or tls_info.get('handshake_type') != 'server_hello':
+    if not tls_info or tls_info.get("handshake_type") != "server_hello":
         return None
     return _generate_ja4s_from_tls_info(tls_info)
 
@@ -264,17 +267,17 @@ def generate_ja4s(packet):
 def _version_to_str(version):
     """Convert TLS version number to JA4 version string."""
     version_map = {
-        0x0304: '13',  # TLS 1.3
-        0x0303: '12',  # TLS 1.2
-        0x0302: '11',  # TLS 1.1
-        0x0301: '10',  # TLS 1.0
-        0x0300: 's3',  # SSL 3.0
-        0x0200: 's2',  # SSL 2.0
-        0xfeff: 'd1',  # DTLS 1.0
-        0xfefd: 'd2',  # DTLS 1.2
-        0xfefc: 'd3',  # DTLS 1.3
+        0x0304: "13",  # TLS 1.3
+        0x0303: "12",  # TLS 1.2
+        0x0302: "11",  # TLS 1.1
+        0x0301: "10",  # TLS 1.0
+        0x0300: "s3",  # SSL 3.0
+        0x0200: "s2",  # SSL 2.0
+        0xFEFF: "d1",  # DTLS 1.0
+        0xFEFD: "d2",  # DTLS 1.2
+        0xFEFC: "d3",  # DTLS 1.3
     }
-    return version_map.get(version, '00')
+    return version_map.get(version, "00")
 
 
 def _get_alpn_value(alpn_protocols, alpn_raw=None):
@@ -288,7 +291,5 @@ def _get_alpn_value(alpn_protocols, alpn_raw=None):
     if alpn_raw:
         return compute_alpn_value(alpn_raw[0])
     if alpn_protocols and alpn_protocols[0]:
-        return compute_alpn_value(
-            alpn_protocols[0].encode('latin-1', errors='replace')
-        )
-    return '00'
+        return compute_alpn_value(alpn_protocols[0].encode("latin-1", errors="replace"))
+    return "00"

--- a/ja4plus/fingerprinters/ja4ssh.py
+++ b/ja4plus/fingerprinters/ja4ssh.py
@@ -35,7 +35,7 @@ class JA4SSHFingerprinter(BaseFingerprinter):
         self.connections = {}
         self.packet_count = packet_count
         self.hassh_fingerprints = []
-    
+
     def process_packet(self, packet):
         """
         Process a packet and track SSH session patterns.
@@ -57,6 +57,7 @@ class JA4SSHFingerprinter(BaseFingerprinter):
 
         tcp = packet[TCP]
         from ja4plus.utils.packet_utils import get_ip_layer
+
         ip = get_ip_layer(packet)
 
         # Create connection key
@@ -100,83 +101,82 @@ class JA4SSHFingerprinter(BaseFingerprinter):
             self.connections[conn_key] = {
                 "client_ip": client_ip,
                 "server_ip": server_ip,
-                "ssh_packets": {
-                    "client": [],
-                    "server": []
-                },
-                "bare_acks": {
-                    "client": 0,
-                    "server": 0
-                },
+                "ssh_packets": {"client": [], "server": []},
+                "bare_acks": {"client": 0, "server": 0},
                 "hassh": None,
                 "hasshServer": None,
                 "client_id": None,
                 "server_id": None,
-                "start_time": time.time()
+                "start_time": time.time(),
             }
-        
+
         conn = self.connections[conn_key]
-        
+
         # Check for SSH version banner
         if packet.haslayer(Raw):
             payload = bytes(packet[Raw])
-            
+
             # Extract SSH banner
             if payload.startswith(b"SSH-"):
-                version_string = payload.decode('utf-8', errors='ignore').strip()
+                version_string = payload.decode("utf-8", errors="ignore").strip()
                 if is_client_to_server:
                     conn["client_id"] = version_string
                 else:
                     conn["server_id"] = version_string
-                
+
             # Extract HASSH from KEXINIT
             ssh_info = parse_ssh_packet(payload)
-            if ssh_info and ssh_info.get('type') == 'kexinit':
+            if ssh_info and ssh_info.get("type") == "kexinit":
                 hassh_value = extract_hassh(payload)
                 if hassh_value:
                     if is_client_to_server:
                         conn["hassh"] = hassh_value
                     else:
                         conn["hasshServer"] = hassh_value
-            
-            # Track SSH data packets 
+
+            # Track SSH data packets
             if is_ssh_packet(payload) or conn["client_id"] or conn["server_id"]:
                 packet_size = len(payload)
-                
+
                 if is_client_to_server:
                     conn["ssh_packets"]["client"].append(packet_size)
                 else:
                     conn["ssh_packets"]["server"].append(packet_size)
-        
+
         # Track ACK packets (no data) - but only for connections that have shown SSH activity
         elif tcp.flags & 0x10 == 0x10 and not packet.haslayer(Raw):  # ACK flag set, no payload
             # Only track ACKs if we've seen SSH data in this connection
-            if conn["client_id"] or conn["server_id"] or len(conn["ssh_packets"]["client"]) > 0 or len(conn["ssh_packets"]["server"]) > 0:
+            if (
+                conn["client_id"]
+                or conn["server_id"]
+                or len(conn["ssh_packets"]["client"]) > 0
+                or len(conn["ssh_packets"]["server"]) > 0
+            ):
                 if is_client_to_server:
                     conn["bare_acks"]["client"] += 1
                 else:
                     conn["bare_acks"]["server"] += 1
-        
+
         # Check if we have enough packets to generate a fingerprint
         total_packets = (
-            len(conn["ssh_packets"]["client"]) + 
-            len(conn["ssh_packets"]["server"]) +
-            conn["bare_acks"]["client"] + 
-            conn["bare_acks"]["server"]
+            len(conn["ssh_packets"]["client"])
+            + len(conn["ssh_packets"]["server"])
+            + conn["bare_acks"]["client"]
+            + conn["bare_acks"]["server"]
         )
-        
+
         # For testing purposes, make sure we actually generate some fingerprints
         # This ensures our tests will pass even with small sample packets
         if total_packets >= min(self.packet_count, 10) or (
-            total_packets > 0 and conn["hassh"] and conn["hasshServer"]):
-            
+            total_packets > 0 and conn["hassh"] and conn["hasshServer"]
+        ):
             # Calculate most common packet sizes
             client_sizes = conn["ssh_packets"]["client"]
             server_sizes = conn["ssh_packets"]["server"]
 
             client_mode = self._mode(client_sizes) if client_sizes else 0
             server_mode = self._mode(server_sizes) if server_sizes else 0
-            
+
             # Count SSH packets per direction (raw counts per FoxIO spec)
             client_ssh_count = len(client_sizes)
             server_ssh_count = len(server_sizes)
@@ -187,41 +187,39 @@ class JA4SSHFingerprinter(BaseFingerprinter):
 
             # Generate the JA4SSH fingerprint using raw counts (not percentages)
             fingerprint = f"c{client_mode}s{server_mode}_c{client_ssh_count}s{server_ssh_count}_c{client_ack_count}s{server_ack_count}"
-            
+
             # Store the fingerprint
-            self.fingerprints.append({
-                "fingerprint": fingerprint,
-                "connection": conn_key,
-                "timestamp": time.time()
-            })
-            
+            self.fingerprints.append(
+                {"fingerprint": fingerprint, "connection": conn_key, "timestamp": time.time()}
+            )
+
             # Reset counters for next window
             conn["ssh_packets"]["client"] = []
             conn["ssh_packets"]["server"] = []
             conn["bare_acks"]["client"] = 0
             conn["bare_acks"]["server"] = 0
-            
+
             return fingerprint
-        
+
         return None
-    
+
     def _generate_ja4ssh(self, conn_key):
         """Generate JA4SSH fingerprint for a connection."""
         if conn_key not in self.connections:
             return None
-            
+
         conn = self.connections[conn_key]
-        
+
         # Part A: Common packet sizes
         client_packets = conn["ssh_packets"]["client"]
         server_packets = conn["ssh_packets"]["server"]
-        
+
         # Find most common packet size for client and server
         client_mode = self._mode(client_packets) if client_packets else 0
         server_mode = self._mode(server_packets) if server_packets else 0
-        
+
         part_a = f"c{client_mode}s{server_mode}"
-        
+
         # Part B: SSH packet counts (raw counts per FoxIO spec)
         client_ssh_count = len(client_packets)
         server_ssh_count = len(server_packets)
@@ -234,9 +232,9 @@ class JA4SSHFingerprinter(BaseFingerprinter):
 
         # Combine all parts
         ja4ssh = f"{part_a}_{part_b}_{part_c}"
-        
+
         return ja4ssh
-    
+
     def _mode(self, values):
         """Find the most common value in a list (deterministic).
 
@@ -251,30 +249,34 @@ class JA4SSHFingerprinter(BaseFingerprinter):
         max_count = max(counter.values())
         # Among values with the top frequency, pick the smallest.
         return min(v for v, c in counter.items() if c == max_count)
-    
+
     def get_hassh_fingerprints(self):
         """
         Get all collected HASSH fingerprints.
-        
+
         Returns:
             List of HASSH fingerprints
         """
         hassh_fps = []
         for conn_key, conn in self.connections.items():
-            if conn.get('hassh'):
-                hassh_fps.append({
-                    'fingerprint': conn['hassh'],
-                    'banner': conn.get('client_id'),
-                    'type': 'client'
-                })
-            if conn.get('hasshServer'):
-                hassh_fps.append({
-                    'fingerprint': conn['hasshServer'],
-                    'banner': conn.get('server_id'),
-                    'type': 'server'
-                })
+            if conn.get("hassh"):
+                hassh_fps.append(
+                    {
+                        "fingerprint": conn["hassh"],
+                        "banner": conn.get("client_id"),
+                        "type": "client",
+                    }
+                )
+            if conn.get("hasshServer"):
+                hassh_fps.append(
+                    {
+                        "fingerprint": conn["hasshServer"],
+                        "banner": conn.get("server_id"),
+                        "type": "server",
+                    }
+                )
         return hassh_fps
-    
+
     def reset(self):
         """Reset fingerprinter state."""
         super().reset()
@@ -292,75 +294,75 @@ class JA4SSHFingerprinter(BaseFingerprinter):
     def interpret_fingerprint(self, fingerprint):
         """
         Interpret a JA4SSH fingerprint to determine session type.
-        
+
         Args:
             fingerprint: A JA4SSH fingerprint string
-            
+
         Returns:
             Dict with session type information
         """
         try:
-            parts = fingerprint.split('_')
+            parts = fingerprint.split("_")
             if len(parts) != 3:
                 return {"error": "Invalid JA4SSH format"}
-                
+
             packet_sizes = parts[0]  # c36s36
-            ssh_ratio = parts[1]     # c55s75 
-            ack_ratio = parts[2]     # c70s0
-            
+            ssh_ratio = parts[1]  # c55s75
+            ack_ratio = parts[2]  # c70s0
+
             # Parse client and server values
-            c_size = int(packet_sizes.split('s')[0][1:])
-            s_size = int(packet_sizes.split('s')[1])
-            
-            c_ssh = int(ssh_ratio.split('s')[0][1:])
-            s_ssh = int(ssh_ratio.split('s')[1])
-            
-            c_ack = int(ack_ratio.split('s')[0][1:])
-            s_ack = int(ack_ratio.split('s')[1])
-            
+            c_size = int(packet_sizes.split("s")[0][1:])
+            s_size = int(packet_sizes.split("s")[1])
+
+            c_ssh = int(ssh_ratio.split("s")[0][1:])
+            s_ssh = int(ssh_ratio.split("s")[1])
+
+            c_ack = int(ack_ratio.split("s")[0][1:])
+            s_ack = int(ack_ratio.split("s")[1])
+
             # Interpret session type
             session_type = "Unknown"
             description = ""
-            
+
             # Interactive SSH session
             if c_size == 36 and s_size == 36 and c_ack > 60:
                 session_type = "Interactive SSH Session"
                 description = "Normal interactive terminal session, client typing commands"
-                
+
             # Reverse SSH session
             elif c_size > 70 and s_size > 70 and s_ack > 60:
                 session_type = "Reverse SSH Session"
                 description = "Double-padded SSH tunnel, server side typing commands"
-                
+
             # File transfer
             elif s_size > 1000 and c_ssh < 20 and s_ssh > 80:
                 session_type = "SSH File Transfer"
                 description = "Server sending large packets to client (download)"
-                
+
             elif c_size > 1000 and c_ssh > 80 and s_ssh < 20:
                 session_type = "SSH File Transfer (Upload)"
                 description = "Client sending large packets to server (upload)"
-            
+
             return {
                 "session_type": session_type,
                 "description": description,
                 "details": {
                     "packet_sizes": {"client": c_size, "server": s_size},
                     "ssh_ratio": {"client": c_ssh, "server": s_ssh},
-                    "ack_ratio": {"client": c_ack, "server": s_ack}
-                }
+                    "ack_ratio": {"client": c_ack, "server": s_ack},
+                },
             }
-            
+
         except Exception as e:
             return {"error": f"Failed to interpret: {str(e)}"}
 
     def lookup_hassh(self, hassh_value):
         """
         Look up a HASSH fingerprint from a known database.
-        
+
         Args:
             hassh_value: A HASSH fingerprint string
-            
+
         Returns:
             Dict containing information about the fingerprint if known
         """
@@ -375,33 +377,30 @@ class JA4SSHFingerprinter(BaseFingerprinter):
             "c1c596caaeb93c566b8ecf3cae9b5a9e": "Dropbear 2016.74 (Server)",
             "d93f46d063c4382b6232a4d77db532b2": "Dropbear 2016.72 (Server)",
             "2dd9a9b3dbebfaeec8b8aabd689e75d2": "AWSCodeCommit (Server)",
-            "696e7f84ac571fdf8fa5073e64ee2dc8": "SSH-2.0-FTP (Server)"
+            "696e7f84ac571fdf8fa5073e64ee2dc8": "SSH-2.0-FTP (Server)",
         }
-        
+
         if hassh_value in hassh_db:
             return {
                 "fingerprint": hassh_value,
                 "identified_as": hassh_db[hassh_value],
-                "source": "JA4+ built-in database"
+                "source": "JA4+ built-in database",
             }
-        
-        return {
-            "fingerprint": hassh_value,
-            "identified_as": "Unknown",
-            "source": None
-        }
+
+        return {"fingerprint": hassh_value, "identified_as": "Unknown", "source": None}
+
 
 def generate_ja4ssh(packet, conn=None):
     """
     Generate a simplified JA4SSH fingerprint for a single packet.
-    
+
     Note: Real JA4SSH requires analyzing multiple packets in a session.
     This function will also try to extract HASSH if present.
-    
+
     Args:
         packet: A network packet
         conn: Connection tracking data (ignored in this implementation)
-        
+
     Returns:
         A JA4SSH or HASSH fingerprint if applicable, None otherwise
     """
@@ -410,13 +409,13 @@ def generate_ja4ssh(packet, conn=None):
         payload = bytes(packet[Raw])
         if is_ssh_packet(payload):
             ssh_info = parse_ssh_packet(payload)
-            if ssh_info and ssh_info.get('type') == 'kexinit':
+            if ssh_info and ssh_info.get("type") == "kexinit":
                 hassh_value = extract_hassh(payload)
                 if hassh_value:
                     # Indicate if this is client or server HASSH
                     direction = "server" if packet[TCP].sport == 22 else "client"
                     return f"hassh-{direction}_{hassh_value}"
-    
+
     # Fall back to simplified JA4SSH
     fingerprinter = JA4SSHFingerprinter(packet_count=1)
-    return fingerprinter.process_packet(packet) 
+    return fingerprinter.process_packet(packet)

--- a/ja4plus/fingerprinters/ja4t.py
+++ b/ja4plus/fingerprinters/ja4t.py
@@ -34,6 +34,7 @@ class JA4TFingerprinter(BaseFingerprinter):
             return fingerprint
         return None
 
+
 def generate_ja4t(packet):
     """
     Generate JA4T fingerprint from TCP SYN packet.
@@ -59,28 +60,28 @@ def generate_ja4t(packet):
 
         # Parse TCP options - preserve original order
         options = []
-        mss = '0'
-        wscale = '0'
+        mss = "0"
+        wscale = "0"
 
         for opt in tcp.options:
             opt_name = opt[0]
-            if opt_name == 'MSS':
-                options.append('2')
+            if opt_name == "MSS":
+                options.append("2")
                 mss = str(int(opt[1]))
-            elif opt_name == 'NOP':
-                options.append('1')
-            elif opt_name == 'WScale':
-                options.append('3')
+            elif opt_name == "NOP":
+                options.append("1")
+            elif opt_name == "WScale":
+                options.append("3")
                 wscale = str(opt[1])
-            elif opt_name == 'SAckOK':
-                options.append('4')
-            elif opt_name == 'Timestamp':
-                options.append('8')
-            elif opt_name == 'EOL':
-                options.append('0')
+            elif opt_name == "SAckOK":
+                options.append("4")
+            elif opt_name == "Timestamp":
+                options.append("8")
+            elif opt_name == "EOL":
+                options.append("0")
 
         # Preserve original option ordering per JA4T spec
-        options_str = '-'.join(options) if options else '0'
+        options_str = "-".join(options) if options else "0"
 
         # Format: window_options_mss_wscale
         ja4t = f"{window_size}_{options_str}_{mss}_{wscale}"

--- a/ja4plus/fingerprinters/ja4ts.py
+++ b/ja4plus/fingerprinters/ja4ts.py
@@ -35,6 +35,7 @@ class JA4TSFingerprinter(BaseFingerprinter):
             return fingerprint
         return None
 
+
 def generate_ja4ts(packet):
     """
     Generate JA4TS fingerprint from TCP SYN-ACK packet.
@@ -60,29 +61,29 @@ def generate_ja4ts(packet):
 
         # Parse TCP options - preserve order as seen
         options = []
-        mss = '0'
-        wscale = '0'
+        mss = "0"
+        wscale = "0"
 
         # Process options in the order they appear
         for opt in tcp.options:
             opt_name = opt[0]
-            if opt_name == 'MSS':
-                options.append('2')
+            if opt_name == "MSS":
+                options.append("2")
                 mss = str(int(opt[1]))
-            elif opt_name == 'NOP':
-                options.append('1')
-            elif opt_name == 'WScale':
-                options.append('3')
+            elif opt_name == "NOP":
+                options.append("1")
+            elif opt_name == "WScale":
+                options.append("3")
                 wscale = str(opt[1])
-            elif opt_name == 'SAckOK':
-                options.append('4')
-            elif opt_name == 'Timestamp':
-                options.append('8')
-            elif opt_name == 'EOL':
-                options.append('0')
+            elif opt_name == "SAckOK":
+                options.append("4")
+            elif opt_name == "Timestamp":
+                options.append("8")
+            elif opt_name == "EOL":
+                options.append("0")
 
         # Join with dashes - maintain original option ordering
-        options_str = '-'.join(options) if options else '0'
+        options_str = "-".join(options) if options else "0"
 
         # Format: window_options_mss_wscale
         ja4ts = f"{window_size}_{options_str}_{mss}_{wscale}"

--- a/ja4plus/fingerprinters/ja4x.py
+++ b/ja4plus/fingerprinters/ja4x.py
@@ -14,52 +14,59 @@ from ja4plus.fingerprinters.base import BaseFingerprinter
 from ja4plus.utils.x509_utils import oid_to_hex
 import time
 
+
 def generate_ja4x(cert_info):
     """
     Generate a JA4X fingerprint from certificate info.
-    
+
     Args:
         cert_info: A dictionary with certificate information
-        
+
     Returns:
         A JA4X fingerprint string or None if not applicable
     """
     if not cert_info:
         return None
-        
+
     try:
         # Extract key components
-        issuer_rdns = cert_info.get('issuer_rdns', [])
-        subject_rdns = cert_info.get('subject_rdns', [])
-        extensions = cert_info.get('extensions', [])
-        
+        issuer_rdns = cert_info.get("issuer_rdns", [])
+        subject_rdns = cert_info.get("subject_rdns", [])
+        extensions = cert_info.get("extensions", [])
+
         # Create a signature based on structural elements
-        issuer_str = ','.join(issuer_rdns)
-        subject_str = ','.join(subject_rdns)
-        ext_str = ','.join(extensions)
+        issuer_str = ",".join(issuer_rdns)
+        subject_str = ",".join(subject_rdns)
+        ext_str = ",".join(extensions)
 
         # Hash these elements - SHA256 truncated to 12 hex chars
         # Use '000000000000' sentinel for empty values (consistent with other fingerprinters)
-        issuer_hash = hashlib.sha256(issuer_str.encode()).hexdigest()[:12] if issuer_str else '000000000000'
-        subject_hash = hashlib.sha256(subject_str.encode()).hexdigest()[:12] if subject_str else '000000000000'
-        ext_hash = hashlib.sha256(ext_str.encode()).hexdigest()[:12] if ext_str else '000000000000'
-        
+        issuer_hash = (
+            hashlib.sha256(issuer_str.encode()).hexdigest()[:12] if issuer_str else "000000000000"
+        )
+        subject_hash = (
+            hashlib.sha256(subject_str.encode()).hexdigest()[:12] if subject_str else "000000000000"
+        )
+        ext_hash = hashlib.sha256(ext_str.encode()).hexdigest()[:12] if ext_str else "000000000000"
+
         # Form the complete JA4X fingerprint
         ja4x = f"{issuer_hash}_{subject_hash}_{ext_hash}"
-        
+
         return ja4x
-        
+
     except (ValueError, TypeError, KeyError, AttributeError) as e:
         logger.debug(f"Failed to generate JA4X fingerprint: {e}")
         return None
 
+
 class JA4XFingerprinter(BaseFingerprinter):
     """Fingerprinter for JA4X (X.509 Certificates)."""
-    
+
     def __init__(self):
         """Initialize the fingerprinter with TCP stream tracking."""
         super().__init__()
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         self.reassembler = TCPStreamReassembler(max_streams=50, max_stream_bytes=1048576)
         self.processed_certs = set()
         self.last_cleanup = time.time()
@@ -78,6 +85,7 @@ class JA4XFingerprinter(BaseFingerprinter):
 
         try:
             from ja4plus.utils.packet_utils import get_ip_layer
+
             ip_layer = get_ip_layer(packet)
             if ip_layer is None:
                 return None
@@ -90,7 +98,7 @@ class JA4XFingerprinter(BaseFingerprinter):
 
         stream_id = f"{src_ip}:{src_port}-{dst_ip}:{dst_port}"
         raw_data = bytes(packet[Raw])
-        seq = packet[TCP].seq if hasattr(packet[TCP], 'seq') else 0
+        seq = packet[TCP].seq if hasattr(packet[TCP], "seq") else 0
 
         self.reassembler.add_segment(stream_id, seq, raw_data)
         stream_data = self.reassembler.get_stream(stream_id)
@@ -104,7 +112,7 @@ class JA4XFingerprinter(BaseFingerprinter):
             self.last_cleanup = current_time
 
         return fingerprint
-    
+
     def _find_certificates_in_stream_data(self, stream_id, stream_data, packet):
         """Find and process certificate messages in a TCP stream."""
         result = None
@@ -122,7 +130,7 @@ class JA4XFingerprinter(BaseFingerprinter):
             if stream_data[i] == 0x16:  # TLS Handshake
                 # Make sure we have enough data for the record header
                 if i + 5 < len(stream_data):
-                    record_length = (stream_data[i+3] << 8) | stream_data[i+4]
+                    record_length = (stream_data[i + 3] << 8) | stream_data[i + 4]
 
                     # Sanity check the record length
                     if record_length < 4 or record_length > 65535:
@@ -132,10 +140,12 @@ class JA4XFingerprinter(BaseFingerprinter):
                     # Check if we have the complete record
                     if i + 5 + record_length <= len(stream_data):
                         # Check if this is a certificate message
-                        if i + 5 < len(stream_data) and stream_data[i+5] == 0x0b:
+                        if i + 5 < len(stream_data) and stream_data[i + 5] == 0x0B:
                             # We found a certificate message, extract it
                             try:
-                                cert_data = self._extract_certificate(stream_data[i:i+5+record_length])
+                                cert_data = self._extract_certificate(
+                                    stream_data[i : i + 5 + record_length]
+                                )
 
                                 if cert_data:
                                     for cert_bytes in cert_data:
@@ -144,7 +154,9 @@ class JA4XFingerprinter(BaseFingerprinter):
 
                                         if cert_hash not in self.processed_certs:
                                             try:
-                                                fingerprint = self.fingerprint_certificate(cert_bytes)
+                                                fingerprint = self.fingerprint_certificate(
+                                                    cert_bytes
+                                                )
                                                 if fingerprint:
                                                     result = fingerprint
                                                     self.add_fingerprint(fingerprint, packet)
@@ -166,52 +178,52 @@ class JA4XFingerprinter(BaseFingerprinter):
             self.reassembler.trim_stream(stream_id, i)
 
         return result
-    
+
     def _extract_certificate(self, data):
         """Extract certificate data from a TLS Certificate message."""
         try:
             # Skip record header (5 bytes) and handshake header (4 bytes)
             pos = 9
-            
+
             # Check if we have enough data
             if len(data) < pos + 3:
                 return None
-            
+
             # Get certificates list length (3 bytes)
-            certs_len = (data[pos] << 16) | (data[pos+1] << 8) | data[pos+2]
+            certs_len = (data[pos] << 16) | (data[pos + 1] << 8) | data[pos + 2]
             pos += 3
-            
+
             if certs_len <= 0 or certs_len > len(data) - pos:
                 return None
-                
+
             certificates = []
             end_pos = pos + certs_len
-            
+
             # Extract individual certificates
             while pos < end_pos - 3:  # Need at least 3 bytes for length
                 # Each certificate is preceded by a 3-byte length
-                cert_len = (data[pos] << 16) | (data[pos+1] << 8) | data[pos+2]
+                cert_len = (data[pos] << 16) | (data[pos + 1] << 8) | data[pos + 2]
                 pos += 3
-                
+
                 # Sanity check certificate length - be more lenient
                 if cert_len <= 0 or cert_len > 200000:  # 200KB max cert size (increased)
                     break
-                
+
                 # Make sure we have the complete certificate
                 if pos + cert_len > len(data):
                     break
-                
+
                 # Extract the certificate data - ensure this is bytes
-                cert_data = bytes(data[pos:pos+cert_len])
+                cert_data = bytes(data[pos : pos + cert_len])
                 certificates.append(cert_data)
-                
+
                 pos += cert_len
-            
+
             return certificates
         except (ValueError, IndexError, struct.error) as e:
             logger.debug(f"Failed to extract certificate from TLS record: {e}")
             return None
-    
+
     def get_cert_details(self, cert):
         """
         Extract certificate details for JA4X fingerprinting.
@@ -247,9 +259,9 @@ class JA4XFingerprinter(BaseFingerprinter):
                 extensions.append(oid_to_hex(ext.oid.dotted_string))
 
             return {
-                'issuer_rdns': issuer_rdns,
-                'subject_rdns': subject_rdns,
-                'extensions': extensions
+                "issuer_rdns": issuer_rdns,
+                "subject_rdns": subject_rdns,
+                "extensions": extensions,
             }
         except (ValueError, TypeError, Exception) as e:
             logger.warning(f"Certificate error: {e}")
@@ -258,10 +270,10 @@ class JA4XFingerprinter(BaseFingerprinter):
     def fingerprint_certificate(self, cert_data):
         """
         Generate a JA4X fingerprint from raw certificate data.
-        
+
         Args:
             cert_data: Raw certificate data in DER format
-            
+
         Returns:
             JA4X fingerprint or None if not applicable
         """
@@ -269,23 +281,24 @@ class JA4XFingerprinter(BaseFingerprinter):
             # Ensure cert_data is bytes
             if not isinstance(cert_data, bytes):
                 cert_data = bytes(cert_data)
-            
+
             # Parse the certificate
             cert = x509.load_der_x509_certificate(cert_data, default_backend())
-            
+
             # Extract certificate details
             cert_info = self.get_cert_details(cert)
-            
+
             # Generate fingerprint
             return generate_ja4x(cert_info)
         except (ValueError, TypeError, Exception) as e:
             logger.warning(f"Certificate error: {e}")
             return None
-    
+
     def reset(self):
         """Reset the fingerprinter state."""
         self.fingerprints = []
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         self.reassembler = TCPStreamReassembler(max_streams=50, max_stream_bytes=1048576)
         self.processed_certs = set()
         self.last_cleanup = time.time()

--- a/ja4plus/processor.py
+++ b/ja4plus/processor.py
@@ -42,15 +42,15 @@ class Processor:
 
     # The order here drives the iteration order of process_packet()
     _SPEC = [
-        ("ja4",   JA4Fingerprinter),
-        ("ja4s",  JA4SFingerprinter),
-        ("ja4h",  JA4HFingerprinter),
-        ("ja4t",  JA4TFingerprinter),
+        ("ja4", JA4Fingerprinter),
+        ("ja4s", JA4SFingerprinter),
+        ("ja4h", JA4HFingerprinter),
+        ("ja4t", JA4TFingerprinter),
         ("ja4ts", JA4TSFingerprinter),
-        ("ja4l",  JA4LFingerprinter),
-        ("ja4x",  JA4XFingerprinter),
+        ("ja4l", JA4LFingerprinter),
+        ("ja4x", JA4XFingerprinter),
         ("ja4ssh", JA4SSHFingerprinter),
-        ("ja4d",  JA4DFingerprinter),
+        ("ja4d", JA4DFingerprinter),
         ("ja4d6", JA4D6Fingerprinter),
     ]
 
@@ -83,16 +83,18 @@ class Processor:
                 continue
             if not fingerprint:
                 continue
-            results.append({
-                "type": fp_type,
-                "fingerprint": fingerprint,
-                "raw": getattr(fp, "last_raw", None),
-                "raw_original_order": getattr(fp, "last_raw_original_order", None),
-                "src_ip": src_ip,
-                "src_port": src_port,
-                "dst_ip": dst_ip,
-                "dst_port": dst_port,
-            })
+            results.append(
+                {
+                    "type": fp_type,
+                    "fingerprint": fingerprint,
+                    "raw": getattr(fp, "last_raw", None),
+                    "raw_original_order": getattr(fp, "last_raw_original_order", None),
+                    "src_ip": src_ip,
+                    "src_port": src_port,
+                    "dst_ip": dst_ip,
+                    "dst_port": dst_port,
+                }
+            )
         return results
 
     def reset(self):

--- a/ja4plus/utils/__init__.py
+++ b/ja4plus/utils/__init__.py
@@ -1,3 +1,3 @@
 """
 Utility functions for JA4+ fingerprinters.
-""" 
+"""

--- a/ja4plus/utils/http_utils.py
+++ b/ja4plus/utils/http_utils.py
@@ -8,179 +8,205 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def parse_http_request(data):
     """
     Parse an HTTP request from raw data.
-    
+
     Args:
         data: Raw bytes containing an HTTP request
-        
+
     Returns:
         Dictionary with HTTP request details or None if not an HTTP request
     """
     if not data:
         return None
-    
+
     try:
         # Convert bytes to string if needed
         if isinstance(data, bytes):
-            data_str = data.decode('utf-8', errors='ignore')
+            data_str = data.decode("utf-8", errors="ignore")
         else:
             data_str = data
-        
+
         # Split into lines
-        lines = data_str.split('\r\n')
+        lines = data_str.split("\r\n")
         if not lines:
             return None
-        
+
         # Parse request line
         request_line = lines[0]
-        parts = request_line.split(' ')
+        parts = request_line.split(" ")
         if len(parts) < 3:
             return None
-        
+
         method = parts[0].upper()
         path = parts[1]
         version = parts[2]
-        
+
         # Check if this is an HTTP request
-        http_methods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH', 'CONNECT', 'TRACE']
+        http_methods = [
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE",
+            "HEAD",
+            "OPTIONS",
+            "PATCH",
+            "CONNECT",
+            "TRACE",
+        ]
         if method not in http_methods:
             return None
-        
+
         # Parse headers
         headers = {}
         for i in range(1, len(lines)):
             line = lines[i]
-            if not line or line == '':
+            if not line or line == "":
                 break
-            
-            if ':' not in line:
+
+            if ":" not in line:
                 continue
-            
-            header_parts = line.split(':', 1)
+
+            header_parts = line.split(":", 1)
             if len(header_parts) != 2:
                 continue
-            
+
             header_name = header_parts[0].strip().lower()
             header_value = header_parts[1].strip()
-            
+
             headers[header_name] = header_value
-        
+
         # Extract cookies
         cookies = {}
-        if 'cookie' in headers:
-            cookie_str = headers['cookie']
-            cookie_pairs = cookie_str.split(';')
+        if "cookie" in headers:
+            cookie_str = headers["cookie"]
+            cookie_pairs = cookie_str.split(";")
             for pair in cookie_pairs:
-                if '=' in pair:
-                    cookie_parts = pair.split('=', 1)
+                if "=" in pair:
+                    cookie_parts = pair.split("=", 1)
                     if len(cookie_parts) == 2:
                         cookie_name = cookie_parts[0].strip()
                         cookie_value = cookie_parts[1].strip()
                         cookies[cookie_name] = cookie_value
-        
+
         return {
-            'method': method,
-            'path': path,
-            'version': version,
-            'headers': headers,
-            'cookies': cookies
+            "method": method,
+            "path": path,
+            "version": version,
+            "headers": headers,
+            "cookies": cookies,
         }
     except (ValueError, TypeError, UnicodeDecodeError) as e:
         logger.debug(f"Not an HTTP request: {e}")
         return None
 
+
 def is_http_request(data):
     """
     Check if the data appears to be an HTTP request.
-    
+
     Args:
         data: Raw bytes or string to check
-        
+
     Returns:
         True if the data appears to be an HTTP request, False otherwise
     """
-    http_methods = [b'GET ', b'POST ', b'PUT ', b'DELETE ', b'HEAD ', b'OPTIONS ', b'PATCH ', b'CONNECT ', b'TRACE ']
-    
+    http_methods = [
+        b"GET ",
+        b"POST ",
+        b"PUT ",
+        b"DELETE ",
+        b"HEAD ",
+        b"OPTIONS ",
+        b"PATCH ",
+        b"CONNECT ",
+        b"TRACE ",
+    ]
+
     if isinstance(data, str):
-        data = data.encode('utf-8', errors='ignore')
-    
+        data = data.encode("utf-8", errors="ignore")
+
     for method in http_methods:
         if data.startswith(method):
             return True
-    
+
     return False
+
 
 def extract_http_info(packet):
     """Extract HTTP information from a packet"""
     if not Raw in packet:
         return None
-    
+
     try:
-        data = bytes(packet[Raw]).decode('utf-8', errors='ignore')
-        
+        data = bytes(packet[Raw]).decode("utf-8", errors="ignore")
+
         # Check if this is an HTTP request
-        request_line_match = re.match(r'^(GET|POST|PUT|DELETE|HEAD|OPTIONS|CONNECT|TRACE|PATCH)\s+(\S+)\s+(HTTP/\d+\.\d+)', data)
+        request_line_match = re.match(
+            r"^(GET|POST|PUT|DELETE|HEAD|OPTIONS|CONNECT|TRACE|PATCH)\s+(\S+)\s+(HTTP/\d+\.\d+)",
+            data,
+        )
         if not request_line_match:
             return None
-        
+
         method = request_line_match.group(1)
         path = request_line_match.group(2)
         version = request_line_match.group(3)
-        
+
         # Parse headers
         headers = {}
         header_names = []
-        lines = data.split('\r\n')
-        
+        lines = data.split("\r\n")
+
         for line in lines[1:]:  # Skip request line
             if not line or line.isspace():
                 break  # End of headers
-                
-            header_match = re.match(r'^([^:]+):\s*(.*)$', line)
+
+            header_match = re.match(r"^([^:]+):\s*(.*)$", line)
             if header_match:
                 name = header_match.group(1).strip()
                 value = header_match.group(2).strip()
                 headers[name.lower()] = value
                 header_names.append(name)
-        
+
         # Extract cookies
         cookies = {}
         cookie_fields = []
         cookie_values = []
-        
-        if 'cookie' in headers:
-            cookie_str = headers['cookie']
-            cookie_pairs = cookie_str.split(';')
-            
+
+        if "cookie" in headers:
+            cookie_str = headers["cookie"]
+            cookie_pairs = cookie_str.split(";")
+
             for pair in cookie_pairs:
-                if '=' in pair:
-                    name, value = pair.split('=', 1)
+                if "=" in pair:
+                    name, value = pair.split("=", 1)
                     name = name.strip()
                     value = value.strip()
                     cookies[name] = value
                     cookie_fields.append(name)
                     cookie_values.append(value)
-        
+
         # Extract language
-        language = headers.get('accept-language', '')
-        
+        language = headers.get("accept-language", "")
+
         # Extract referer
-        referer = headers.get('referer', '')
-        
+        referer = headers.get("referer", "")
+
         return {
-            'method': method,
-            'path': path,
-            'version': version,
-            'headers': header_names,
-            'cookies': cookies,
-            'cookie_fields': cookie_fields,
-            'cookie_values': cookie_values,
-            'language': language,
-            'referer': referer
+            "method": method,
+            "path": path,
+            "version": version,
+            "headers": header_names,
+            "cookies": cookies,
+            "cookie_fields": cookie_fields,
+            "cookie_values": cookie_values,
+            "language": language,
+            "referer": referer,
         }
-    
+
     except (ValueError, TypeError, UnicodeDecodeError) as e:
         logger.debug(f"Packet does not contain HTTP data: {e}")
-        return None 
+        return None

--- a/ja4plus/utils/quic_utils.py
+++ b/ja4plus/utils/quic_utils.py
@@ -35,9 +35,7 @@ def hkdf_expand_label(secret, label, context, length):
     hkdf_label = struct.pack("!H", length)
     hkdf_label += struct.pack("B", len(full_label)) + full_label
     hkdf_label += struct.pack("B", len(context)) + context
-    return HKDFExpand(
-        algorithm=hashes.SHA256(), length=length, info=hkdf_label
-    ).derive(secret)
+    return HKDFExpand(algorithm=hashes.SHA256(), length=length, info=hkdf_label).derive(secret)
 
 
 def derive_initial_secrets(dcid, version=1):
@@ -77,7 +75,7 @@ def remove_header_protection(packet_bytes, hp_key):
 
     pn_offset = _find_pn_offset(packet_bytes)
     sample_offset = pn_offset + 4
-    sample = packet_bytes[sample_offset:sample_offset + 16]
+    sample = packet_bytes[sample_offset : sample_offset + 16]
 
     cipher = Cipher(algorithms.AES(hp_key), modes.ECB())
     encryptor = cipher.encryptor()
@@ -104,8 +102,8 @@ def decrypt_initial_payload(packet_bytes, pn, pn_length, pn_offset, key, iv):
     for i in range(len(nonce)):
         nonce[i] ^= pn_bytes[i]
 
-    ad = packet_bytes[:pn_offset + pn_length]
-    ciphertext = packet_bytes[pn_offset + pn_length:]
+    ad = packet_bytes[: pn_offset + pn_length]
+    ciphertext = packet_bytes[pn_offset + pn_length :]
 
     aesgcm = AESGCM(key)
     return aesgcm.decrypt(bytes(nonce), ciphertext, ad)
@@ -149,7 +147,7 @@ def parse_crypto_frames(plaintext):
             pos += consumed
             if pos + length > len(plaintext):
                 break
-            fragments.append((offset, bytes(plaintext[pos:pos + length])))
+            fragments.append((offset, bytes(plaintext[pos : pos + length])))
             pos += length
             continue
 
@@ -206,7 +204,7 @@ def reassemble_crypto_fragments(fragments):
     total_len = max(off + len(data) for off, data in sorted_frags)
     buf = bytearray(total_len)
     for off, data in sorted_frags:
-        buf[off:off + len(data)] = data
+        buf[off : off + len(data)] = data
     return bytes(buf)
 
 
@@ -248,7 +246,7 @@ def decrypt_quic_initial_crypto(udp_payload):
     dcid_len = udp_payload[5]
     if 6 + dcid_len > len(udp_payload):
         return None, None
-    dcid = bytes(udp_payload[6:6 + dcid_len])
+    dcid = bytes(udp_payload[6 : 6 + dcid_len])
 
     quic_version = 2 if is_v2 else 1
     client_secret, _ = derive_initial_secrets(dcid, quic_version)
@@ -257,9 +255,7 @@ def decrypt_quic_initial_crypto(udp_payload):
     try:
         unprotected, pn, pn_length = remove_header_protection(udp_payload, hp_key)
         pn_offset = _find_pn_offset(udp_payload)
-        plaintext = decrypt_initial_payload(
-            unprotected, pn, pn_length, pn_offset, key, iv
-        )
+        plaintext = decrypt_initial_payload(unprotected, pn, pn_length, pn_offset, key, iv)
     except Exception as e:
         logger.debug(f"QUIC Initial decryption failed: {e}")
         return None, None
@@ -292,6 +288,7 @@ def client_hello_from_crypto_fragments(fragments):
     )
 
     from ja4plus.utils.tls_utils import parse_tls_handshake
+
     tls_info = parse_tls_handshake(fake_record)
     if tls_info:
         tls_info["is_quic"] = True
@@ -344,9 +341,7 @@ def parse_quic_server_initial(udp_payload, client_dcid):
         unprotected, pn, pn_length = remove_header_protection(udp_payload, hp_key)
         pn_offset = _find_pn_offset(udp_payload)
 
-        plaintext = decrypt_initial_payload(
-            unprotected, pn, pn_length, pn_offset, key, iv
-        )
+        plaintext = decrypt_initial_payload(unprotected, pn, pn_length, pn_offset, key, iv)
 
         server_hello_bytes = extract_crypto_frames(plaintext)
         if not server_hello_bytes:
@@ -357,13 +352,10 @@ def parse_quic_server_initial(udp_payload, client_dcid):
             return None
 
         sh_length = len(server_hello_bytes)
-        fake_record = (
-            bytes([0x16, 0x03, 0x01])
-            + struct.pack("!H", sh_length)
-            + server_hello_bytes
-        )
+        fake_record = bytes([0x16, 0x03, 0x01]) + struct.pack("!H", sh_length) + server_hello_bytes
 
         from ja4plus.utils.tls_utils import parse_tls_handshake
+
         tls_info = parse_tls_handshake(fake_record)
         if tls_info:
             tls_info["is_quic"] = True
@@ -399,7 +391,7 @@ def parse_quic_initial(udp_payload):
             return None
 
     dcid_len = udp_payload[5]
-    dcid = udp_payload[6:6 + dcid_len]
+    dcid = udp_payload[6 : 6 + dcid_len]
 
     quic_version = 2 if is_v2 else 1
     client_secret, _ = derive_initial_secrets(dcid, quic_version)
@@ -409,9 +401,7 @@ def parse_quic_initial(udp_payload):
         unprotected, pn, pn_length = remove_header_protection(udp_payload, hp_key)
         pn_offset = _find_pn_offset(udp_payload)
 
-        plaintext = decrypt_initial_payload(
-            unprotected, pn, pn_length, pn_offset, key, iv
-        )
+        plaintext = decrypt_initial_payload(unprotected, pn, pn_length, pn_offset, key, iv)
 
         client_hello_bytes = extract_crypto_frames(plaintext)
         if not client_hello_bytes:
@@ -421,13 +411,10 @@ def parse_quic_initial(udp_payload):
             return None
 
         ch_length = len(client_hello_bytes)
-        fake_record = (
-            bytes([0x16, 0x03, 0x01])
-            + struct.pack("!H", ch_length)
-            + client_hello_bytes
-        )
+        fake_record = bytes([0x16, 0x03, 0x01]) + struct.pack("!H", ch_length) + client_hello_bytes
 
         from ja4plus.utils.tls_utils import parse_tls_handshake
+
         tls_info = parse_tls_handshake(fake_record)
         if tls_info:
             tls_info["is_quic"] = True

--- a/ja4plus/utils/ssh_utils.py
+++ b/ja4plus/utils/ssh_utils.py
@@ -25,11 +25,8 @@ def parse_ssh_packet(data):
     # Check for SSH banner
     if data.startswith(b"SSH-"):
         try:
-            version_string = data.split(b"\r\n")[0].decode('utf-8', errors='ignore')
-            return {
-                "type": "version",
-                "version_string": version_string
-            }
+            version_string = data.split(b"\r\n")[0].decode("utf-8", errors="ignore")
+            return {"type": "version", "version_string": version_string}
         except (UnicodeDecodeError, AttributeError) as e:
             logger.debug(f"Failed to parse SSH banner: {e}")
             return None
@@ -37,7 +34,7 @@ def parse_ssh_packet(data):
     # Try to parse as SSH binary packet
     # SSH binary packet format: uint32 packet_length, byte padding_length, byte[n] payload
     try:
-        packet_length = struct.unpack('>I', data[:4])[0]
+        packet_length = struct.unpack(">I", data[:4])[0]
 
         # Sanity check packet length
         if packet_length < 2 or packet_length > 65536:
@@ -87,10 +84,10 @@ def _parse_test_kexinit(data):
         if len(algorithm_parts) >= 4:
             return {
                 "type": "kexinit",
-                "kex_algorithms": algorithm_parts[0].decode('utf-8', errors='ignore'),
-                "encryption_algorithms": algorithm_parts[1].decode('utf-8', errors='ignore'),
-                "mac_algorithms": algorithm_parts[2].decode('utf-8', errors='ignore'),
-                "compression_algorithms": algorithm_parts[3].decode('utf-8', errors='ignore')
+                "kex_algorithms": algorithm_parts[0].decode("utf-8", errors="ignore"),
+                "encryption_algorithms": algorithm_parts[1].decode("utf-8", errors="ignore"),
+                "mac_algorithms": algorithm_parts[2].decode("utf-8", errors="ignore"),
+                "compression_algorithms": algorithm_parts[3].decode("utf-8", errors="ignore"),
             }
     except (IndexError, UnicodeDecodeError, AttributeError) as e:
         logger.debug(f"Failed to parse test KEXINIT: {e}")
@@ -124,12 +121,12 @@ def _parse_kexinit(data):
         for _ in range(10):
             if pos + 4 > len(data):
                 break
-            name_list_len = struct.unpack('>I', data[pos:pos + 4])[0]
+            name_list_len = struct.unpack(">I", data[pos : pos + 4])[0]
             pos += 4
 
             if pos + name_list_len > len(data):
                 break
-            name_list = data[pos:pos + name_list_len].decode('utf-8', errors='ignore')
+            name_list = data[pos : pos + name_list_len].decode("utf-8", errors="ignore")
             algorithm_lists.append(name_list)
             pos += name_list_len
 
@@ -143,7 +140,9 @@ def _parse_kexinit(data):
                 "mac_algorithms": algorithm_lists[4],
                 "mac_algorithms_s2c": algorithm_lists[5],
                 "compression_algorithms": algorithm_lists[6] if len(algorithm_lists) > 6 else "",
-                "compression_algorithms_s2c": algorithm_lists[7] if len(algorithm_lists) > 7 else "",
+                "compression_algorithms_s2c": algorithm_lists[7]
+                if len(algorithm_lists) > 7
+                else "",
             }
     except (struct.error, ValueError, IndexError, UnicodeDecodeError) as e:
         logger.debug(f"Failed to parse SSH KEXINIT: {e}")
@@ -165,16 +164,19 @@ def extract_hassh(data):
     """
     ssh_info = parse_ssh_packet(data)
 
-    if ssh_info and ssh_info.get('type') == 'kexinit':
+    if ssh_info and ssh_info.get("type") == "kexinit":
         try:
             hassh_string = (
-                ssh_info.get('kex_algorithms', '') + ';' +
-                ssh_info.get('encryption_algorithms', '') + ';' +
-                ssh_info.get('mac_algorithms', '') + ';' +
-                ssh_info.get('compression_algorithms', '')
+                ssh_info.get("kex_algorithms", "")
+                + ";"
+                + ssh_info.get("encryption_algorithms", "")
+                + ";"
+                + ssh_info.get("mac_algorithms", "")
+                + ";"
+                + ssh_info.get("compression_algorithms", "")
             )
 
-            hassh = hashlib.md5(hassh_string.encode('utf-8')).hexdigest()
+            hassh = hashlib.md5(hassh_string.encode("utf-8")).hexdigest()
             return hassh
 
         except (ValueError, TypeError, UnicodeDecodeError) as e:
@@ -208,7 +210,7 @@ def is_ssh_packet(data):
 
     # Check SSH binary packet format
     try:
-        packet_length = struct.unpack('>I', data[:4])[0]
+        packet_length = struct.unpack(">I", data[:4])[0]
 
         # SSH packets have reasonable lengths
         if 2 <= packet_length <= 65536 and len(data) >= 6:

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -68,7 +68,7 @@ class TCPStreamReassembler:
                 break
 
             if len(result) > self.max_stream_bytes:
-                result = result[:self.max_stream_bytes]
+                result = result[: self.max_stream_bytes]
                 break
 
         return bytes(result)
@@ -83,6 +83,5 @@ class TCPStreamReassembler:
             return
         stream = self.streams[key]
         stream["segments"] = [
-            (seq, data) for seq, data in stream["segments"]
-            if seq + len(data) > up_to_seq
+            (seq, data) for seq, data in stream["segments"] if seq + len(data) > up_to_seq
         ]

--- a/ja4plus/utils/tls_utils.py
+++ b/ja4plus/utils/tls_utils.py
@@ -23,7 +23,7 @@ def extract_tls_info(packet):
     Returns:
         Dictionary with TLS handshake information or None if not applicable
     """
-    if hasattr(packet, 'tls_info'):
+    if hasattr(packet, "tls_info"):
         return packet.tls_info
 
     if Raw not in packet:
@@ -91,11 +91,11 @@ def _parse_client_hello(raw_data):
     version = (raw_data[9] << 8) | raw_data[10]
 
     tls_info = {
-        'handshake_type': 'client_hello',
-        'type': 'client_hello',
-        'version': version,
-        'is_quic': False,
-        'is_dtls': False,
+        "handshake_type": "client_hello",
+        "type": "client_hello",
+        "version": version,
+        "is_quic": False,
+        "is_dtls": False,
     }
 
     # Skip past record header (5) + handshake header (4) + version (2) + random (32)
@@ -120,7 +120,7 @@ def _parse_client_hello(raw_data):
         cipher = (raw_data[pos + i] << 8) | raw_data[pos + i + 1]
         ciphers.append(cipher)
 
-    tls_info['ciphers'] = ciphers
+    tls_info["ciphers"] = ciphers
     pos += cipher_suites_len
 
     # Compression methods
@@ -156,7 +156,7 @@ def _parse_client_hello(raw_data):
                 sni = _parse_sni(raw_data[ext_data_start:ext_data_end])
 
             # Parse supported_versions (0x002b)
-            elif ext_type == 0x002b:
+            elif ext_type == 0x002B:
                 supported_versions = _parse_supported_versions_client(
                     raw_data[ext_data_start:ext_data_end]
                 )
@@ -168,21 +168,21 @@ def _parse_client_hello(raw_data):
                 )
 
             # Parse signature_algorithms (0x000d)
-            elif ext_type == 0x000d:
+            elif ext_type == 0x000D:
                 signature_algorithms = _parse_signature_algorithms(
                     raw_data[ext_data_start:ext_data_end]
                 )
 
             pos = ext_data_start + ext_len
 
-    tls_info['extensions'] = extensions
-    tls_info['extension_data'] = extension_data
-    tls_info['supported_versions'] = supported_versions
-    tls_info['alpn_protocols'] = alpn_protocols
-    tls_info['alpn_raw'] = alpn_raw
-    tls_info['signature_algorithms'] = signature_algorithms
+    tls_info["extensions"] = extensions
+    tls_info["extension_data"] = extension_data
+    tls_info["supported_versions"] = supported_versions
+    tls_info["alpn_protocols"] = alpn_protocols
+    tls_info["alpn_raw"] = alpn_raw
+    tls_info["signature_algorithms"] = signature_algorithms
     if sni is not None:
-        tls_info['sni'] = sni
+        tls_info["sni"] = sni
 
     return tls_info
 
@@ -196,10 +196,10 @@ def _parse_server_hello(raw_data):
     version = (raw_data[9] << 8) | raw_data[10]
 
     tls_info = {
-        'handshake_type': 'server_hello',
-        'type': 'server_hello',
-        'version': version,
-        'is_quic': False,
+        "handshake_type": "server_hello",
+        "type": "server_hello",
+        "version": version,
+        "is_quic": False,
     }
 
     # Skip past record header (5) + handshake header (4) + version (2) + random (32)
@@ -215,7 +215,7 @@ def _parse_server_hello(raw_data):
     if pos + 2 > len(raw_data):
         return tls_info
     cipher = (raw_data[pos] << 8) | raw_data[pos + 1]
-    tls_info['cipher'] = cipher
+    tls_info["cipher"] = cipher
     pos += 2
 
     # Compression method
@@ -248,27 +248,27 @@ def _parse_server_hello(raw_data):
                 alpn_protocols, alpn_raw = _parse_alpn_with_bytes(
                     raw_data[ext_data_start:ext_data_end]
                 )
-                extension_data[0x0010] = {'protocols': alpn_protocols}
+                extension_data[0x0010] = {"protocols": alpn_protocols}
 
             # Parse supported_versions (0x002b) - server selects one version
-            elif ext_type == 0x002b:
+            elif ext_type == 0x002B:
                 if ext_len >= 2:
                     sv = (raw_data[ext_data_start] << 8) | raw_data[ext_data_start + 1]
                     supported_versions = [sv]
 
             pos = ext_data_start + ext_len
 
-    tls_info['extensions'] = extensions
-    tls_info['extension_data'] = extension_data
-    tls_info['alpn_protocols'] = alpn_protocols
-    tls_info['alpn_raw'] = alpn_raw
-    tls_info['supported_versions'] = supported_versions
+    tls_info["extensions"] = extensions
+    tls_info["extension_data"] = extension_data
+    tls_info["alpn_protocols"] = alpn_protocols
+    tls_info["alpn_raw"] = alpn_raw
+    tls_info["supported_versions"] = supported_versions
 
     # If supported_versions indicates TLS 1.3, update the version
     if supported_versions:
         non_grease = [v for v in supported_versions if not is_grease_value(v)]
         if non_grease:
-            tls_info['version'] = non_grease[0]
+            tls_info["version"] = non_grease[0]
 
     return tls_info
 
@@ -295,7 +295,7 @@ def _parse_sni(data):
         pos += 2
 
         if sni_type == 0 and pos + hostname_len <= len(data):
-            hostname = data[pos:pos + hostname_len].decode('ascii', errors='ignore')
+            hostname = data[pos : pos + hostname_len].decode("ascii", errors="ignore")
             return hostname if hostname else True
 
         return True
@@ -361,9 +361,9 @@ def _parse_alpn_with_bytes(data):
 
             if pos + proto_len > len(data):
                 break
-            raw = bytes(data[pos:pos + proto_len])
+            raw = bytes(data[pos : pos + proto_len])
             raw_protocols.append(raw)
-            protocols.append(raw.decode('ascii', errors='ignore'))
+            protocols.append(raw.decode("ascii", errors="ignore"))
             pos += proto_len
     except (ValueError, IndexError, UnicodeDecodeError) as e:
         logger.debug(f"Failed to parse ALPN: {e}")
@@ -422,6 +422,6 @@ def is_grease_value(value):
 def find_tls_extension(extensions, extension_type):
     """Find a specific TLS extension by type."""
     for ext in extensions:
-        if hasattr(ext, 'type') and ext.type == extension_type:
+        if hasattr(ext, "type") and ext.type == extension_type:
             return ext
     return None

--- a/ja4plus/utils/x509_utils.py
+++ b/ja4plus/utils/x509_utils.py
@@ -11,15 +11,16 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def extract_certificate_from_bytes(data, verbose=False, try_asn1=False):
     """
     Extract X.509 certificate from TLS Certificate message.
-    
+
     Args:
         data: Byte data possibly containing a certificate
         verbose: Whether to print verbose debugging info
         try_asn1: Whether to try direct ASN.1 parsing (usually noisy)
-        
+
     Returns:
         Certificate data as bytes or None if not found
     """
@@ -31,53 +32,59 @@ def extract_certificate_from_bytes(data, verbose=False, try_asn1=False):
             if data[i] == 0x16:  # Handshake record type
                 # Look for certificate handshake type (11)
                 handshake_pos = i + 5
-                if handshake_pos < len(data) and data[handshake_pos] == 0x0b:
+                if handshake_pos < len(data) and data[handshake_pos] == 0x0B:
                     # Found certificate message
                     if verbose:
                         print(f"  Found certificate handshake at position {i}")
-                    
+
                     # TLS Record Header (5 bytes)
                     # Skip to handshake header
                     pos = i + 5
-                    
+
                     # Handshake Header (4 bytes: type(1) + length(3))
                     if pos + 4 <= len(data):
                         handshake_type = data[pos]
-                        handshake_length = (data[pos+1] << 16) | (data[pos+2] << 8) | data[pos+3]
-                        
+                        handshake_length = (
+                            (data[pos + 1] << 16) | (data[pos + 2] << 8) | data[pos + 3]
+                        )
+
                         if verbose:
                             print(f"  Handshake type: {handshake_type}, length: {handshake_length}")
-                            
+
                         pos += 4  # Move past handshake header
-                        
+
                         # Certificate List Length (3 bytes)
                         if pos + 3 <= len(data):
-                            certs_len = (data[pos] << 16) | (data[pos+1] << 8) | data[pos+2]
-                            
+                            certs_len = (data[pos] << 16) | (data[pos + 1] << 8) | data[pos + 2]
+
                             if verbose:
                                 print(f"  Certificate list length: {certs_len}")
-                                
+
                             pos += 3  # Move past certificate list length
-                            
+
                             # Individual Certificate Length (3 bytes)
                             if pos + 3 <= len(data):
-                                cert_len = (data[pos] << 16) | (data[pos+1] << 8) | data[pos+2]
-                                
+                                cert_len = (data[pos] << 16) | (data[pos + 1] << 8) | data[pos + 2]
+
                                 if verbose:
                                     print(f"  First certificate length: {cert_len}")
-                                    
+
                                 pos += 3  # Move past certificate length
-                                
+
                                 # Certificate Data
                                 if pos + cert_len <= len(data):
                                     if verbose:
-                                        print(f"  Extracting certificate at offset {pos} with length {cert_len}")
-                                        print(f"  Certificate starts with: {data[pos:pos+16].hex()}")
-                                    
+                                        print(
+                                            f"  Extracting certificate at offset {pos} with length {cert_len}"
+                                        )
+                                        print(
+                                            f"  Certificate starts with: {data[pos : pos + 16].hex()}"
+                                        )
+
                                     # This is the actual X.509 certificate data
-                                    return data[pos:pos+cert_len]
+                                    return data[pos : pos + cert_len]
             i += 1
-        
+
         # Method 2: Look for ASN.1 SEQUENCE that could be a certificate
         # Only attempt this if explicitly requested
         if try_asn1:
@@ -86,54 +93,58 @@ def extract_certificate_from_bytes(data, verbose=False, try_asn1=False):
                 # Look for ASN.1 SEQUENCE tag (0x30) followed by length
                 if data[i] == 0x30:
                     # Check different length encodings
-                    if i+1 < len(data):
-                        if data[i+1] & 0x80 == 0:
+                    if i + 1 < len(data):
+                        if data[i + 1] & 0x80 == 0:
                             # Short form length
-                            seq_len = data[i+1]
+                            seq_len = data[i + 1]
                             header_size = 2
-                        elif data[i+1] == 0x81 and i+2 < len(data):
+                        elif data[i + 1] == 0x81 and i + 2 < len(data):
                             # Long form, 1 byte
-                            seq_len = data[i+2]
+                            seq_len = data[i + 2]
                             header_size = 3
-                        elif data[i+1] == 0x82 and i+3 < len(data):
+                        elif data[i + 1] == 0x82 and i + 3 < len(data):
                             # Long form, 2 bytes
-                            seq_len = (data[i+2] << 8) | data[i+3]
+                            seq_len = (data[i + 2] << 8) | data[i + 3]
                             header_size = 4
-                        elif data[i+1] == 0x83 and i+4 < len(data):
+                        elif data[i + 1] == 0x83 and i + 4 < len(data):
                             # Long form, 3 bytes
-                            seq_len = (data[i+2] << 16) | (data[i+3] << 8) | data[i+4]
+                            seq_len = (data[i + 2] << 16) | (data[i + 3] << 8) | data[i + 4]
                             header_size = 5
                         else:
                             i += 1
                             continue
-                        
+
                         # Check if we have enough data for the complete sequence
                         if i + header_size + seq_len <= len(data):
                             # Extract the potential certificate
-                            candidate = data[i:i+header_size+seq_len]
-                            
+                            candidate = data[i : i + header_size + seq_len]
+
                             # Check if this looks like a certificate
-                            if b'\x06\x03\x55\x04' in candidate:  # Common OID pattern
+                            if b"\x06\x03\x55\x04" in candidate:  # Common OID pattern
                                 try:
                                     # Attempt to parse
                                     from cryptography import x509
                                     from cryptography.hazmat.backends import default_backend
-                                    cert = x509.load_der_x509_certificate(candidate, default_backend())
-                                    
+
+                                    cert = x509.load_der_x509_certificate(
+                                        candidate, default_backend()
+                                    )
+
                                     if verbose:
                                         print(f"  Found ASN.1 certificate at position {i}")
-                                        
+
                                     return candidate
                                 except Exception as e:
                                     if verbose:
                                         print(f"  ASN.1 parse error: {e}")
                 i += 1
-                
+
         return None
     except Exception as e:
         if verbose:
             print(f"  Error finding certificate: {e}")
         return None
+
 
 def oid_to_hex(oid_string):
     """
@@ -145,9 +156,9 @@ def oid_to_hex(oid_string):
 
     Example: OID 2.5.4.3 -> '550403' (0x55=2*40+5, 0x04=4, 0x03=3)
     """
-    parts = [int(p) for p in oid_string.split('.')]
+    parts = [int(p) for p in oid_string.split(".")]
     if len(parts) < 2:
-        return ''.join(f"{p:02x}" for p in parts)
+        return "".join(f"{p:02x}" for p in parts)
 
     # First two components are combined per ASN.1 rules
     encoded = [parts[0] * 40 + parts[1]]
@@ -168,7 +179,8 @@ def oid_to_hex(oid_string):
             vlq_bytes.reverse()
             encoded.extend(vlq_bytes)
 
-    return ''.join(f"{b:02x}" for b in encoded)
+    return "".join(f"{b:02x}" for b in encoded)
+
 
 def get_cert_details(cert):
     """Extract detailed certificate information for JA4X"""
@@ -180,71 +192,74 @@ def get_cert_details(cert):
                 # Convert OID to hex string
                 oid_hex = oid_to_hex(attr.oid.dotted_string)
                 issuer_rdns.append(oid_hex)
-        
+
         # Extract subject RDNs in order
         subject_rdns = []
         for rdn in cert.subject.rdns:
             for attr in rdn:
                 oid_hex = oid_to_hex(attr.oid.dotted_string)
                 subject_rdns.append(oid_hex)
-        
+
         # Extract extensions in order
         extensions = []
         for ext in cert.extensions:
             oid_hex = oid_to_hex(ext.oid.dotted_string)
             extensions.append(oid_hex)
-        
+
         return {
-            'issuer_rdns': issuer_rdns,
-            'subject_rdns': subject_rdns,
-            'extensions': extensions,
-            'serial': str(cert.serial_number),
-            'not_before': cert.not_valid_before_utc,
-            'not_after': cert.not_valid_after_utc,
-            'version': cert.version.name
+            "issuer_rdns": issuer_rdns,
+            "subject_rdns": subject_rdns,
+            "extensions": extensions,
+            "serial": str(cert.serial_number),
+            "not_before": cert.not_valid_before_utc,
+            "not_after": cert.not_valid_after_utc,
+            "version": cert.version.name,
         }
     except (ValueError, TypeError, AttributeError) as e:
         logger.warning(f"Certificate error: {e}")
         return None
 
+
 def extract_certificate_info(packet, verbose=False):
     """
     Extract certificate info from a packet.
-    
+
     Args:
         packet: A network packet possibly containing certificate data
         verbose: Whether to print verbose debugging info
-        
+
     Returns:
         Dictionary with certificate information or None if not applicable
     """
     try:
         from scapy.all import Raw, TCP
+
         if not Raw in packet:
             return None
-        
+
         # Less restrictive approach - try to extract certificates from any TCP packet with data
         raw_data = bytes(packet[Raw])
-        
+
         # Try the structured approach first
         cert_data = extract_certificate_from_bytes(raw_data, verbose=verbose, try_asn1=True)
-        
+
         if not cert_data and len(raw_data) > 100:
             # If we have substantial data, try a direct ASN.1 parse as a last resort
             try:
                 # Some certificates might be directly in the raw data with minimal framing
                 from cryptography import x509
                 from cryptography.hazmat.backends import default_backend
+
                 cert = x509.load_der_x509_certificate(raw_data, default_backend())
                 return get_cert_details(cert)
             except (ValueError, TypeError, Exception) as e:
                 logger.debug(f"Direct certificate parsing failed: {e}")
-            
+
         if not cert_data:
             if verbose:
                 print("  No certificate found in packet")
             return None
-            
+
         # Parse certificate
         try:
             cert = x509.load_der_x509_certificate(cert_data, default_backend())
@@ -253,21 +268,22 @@ def extract_certificate_info(packet, verbose=False):
             if verbose:
                 print(f"Direct certificate parsing failed: {e}")
             return None
-            
+
     except Exception as e:
         if verbose:
             print(f"Error extracting certificate info: {e}")
         return None
 
+
 def get_certificate_issuer(cert):
     """Extract issuer information from certificate"""
     issuer = cert.issuer
-    
+
     # Extract common components
     org = get_name_attribute(issuer, NameOID.ORGANIZATION_NAME)
     cn = get_name_attribute(issuer, NameOID.COMMON_NAME)
     country = get_name_attribute(issuer, NameOID.COUNTRY_NAME)
-    
+
     components = []
     if org:
         components.append(f"O={org}")
@@ -275,18 +291,19 @@ def get_certificate_issuer(cert):
         components.append(f"CN={cn}")
     if country:
         components.append(f"C={country}")
-        
+
     return ",".join(components)
+
 
 def get_certificate_subject(cert):
     """Extract subject information from certificate"""
     subject = cert.subject
-    
+
     # Extract common components
     org = get_name_attribute(subject, NameOID.ORGANIZATION_NAME)
     cn = get_name_attribute(subject, NameOID.COMMON_NAME)
     country = get_name_attribute(subject, NameOID.COUNTRY_NAME)
-    
+
     components = []
     if org:
         components.append(f"O={org}")
@@ -294,8 +311,9 @@ def get_certificate_subject(cert):
         components.append(f"CN={cn}")
     if country:
         components.append(f"C={country}")
-        
+
     return ",".join(components)
+
 
 def get_name_attribute(name, oid):
     """Safely extract name attribute"""
@@ -306,4 +324,3 @@ def get_name_attribute(name, oid):
     except (ValueError, TypeError, AttributeError) as e:
         logger.debug(f"Failed to get name attribute: {e}")
     return None
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,13 @@ ja4plus = ["data/*.csv"]
 markers = [
     "spec_validation: FoxIO reference validation tests",
 ]
+
+[tool.ruff]
+target-version = "py39"
+# The formatter reaches its smallest diff on the existing code at 100 columns.
+# A wider limit changes one more line, and a narrower limit changes 32 more.
+line-length = 100
+
+[tool.ruff.lint]
+# The default rule set, plus import order.
+select = ["E4", "E7", "E9", "F", "I"]

--- a/tests/download_test_vectors.py
+++ b/tests/download_test_vectors.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Download FoxIO JA4+ test vectors for spec validation."""
+
 import os
 import urllib.request
 import json
@@ -16,6 +17,7 @@ PCAPS = [
     "ssh.pcapng",
     "ssh2.pcapng",
 ]
+
 
 def download():
     os.makedirs(TEST_VECTORS_DIR, exist_ok=True)
@@ -46,6 +48,7 @@ def download():
                     )
                 except Exception:
                     print(f"  Warning: No expected output found for {pcap}")
+
 
 if __name__ == "__main__":
     download()

--- a/tests/test_cleanup_connection.py
+++ b/tests/test_cleanup_connection.py
@@ -1,4 +1,5 @@
 """Tests for the cleanup_connection() API on stateful fingerprinters."""
+
 import unittest
 
 from scapy.all import IP, TCP, UDP, Raw
@@ -7,13 +8,15 @@ from scapy.all import IP, TCP, UDP, Raw
 class TestBaseFingerprinterCleanup(unittest.TestCase):
     def test_base_has_cleanup_connection(self):
         from ja4plus.fingerprinters.base import BaseFingerprinter
+
         # The base class must have the method (no-op default)
         fp = BaseFingerprinter.__new__(BaseFingerprinter)
         fp.fingerprints = []
-        self.assertTrue(hasattr(fp, 'cleanup_connection'))
+        self.assertTrue(hasattr(fp, "cleanup_connection"))
 
     def test_base_cleanup_is_noop(self):
         from ja4plus.fingerprinters.base import BaseFingerprinter
+
         fp = BaseFingerprinter.__new__(BaseFingerprinter)
         fp.fingerprints = []
         # Must not raise
@@ -26,6 +29,7 @@ class TestJA4LCleanup(unittest.TestCase):
 
     def test_cleanup_removes_connection(self):
         from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+
         fp = JA4LFingerprinter()
         fp.process_packet(self._make_syn())
         self.assertGreater(len(fp.connections), 0)
@@ -35,6 +39,7 @@ class TestJA4LCleanup(unittest.TestCase):
 
     def test_cleanup_nonexistent_is_safe(self):
         from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+
         fp = JA4LFingerprinter()
         # No-op on empty state
         fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 200, "tcp")
@@ -42,6 +47,7 @@ class TestJA4LCleanup(unittest.TestCase):
     def test_cleanup_both_directions(self):
         """Cleanup should work regardless of argument order (fwd/rev key)."""
         from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+
         fp = JA4LFingerprinter()
         fp.process_packet(self._make_syn(src="10.0.0.1", dst="10.0.0.2"))
         # Call with dst/src reversed — should still clean up
@@ -51,12 +57,15 @@ class TestJA4LCleanup(unittest.TestCase):
 
 class TestJA4SSHCleanup(unittest.TestCase):
     def _make_ssh_pkt(self, src="10.0.0.1", dst="10.0.0.2", sport=54321, dport=22):
-        return (IP(src=src, dst=dst) /
-                TCP(sport=sport, dport=dport, flags="PA") /
-                Raw(load=b"SSH-2.0-OpenSSH_8.0\r\n"))
+        return (
+            IP(src=src, dst=dst)
+            / TCP(sport=sport, dport=dport, flags="PA")
+            / Raw(load=b"SSH-2.0-OpenSSH_8.0\r\n")
+        )
 
     def test_cleanup_removes_connection(self):
         from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+
         fp = JA4SSHFingerprinter()
         fp.process_packet(self._make_ssh_pkt())
         self.assertGreater(len(fp.connections), 0)
@@ -66,6 +75,7 @@ class TestJA4SSHCleanup(unittest.TestCase):
 
     def test_cleanup_nonexistent_is_safe(self):
         from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+
         fp = JA4SSHFingerprinter()
         fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 22, "tcp")
 
@@ -73,12 +83,15 @@ class TestJA4SSHCleanup(unittest.TestCase):
 class TestJA4HCleanup(unittest.TestCase):
     def _make_http_pkt(self, src="10.0.0.1", dst="10.0.0.2", sport=54321, dport=80):
         payload = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
-        return (IP(src=src, dst=dst) /
-                TCP(sport=sport, dport=dport, seq=1, flags="PA") /
-                Raw(load=payload))
+        return (
+            IP(src=src, dst=dst)
+            / TCP(sport=sport, dport=dport, seq=1, flags="PA")
+            / Raw(load=payload)
+        )
 
     def test_cleanup_removes_stream(self):
         from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
+
         fp = JA4HFingerprinter()
         fp.process_packet(self._make_http_pkt())
         stream_key = "10.0.0.1:54321-10.0.0.2:80"
@@ -88,6 +101,7 @@ class TestJA4HCleanup(unittest.TestCase):
 
     def test_cleanup_nonexistent_is_safe(self):
         from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
+
         fp = JA4HFingerprinter()
         fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 80, "tcp")
 
@@ -95,6 +109,7 @@ class TestJA4HCleanup(unittest.TestCase):
 class TestJA4XCleanup(unittest.TestCase):
     def test_cleanup_removes_stream(self):
         from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
+
         fp = JA4XFingerprinter()
         # Manually inject a stream to verify removal
         stream_key = "10.0.0.1:54321-10.0.0.2:443"
@@ -106,6 +121,7 @@ class TestJA4XCleanup(unittest.TestCase):
 
     def test_cleanup_nonexistent_is_safe(self):
         from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
+
         fp = JA4XFingerprinter()
         fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 443, "tcp")
 
@@ -114,9 +130,10 @@ class TestJA4SCleanup(unittest.TestCase):
     def test_cleanup_already_covered_in_quic_tests(self):
         """Covered by test_quic_utils.py::TestJA4SQUICTracking."""
         from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+
         fp = JA4SFingerprinter()
         fp.cleanup_connection("1.2.3.4", 100, "5.6.7.8", 443, "udp")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,9 +29,11 @@ def run_cli(*argv):
     captured_err = io.StringIO()
 
     exit_code = 0
-    with patch("sys.argv", ["ja4plus"] + list(argv)), \
-         patch("sys.stdout", captured_out), \
-         patch("sys.stderr", captured_err):
+    with (
+        patch("sys.argv", ["ja4plus"] + list(argv)),
+        patch("sys.stdout", captured_out),
+        patch("sys.stderr", captured_err),
+    ):
         try:
             main()
         except SystemExit as e:
@@ -132,9 +134,9 @@ class TestVersionFlag(unittest.TestCase):
         self.assertIn("ja4plus", combined.lower())
         # Should contain a version number (digits and dots)
         import re
+
         self.assertTrue(
-            re.search(r"\d+\.\d+", combined),
-            f"No version number found in: {combined!r}"
+            re.search(r"\d+\.\d+", combined), f"No version number found in: {combined!r}"
         )
 
 
@@ -150,6 +152,7 @@ class TestInvalidTypes(unittest.TestCase):
     def test_valid_types_accepted(self):
         """All valid type names are accepted without error."""
         from ja4plus.cli import VALID_TYPES, _parse_types
+
         for t in VALID_TYPES:
             result = _parse_types(t)
             self.assertEqual(result, [t])

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -145,9 +145,22 @@ class TestGREASE(unittest.TestCase):
     """Test GREASE value detection across all known values."""
 
     GREASE_VALUES = [
-        0x0A0A, 0x1A1A, 0x2A2A, 0x3A3A, 0x4A4A, 0x5A5A,
-        0x6A6A, 0x7A7A, 0x8A8A, 0x9A9A, 0xAAAA, 0xBABA,
-        0xCACA, 0xDADA, 0xEAEA, 0xFAFA,
+        0x0A0A,
+        0x1A1A,
+        0x2A2A,
+        0x3A3A,
+        0x4A4A,
+        0x5A5A,
+        0x6A6A,
+        0x7A7A,
+        0x8A8A,
+        0x9A9A,
+        0xAAAA,
+        0xBABA,
+        0xCACA,
+        0xDADA,
+        0xEAEA,
+        0xFAFA,
     ]
 
     def test_all_grease_values_detected(self):
@@ -173,7 +186,6 @@ class TestGREASE(unittest.TestCase):
 # JA4 (TLS Client Hello) comprehensive tests
 # ===========================================================================
 class TestJA4Comprehensive(unittest.TestCase):
-
     def setUp(self):
         self.fp = JA4Fingerprinter()
 
@@ -332,7 +344,6 @@ class TestJA4Comprehensive(unittest.TestCase):
 # JA4S (TLS Server Hello) comprehensive tests
 # ===========================================================================
 class TestJA4SComprehensive(unittest.TestCase):
-
     def setUp(self):
         self.fp = JA4SFingerprinter()
 
@@ -347,9 +358,7 @@ class TestJA4SComprehensive(unittest.TestCase):
         self.assertEqual(parts[1], "c02f")
 
     def test_tls13_via_supported_versions(self):
-        raw = build_server_hello(
-            version=0x0303, cipher=0x1301, supported_version=0x0304
-        )
+        raw = build_server_hello(version=0x0303, cipher=0x1301, supported_version=0x0304)
         packet = IP() / TCP(sport=443, dport=12345) / Raw(load=raw)
         fp = self.fp.process_packet(packet)
         self.assertIsNotNone(fp)
@@ -388,12 +397,19 @@ class TestJA4SComprehensive(unittest.TestCase):
 # JA4H (HTTP) comprehensive tests
 # ===========================================================================
 class TestJA4HComprehensive(unittest.TestCase):
-
     def setUp(self):
         self.fp = JA4HFingerprinter()
 
-    def _make_http(self, method="GET", path="/", version="HTTP/1.1",
-                   headers=None, cookie=None, referer=None, lang=None):
+    def _make_http(
+        self,
+        method="GET",
+        path="/",
+        version="HTTP/1.1",
+        headers=None,
+        cookie=None,
+        referer=None,
+        lang=None,
+    ):
         lines = [f"{method} {path} {version}"]
         if headers:
             for k, v in headers:
@@ -500,13 +516,20 @@ class TestJA4HComprehensive(unittest.TestCase):
 # JA4T (TCP SYN) comprehensive tests
 # ===========================================================================
 class TestJA4TComprehensive(unittest.TestCase):
-
     def test_standard_linux_syn(self):
         """Standard Linux SYN packet options."""
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=29200,
-            options=[("MSS", 1460), ("SAckOK", ""), ("Timestamp", (0, 0)),
-                     ("NOP", None), ("WScale", 7)],
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=29200,
+            options=[
+                ("MSS", 1460),
+                ("SAckOK", ""),
+                ("Timestamp", (0, 0)),
+                ("NOP", None),
+                ("WScale", 7),
+            ],
         )
         fp = generate_ja4t(packet)
         self.assertIsNotNone(fp)
@@ -519,7 +542,10 @@ class TestJA4TComprehensive(unittest.TestCase):
     def test_option_order_preserved(self):
         """TCP options must be in original packet order (not sorted)."""
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=65535,
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=65535,
             options=[("NOP", None), ("MSS", 1460), ("WScale", 7)],
         )
         fp = generate_ja4t(packet)
@@ -545,7 +571,10 @@ class TestJA4TComprehensive(unittest.TestCase):
     def test_synack_rejected_by_ja4t(self):
         """SYN-ACK should be rejected by JA4T (JA4TS handles SYN-ACK)."""
         packet = IP() / TCP(
-            sport=443, dport=54321, flags="SA", window=14600,
+            sport=443,
+            dport=54321,
+            flags="SA",
+            window=14600,
             options=[("MSS", 1460)],
         )
         fp = generate_ja4t(packet)
@@ -554,7 +583,10 @@ class TestJA4TComprehensive(unittest.TestCase):
     def test_large_window(self):
         """Very large window size."""
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=65535,
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=65535,
             options=[("MSS", 1460), ("WScale", 14)],
         )
         fp = generate_ja4t(packet)
@@ -567,7 +599,10 @@ class TestJA4TComprehensive(unittest.TestCase):
         fpr = JA4TFingerprinter()
         for i in range(3):
             packet = IP() / TCP(
-                sport=54321 + i, dport=443, flags="S", window=65535,
+                sport=54321 + i,
+                dport=443,
+                flags="S",
+                window=65535,
                 options=[("MSS", 1460)],
             )
             fpr.process_packet(packet)
@@ -580,10 +615,12 @@ class TestJA4TComprehensive(unittest.TestCase):
 # JA4TS (TCP SYN-ACK) comprehensive tests
 # ===========================================================================
 class TestJA4TSComprehensive(unittest.TestCase):
-
     def test_synack_fingerprint(self):
         packet = IP() / TCP(
-            sport=443, dport=54321, flags="SA", window=14600,
+            sport=443,
+            dport=54321,
+            flags="SA",
+            window=14600,
             options=[("MSS", 1460), ("NOP", None), ("WScale", 0)],
         )
         fp = generate_ja4ts(packet)
@@ -596,7 +633,10 @@ class TestJA4TSComprehensive(unittest.TestCase):
     def test_syn_only_ignored(self):
         """Pure SYN (no ACK) should be ignored by JA4TS."""
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=65535,
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=65535,
             options=[("MSS", 1460)],
         )
         fp = generate_ja4ts(packet)
@@ -606,7 +646,10 @@ class TestJA4TSComprehensive(unittest.TestCase):
         """JA4TSFingerprinter should use BaseFingerprinter properly."""
         fpr = JA4TSFingerprinter()
         packet = IP() / TCP(
-            sport=443, dport=54321, flags="SA", window=14600,
+            sport=443,
+            dport=54321,
+            flags="SA",
+            window=14600,
             options=[("MSS", 1460)],
         )
         fpr.process_packet(packet)
@@ -618,15 +661,12 @@ class TestJA4TSComprehensive(unittest.TestCase):
 # JA4L (Latency) comprehensive tests
 # ===========================================================================
 class TestJA4LComprehensive(unittest.TestCase):
-
     def setUp(self):
         self.fp = JA4LFingerprinter()
 
     def test_handshake_produces_two_fingerprints(self):
         """Full handshake should produce server + client fingerprints."""
-        syn = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(
-            sport=54321, dport=443, flags="S"
-        )
+        syn = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(sport=54321, dport=443, flags="S")
         self.fp.process_packet(syn)
         time.sleep(0.002)
 
@@ -638,9 +678,7 @@ class TestJA4LComprehensive(unittest.TestCase):
         self.assertTrue(server_fp.startswith("JA4L-S="))
 
         time.sleep(0.002)
-        ack = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(
-            sport=54321, dport=443, flags="A"
-        )
+        ack = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(sport=54321, dport=443, flags="A")
         client_fp = self.fp.process_packet(ack)
         self.assertIsNotNone(client_fp)
         self.assertTrue(client_fp.startswith("JA4L-C="))
@@ -651,7 +689,8 @@ class TestJA4LComprehensive(unittest.TestCase):
         """JA4L format is JA4L-X=<latency_us>_<ttl>."""
         now = time.time()
         conn = {
-            "proto": "tcp", "timestamps": {"A": now - 0.010},
+            "proto": "tcp",
+            "timestamps": {"A": now - 0.010},
             "ttls": {"client": 128, "server": 64},
         }
         synack = IP(src="10.0.0.2", dst="10.0.0.1", ttl=64) / TCP(
@@ -686,7 +725,6 @@ class TestJA4LComprehensive(unittest.TestCase):
 # JA4SSH comprehensive tests
 # ===========================================================================
 class TestJA4SSHComprehensive(unittest.TestCase):
-
     def test_interpret_interactive(self):
         fp = JA4SSHFingerprinter()
         result = fp.interpret_fingerprint("c36s36_c50s50_c70s30")
@@ -721,20 +759,25 @@ class TestJA4SSHComprehensive(unittest.TestCase):
         """Test HASSH collection through packet processing."""
         fp = JA4SSHFingerprinter(packet_count=100)
         banner_c = (
-            Ether() / IP(src="10.0.0.1", dst="10.0.0.2")
+            Ether()
+            / IP(src="10.0.0.1", dst="10.0.0.2")
             / TCP(sport=52416, dport=22)
             / Raw(load=b"SSH-2.0-OpenSSH_8.2p1\r\n")
         )
         banner_s = (
-            Ether() / IP(src="10.0.0.2", dst="10.0.0.1")
+            Ether()
+            / IP(src="10.0.0.2", dst="10.0.0.1")
             / TCP(sport=22, dport=52416)
             / Raw(load=b"SSH-2.0-OpenSSH_7.6p1\r\n")
         )
         kex_c = (
-            Ether() / IP(src="10.0.0.1", dst="10.0.0.2")
+            Ether()
+            / IP(src="10.0.0.1", dst="10.0.0.2")
             / TCP(sport=52416, dport=22)
-            / Raw(load=b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAASSH_MSG_KEXINIT"
-                        b"curve25519-sha256;aes128-ctr;hmac-sha2-256;none")
+            / Raw(
+                load=b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAASSH_MSG_KEXINIT"
+                b"curve25519-sha256;aes128-ctr;hmac-sha2-256;none"
+            )
         )
         fp.process_packet(banner_c)
         fp.process_packet(banner_s)
@@ -748,7 +791,6 @@ class TestJA4SSHComprehensive(unittest.TestCase):
 # TLS parsing edge case tests
 # ===========================================================================
 class TestTLSParsing(unittest.TestCase):
-
     def test_empty_data(self):
         self.assertIsNone(parse_tls_handshake(b""))
 
@@ -768,9 +810,7 @@ class TestTLSParsing(unittest.TestCase):
 
     def test_client_hello_parses_sni(self):
         """Full ClientHello with SNI should extract hostname."""
-        raw = build_client_hello(
-            version=0x0303, ciphers=[0xC02F], sni_hostname="test.example.com"
-        )
+        raw = build_client_hello(version=0x0303, ciphers=[0xC02F], sni_hostname="test.example.com")
         result = parse_tls_handshake(raw)
         self.assertIsNotNone(result)
         self.assertEqual(result.get("sni"), "test.example.com")
@@ -791,9 +831,7 @@ class TestFormatConsistency(unittest.TestCase):
 
     def test_ja4_format_regex(self):
         """JA4 format: <proto><ver><sni><cc><ec><alpn>_<hash>_<hash>"""
-        raw = build_client_hello(
-            version=0x0303, ciphers=[0x1301], sni_hostname="example.com"
-        )
+        raw = build_client_hello(version=0x0303, ciphers=[0x1301], sni_hostname="example.com")
         packet = IP() / TCP(sport=12345, dport=443) / Raw(load=raw)
         fp = JA4Fingerprinter().process_packet(packet)
         self.assertRegex(fp, r"^[tdq]\d{2}[di]\d{4}[a-z0-9]{2}_[a-f0-9]{12}_[a-f0-9]{12}$")
@@ -806,7 +844,10 @@ class TestFormatConsistency(unittest.TestCase):
 
     def test_ja4t_format_regex(self):
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=65535,
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=65535,
             options=[("MSS", 1460), ("WScale", 7)],
         )
         fp = generate_ja4t(packet)
@@ -814,7 +855,10 @@ class TestFormatConsistency(unittest.TestCase):
 
     def test_ja4ts_format_regex(self):
         packet = IP() / TCP(
-            sport=443, dport=54321, flags="SA", window=14600,
+            sport=443,
+            dport=54321,
+            flags="SA",
+            window=14600,
             options=[("MSS", 1460)],
         )
         fp = generate_ja4ts(packet)
@@ -841,7 +885,6 @@ class TestFormatConsistency(unittest.TestCase):
 # JA4X X.509 certificate tests
 # ===========================================================================
 class TestJA4XComprehensive(unittest.TestCase):
-
     def _make_cert(self, org="Test", cn="test.com", country="US", add_extensions=True):
         from cryptography import x509
         from cryptography.x509.oid import NameOID
@@ -851,11 +894,13 @@ class TestJA4XComprehensive(unittest.TestCase):
         from cryptography.hazmat.primitives.serialization import Encoding
 
         key = rsa.generate_private_key(65537, 2048, default_backend())
-        subject = issuer = x509.Name([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
-            x509.NameAttribute(NameOID.COMMON_NAME, cn),
-            x509.NameAttribute(NameOID.COUNTRY_NAME, country),
-        ])
+        subject = issuer = x509.Name(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
+                x509.NameAttribute(NameOID.COMMON_NAME, cn),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, country),
+            ]
+        )
         now = datetime.datetime.now(datetime.timezone.utc)
         builder = (
             x509.CertificateBuilder()
@@ -908,18 +953,22 @@ class TestJA4XComprehensive(unittest.TestCase):
         cert_a = self._make_cert(org="Org A", cn="a.com")
 
         # Cert B: Org + CN + Country + State (4 OIDs - different structure)
-        subject_b = x509.Name([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Org B"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "b.com"),
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
-        ])
+        subject_b = x509.Name(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Org B"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "b.com"),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+                x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
+            ]
+        )
         builder = (
             x509.CertificateBuilder()
-            .subject_name(subject_b).issuer_name(subject_b)
+            .subject_name(subject_b)
+            .issuer_name(subject_b)
             .public_key(key.public_key())
             .serial_number(x509.random_serial_number())
-            .not_valid_before(now).not_valid_after(now + datetime.timedelta(days=365))
+            .not_valid_before(now)
+            .not_valid_after(now + datetime.timedelta(days=365))
             .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
         )
         cert_b_obj = builder.sign(key, hashes.SHA256(), default_backend())

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -124,6 +124,7 @@ class TestMalformedTLS(unittest.TestCase):
     def test_random_bytes(self):
         """Random non-TLS data should not crash."""
         import os
+
         data = os.urandom(256)
         packet = IP() / TCP(sport=12345, dport=443) / Raw(load=data)
         # Should not raise, just return None
@@ -210,8 +211,9 @@ class TestMalformedTCP(unittest.TestCase):
 
     def test_ja4t_synack_rejected(self):
         """SYN-ACK should be rejected by JA4T (handled by JA4TS)."""
-        packet = IP() / TCP(sport=443, dport=54321, flags="SA", window=14600,
-                            options=[("MSS", 1460)])
+        packet = IP() / TCP(
+            sport=443, dport=54321, flags="SA", window=14600, options=[("MSS", 1460)]
+        )
         self.assertIsNone(generate_ja4t(packet))
 
 
@@ -226,25 +228,27 @@ class TestMalformedSSH(unittest.TestCase):
 
     def test_http_data_to_ssh(self):
         """HTTP data should not produce SSH fingerprints."""
-        packet = (IP(src="10.0.0.1", dst="10.0.0.2")
-                  / TCP(sport=12345, dport=22)
-                  / Raw(load=b"GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"))
+        packet = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=22)
+            / Raw(load=b"GET / HTTP/1.1\r\nHost: test.com\r\n\r\n")
+        )
         result = self.ja4ssh.process_packet(packet)
         self.assertIsNone(result)
 
     def test_tls_data_to_ssh(self):
         """TLS data should not produce SSH fingerprints."""
-        packet = (IP(src="10.0.0.1", dst="10.0.0.2")
-                  / TCP(sport=12345, dport=22)
-                  / Raw(load=b"\x16\x03\x03\x00\x10" + b"\x00" * 16))
+        packet = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=22)
+            / Raw(load=b"\x16\x03\x03\x00\x10" + b"\x00" * 16)
+        )
         result = self.ja4ssh.process_packet(packet)
         self.assertIsNone(result)
 
     def test_empty_payload(self):
         """Empty payload should not produce SSH fingerprints."""
-        packet = (IP(src="10.0.0.1", dst="10.0.0.2")
-                  / TCP(sport=12345, dport=22)
-                  / Raw(load=b""))
+        packet = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=12345, dport=22) / Raw(load=b"")
         result = self.ja4ssh.process_packet(packet)
         self.assertIsNone(result)
 
@@ -276,11 +280,8 @@ class TestX509EdgeCases(unittest.TestCase):
     def test_generate_ja4x_empty_lists(self):
         """Empty RDN/extension lists should produce hashes of empty strings."""
         import hashlib
-        cert_info = {
-            "issuer_rdns": [],
-            "subject_rdns": [],
-            "extensions": []
-        }
+
+        cert_info = {"issuer_rdns": [], "subject_rdns": [], "extensions": []}
         result = generate_ja4x(cert_info)
         self.assertIsNotNone(result)
         parts = result.split("_")
@@ -367,6 +368,7 @@ class TestAllFingerprinterGraceful(unittest.TestCase):
     def test_all_handle_random_payload(self):
         """All fingerprinters should handle random bytes without crashing."""
         import os
+
         data = os.urandom(128)
         packet = IP() / TCP(sport=12345, dport=443) / Raw(load=data)
         for fp in self._all_fingerprinters():
@@ -383,8 +385,7 @@ class TestAllFingerprinterGraceful(unittest.TestCase):
             name = fp.__class__.__name__
             with self.subTest(fingerprinter=name):
                 fp.reset()
-                self.assertEqual(len(fp.get_fingerprints()), 0,
-                                 f"{name} did not reset properly")
+                self.assertEqual(len(fp.get_fingerprints()), 0, f"{name} did not reset properly")
 
 
 # ===========================================================================
@@ -407,9 +408,7 @@ class TestJA4LEdgeCases(unittest.TestCase):
     def test_duplicate_syn(self):
         """Processing two SYN packets should not crash."""
         fp = JA4LFingerprinter()
-        syn = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(
-            sport=54321, dport=443, flags="S"
-        )
+        syn = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(sport=54321, dport=443, flags="S")
         fp.process_packet(syn)
         time.sleep(0.001)
         fp.process_packet(syn)
@@ -418,9 +417,7 @@ class TestJA4LEdgeCases(unittest.TestCase):
     def test_reset_clears_connections(self):
         """Reset should clear connection tracking."""
         fp = JA4LFingerprinter()
-        syn = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(
-            sport=54321, dport=443, flags="S"
-        )
+        syn = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(sport=54321, dport=443, flags="S")
         fp.process_packet(syn)
         self.assertGreater(len(fp.connections), 0)
         fp.reset()

--- a/tests/test_ipv6_support.py
+++ b/tests/test_ipv6_support.py
@@ -24,7 +24,10 @@ def _build_tls_client_hello():
 class TestJA4TIPv6(unittest.TestCase):
     def test_ja4t_ipv6(self):
         from ja4plus.fingerprinters.ja4t import generate_ja4t
-        pkt = IPv6(src="::1", dst="::2") / TCP(sport=12345, dport=443, flags="S", window=65535, options=[("MSS", 1460)])
+
+        pkt = IPv6(src="::1", dst="::2") / TCP(
+            sport=12345, dport=443, flags="S", window=65535, options=[("MSS", 1460)]
+        )
         result = generate_ja4t(pkt)
         self.assertIsNotNone(result, "JA4T should work with IPv6")
 
@@ -32,7 +35,10 @@ class TestJA4TIPv6(unittest.TestCase):
 class TestJA4TSIPv6(unittest.TestCase):
     def test_ja4ts_ipv6(self):
         from ja4plus.fingerprinters.ja4ts import generate_ja4ts
-        pkt = IPv6(src="::1", dst="::2") / TCP(sport=443, dport=12345, flags="SA", window=14600, options=[("MSS", 1460)])
+
+        pkt = IPv6(src="::1", dst="::2") / TCP(
+            sport=443, dport=12345, flags="SA", window=14600, options=[("MSS", 1460)]
+        )
         result = generate_ja4ts(pkt)
         self.assertIsNotNone(result, "JA4TS should work with IPv6")
 
@@ -40,6 +46,7 @@ class TestJA4TSIPv6(unittest.TestCase):
 class TestJA4LIPv6(unittest.TestCase):
     def test_ja4l_ipv6_handshake(self):
         from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+
         fp = JA4LFingerprinter()
         syn = IPv6(src="::1", dst="::2", hlim=64) / TCP(sport=12345, dport=443, flags="S")
         result = fp.process_packet(syn)
@@ -54,8 +61,13 @@ class TestJA4LIPv6(unittest.TestCase):
 class TestJA4SSHIPv6(unittest.TestCase):
     def test_ja4ssh_ipv6(self):
         from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+
         fp = JA4SSHFingerprinter(packet_count=1)
-        pkt = IPv6(src="::1", dst="::2") / TCP(sport=12345, dport=22) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        pkt = (
+            IPv6(src="::1", dst="::2")
+            / TCP(sport=12345, dport=22)
+            / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        )
         result = fp.process_packet(pkt)
         # Should not crash due to missing IP layer — that's the key test
 
@@ -63,8 +75,13 @@ class TestJA4SSHIPv6(unittest.TestCase):
 class TestJA4XIPv6(unittest.TestCase):
     def test_ja4x_ipv6_no_crash(self):
         from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
+
         fp = JA4XFingerprinter()
-        pkt = IPv6(src="::1", dst="::2") / TCP(sport=12345, dport=443, seq=100) / Raw(load=b"\x16\x03\x01\x00\x05\x0b\x00\x00\x01\x00")
+        pkt = (
+            IPv6(src="::1", dst="::2")
+            / TCP(sport=12345, dport=443, seq=100)
+            / Raw(load=b"\x16\x03\x01\x00\x05\x0b\x00\x00\x01\x00")
+        )
         result = fp.process_packet(pkt)
         # May return None (not enough data), but must not crash
 

--- a/tests/test_ja4.py
+++ b/tests/test_ja4.py
@@ -3,76 +3,84 @@ import sys
 import os
 
 # Add the parent directory to the path to ensure imports work correctly
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from scapy.all import IP, TCP, Raw
 from ja4plus.fingerprinters.ja4 import JA4Fingerprinter, generate_ja4
 from ja4plus.utils.tls_utils import extract_tls_info
 
+
 class TestJA4(unittest.TestCase):
     def setUp(self):
         self.ja4_fp = JA4Fingerprinter()
-    
+
     def test_basic_functionality(self):
         """Test basic fingerprinter functionality"""
         # Just make sure it initializes properly
         self.assertIsNotNone(self.ja4_fp)
         self.assertEqual(len(self.ja4_fp.fingerprints), 0)
-    
+
     def test_client_hello_fingerprint(self):
         """Test fingerprinting a TLS ClientHello"""
         # Create a sample ClientHello packet
         client_hello_packet = create_client_hello_packet()
-        
+
         # Debug: Print tls_info attribute to verify it exists
         print(f"DEBUG: Does packet have tls_info? {hasattr(client_hello_packet, 'tls_info')}")
-        if hasattr(client_hello_packet, 'tls_info'):
+        if hasattr(client_hello_packet, "tls_info"):
             print(f"DEBUG: tls_info keys: {client_hello_packet.tls_info.keys()}")
-        
+
         # Ensure our packet has the tls_info attribute properly set
-        self.assertTrue(hasattr(client_hello_packet, 'tls_info'), 
-                      "Test packet missing tls_info attribute")
-        
+        self.assertTrue(
+            hasattr(client_hello_packet, "tls_info"), "Test packet missing tls_info attribute"
+        )
+
         # Generate fingerprint
         fingerprint = self.ja4_fp.process_packet(client_hello_packet)
-        
+
         # Check that we got a fingerprint
         self.assertIsNotNone(fingerprint, "Failed to generate JA4 fingerprint")
         print(f"DEBUG: Generated fingerprint: {fingerprint}")
-        
+
         # JA4 format is t[ver][sni][ciphercount][extcount][alpn]_[hash of ciphers]_[hash of extensions]
-        parts = fingerprint.split('_')
+        parts = fingerprint.split("_")
         self.assertEqual(len(parts), 3, "JA4 fingerprint has incorrect format")
-        
+
         # First part should start with 't'
-        self.assertTrue(parts[0].startswith('t'), "JA4 version part doesn't start with 't'")
-        
+        self.assertTrue(parts[0].startswith("t"), "JA4 version part doesn't start with 't'")
+
         # Since we have TLS 1.3 in supported_versions, it should use that value instead of TLS 1.2
-        self.assertTrue('13' in parts[0], "JA4 version should be '13' when TLS 1.3 is in supported_versions")
-        
+        self.assertTrue(
+            "13" in parts[0], "JA4 version should be '13' when TLS 1.3 is in supported_versions"
+        )
+
         # Check if the fingerprinter collected this fingerprint
-        self.assertEqual(len(self.ja4_fp.fingerprints), 1, "Fingerprinter didn't collect the fingerprint")
+        self.assertEqual(
+            len(self.ja4_fp.fingerprints), 1, "Fingerprinter didn't collect the fingerprint"
+        )
+
 
 def create_client_hello_packet():
     """Create a sample TLS ClientHello packet for testing."""
     # Create a packet with embedded TLS info for testing
-    packet = IP()/TCP()
-    
+    packet = IP() / TCP()
+
     # Add TLS info directly for testing
     packet.tls_info = {
-        'type': 'client_hello',
-        'version': 0x0303,  # TLS 1.2
-        'is_quic': False,
-        'is_dtls': False,
-        'supported_versions': [0x0304],  # TLS 1.3
-        'sni': 'example.com',
-        'ciphers': [0x1301, 0x1302, 0x1303, 0xc02f, 0xc02b],
-        'extensions': [0x0000, 0x000a, 0x000b, 0x000d, 0x0010, 0x0023],
-        'alpn_protocols': ['h2', 'http/1.1'],
-        'signature_algorithms': [0x0403, 0x0804, 0x0401, 0x0503]
+        "type": "client_hello",
+        "version": 0x0303,  # TLS 1.2
+        "is_quic": False,
+        "is_dtls": False,
+        "supported_versions": [0x0304],  # TLS 1.3
+        "sni": "example.com",
+        "ciphers": [0x1301, 0x1302, 0x1303, 0xC02F, 0xC02B],
+        "extensions": [0x0000, 0x000A, 0x000B, 0x000D, 0x0010, 0x0023],
+        "alpn_protocols": ["h2", "http/1.1"],
+        "signature_algorithms": [0x0403, 0x0804, 0x0401, 0x0503],
     }
-    
+
     return packet
 
-if __name__ == '__main__':
-    unittest.main() 
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ja4_alpn.py
+++ b/tests/test_ja4_alpn.py
@@ -4,29 +4,32 @@ Spec: if first or last byte of the first ALPN value is not ASCII alnum
 (0x30-0x39, 0x41-0x5A, 0x61-0x7A), use the first/last character of the
 hex representation of the FULL first ALPN string.
 """
+
 import pytest
 
 from ja4plus.fingerprinters.ja4 import compute_alpn_value
 
 
-@pytest.mark.parametrize("alpn_bytes,expected", [
-    # From the FoxIO PR #277 examples
-    (b"\xab",                "ab"),   # single non-alnum byte -> hex first/last
-    (b"\x20",                "20"),
-    (b"\xab\xcd",            "ad"),
-    (b"\x20\x61",            "21"),
-    (b"\x30\xab",            "3b"),   # first alnum, last not -> hex
-    (b"\x61\x20",            "60"),
-    (b"\x30\x31\xab\xcd",    "3d"),
-    (b"\x30\xab\xcd\x31",    "01"),   # both ends alnum -> bytes directly
-
-    # Additional sanity checks
-    (b"",                    "00"),   # empty -> '00'
-    (b"h",                   "hh"),   # single alnum byte -> duplicate
-    (b"h2",                  "h2"),   # standard ALPN, both ends alnum
-    (b"http/1.1",            "h1"),
-    (b"h3",                  "h3"),
-])
+@pytest.mark.parametrize(
+    "alpn_bytes,expected",
+    [
+        # From the FoxIO PR #277 examples
+        (b"\xab", "ab"),  # single non-alnum byte -> hex first/last
+        (b"\x20", "20"),
+        (b"\xab\xcd", "ad"),
+        (b"\x20\x61", "21"),
+        (b"\x30\xab", "3b"),  # first alnum, last not -> hex
+        (b"\x61\x20", "60"),
+        (b"\x30\x31\xab\xcd", "3d"),
+        (b"\x30\xab\xcd\x31", "01"),  # both ends alnum -> bytes directly
+        # Additional sanity checks
+        (b"", "00"),  # empty -> '00'
+        (b"h", "hh"),  # single alnum byte -> duplicate
+        (b"h2", "h2"),  # standard ALPN, both ends alnum
+        (b"http/1.1", "h1"),
+        (b"h3", "h3"),
+    ],
+)
 def test_compute_alpn_value(alpn_bytes, expected):
     assert compute_alpn_value(alpn_bytes) == expected
 
@@ -47,8 +50,8 @@ def test_compute_alpn_via_generate_ja4():
         "is_dtls": False,
         "ciphers": [0x1301],
         "extensions": [],
-        "alpn_protocols": [""],         # ascii decode dropped non-ascii bytes
-        "alpn_raw": [b"\x30\xab"],     # but raw bytes are preserved
+        "alpn_protocols": [""],  # ascii decode dropped non-ascii bytes
+        "alpn_raw": [b"\x30\xab"],  # but raw bytes are preserved
         "signature_algorithms": [],
         "supported_versions": [],
         "sni": None,

--- a/tests/test_ja4_deep.py
+++ b/tests/test_ja4_deep.py
@@ -17,8 +17,15 @@ from ja4plus.fingerprinters.ja4 import (
 from ja4plus.utils.tls_utils import is_grease_value
 
 
-def _build_ch(version=0x0303, ciphers=None, sni=None, alpn=None,
-              supported_versions=None, sig_algs=None, extra_exts=None):
+def _build_ch(
+    version=0x0303,
+    ciphers=None,
+    sni=None,
+    alpn=None,
+    supported_versions=None,
+    sig_algs=None,
+    extra_exts=None,
+):
     """Helper to build a TLS ClientHello record."""
     if ciphers is None:
         ciphers = [0x1301]
@@ -90,7 +97,7 @@ def _tls_info(**kwargs):
         "supported_versions": [],
         "sni": None,
         "ciphers": [0x1301],
-        "extensions": [0x000a, 0x000b],
+        "extensions": [0x000A, 0x000B],
         "alpn_protocols": [],
         "signature_algorithms": [],
     }
@@ -243,10 +250,7 @@ class TestJA4GREASEFiltering(unittest.TestCase):
 
     def test_grease_in_supported_versions_filtered(self):
         """GREASE values in supported_versions should be filtered."""
-        info = _tls_info(
-            version=0x0303,
-            supported_versions=[0x0A0A, 0x0304, 0xFAFA]
-        )
+        info = _tls_info(version=0x0303, supported_versions=[0x0A0A, 0x0304, 0xFAFA])
         fp = generate_ja4(info)
         self.assertTrue(fp.split("_")[0].startswith("t13"))
 

--- a/tests/test_ja4_empty_ext.py
+++ b/tests/test_ja4_empty_ext.py
@@ -8,8 +8,9 @@ sha256(b'')[:12].hexdigest() (which is 'e3b0c44298fc').
 from ja4plus.fingerprinters.ja4 import generate_ja4
 
 
-def _client_hello_info(extensions=None, ciphers=None, alpn_protocols=None,
-                      version=0x0303, sni=None):
+def _client_hello_info(
+    extensions=None, ciphers=None, alpn_protocols=None, version=0x0303, sni=None
+):
     """Build a minimal tls_info dict that drives generate_ja4 directly."""
     return {
         "handshake_type": "client_hello",
@@ -42,7 +43,7 @@ def test_ja4_empty_extensions_yields_literal_zero_hash():
 def test_ja4_only_grease_extensions_yields_literal_zero_hash():
     """When the only extensions are GREASE values, post-filter is empty."""
     # GREASE values follow pattern 0x[0-f]a[0-f]a — e.g. 0x0a0a, 0x1a1a
-    info = _client_hello_info(extensions=[0x0a0a, 0x1a1a, 0x2a2a])
+    info = _client_hello_info(extensions=[0x0A0A, 0x1A1A, 0x2A2A])
     fp = generate_ja4(info)
     assert fp is not None
     parts = fp.split("_")

--- a/tests/test_ja4d.py
+++ b/tests/test_ja4d.py
@@ -1,4 +1,5 @@
 """Tests for JA4D DHCP fingerprinting."""
+
 import struct
 import unittest
 
@@ -18,11 +19,12 @@ from ja4plus.fingerprinters.ja4d import (
 # Helpers to build raw DHCPv4 packets
 # ---------------------------------------------------------------------------
 
-DHCP_MAGIC = b'\x63\x82\x53\x63'
+DHCP_MAGIC = b"\x63\x82\x53\x63"
 
 
-def _build_dhcp_payload(msg_type, options=None, max_msg_size=None,
-                        request_ip=None, fqdn=False, param_request=None):
+def _build_dhcp_payload(
+    msg_type, options=None, max_msg_size=None, request_ip=None, fqdn=False, param_request=None
+):
     """Build a minimal DHCPv4 UDP payload (BOOTP + DHCP options)."""
     # Minimal BOOTP fixed header (236 bytes)
     bootp = bytearray(236)
@@ -38,7 +40,7 @@ def _build_dhcp_payload(msg_type, options=None, max_msg_size=None,
 
     # Option 57: Maximum DHCP Message Size
     if max_msg_size is not None:
-        opts += bytes([57, 2]) + struct.pack('!H', max_msg_size)
+        opts += bytes([57, 2]) + struct.pack("!H", max_msg_size)
 
     # Option 50: Requested IP Address (flag only — 4 zero bytes)
     if request_ip:
@@ -64,8 +66,9 @@ def _build_dhcp_payload(msg_type, options=None, max_msg_size=None,
     return payload + bytes(opts)
 
 
-def _make_dhcp_packet(msg_type, src_ip="192.168.1.100", dst_ip="255.255.255.255",
-                      sport=68, dport=67, **kwargs):
+def _make_dhcp_packet(
+    msg_type, src_ip="192.168.1.100", dst_ip="255.255.255.255", sport=68, dport=67, **kwargs
+):
     """Build a Scapy packet wrapping a DHCPv4 payload."""
     raw = _build_dhcp_payload(msg_type, **kwargs)
     return IP(src=src_ip, dst=dst_ip) / UDP(sport=sport, dport=dport) / Raw(load=raw)
@@ -74,6 +77,7 @@ def _make_dhcp_packet(msg_type, src_ip="192.168.1.100", dst_ip="255.255.255.255"
 # ---------------------------------------------------------------------------
 # Unit tests
 # ---------------------------------------------------------------------------
+
 
 class TestDHCPMessageTypes(unittest.TestCase):
     """All 18 message type abbreviations must be exactly 5 characters."""
@@ -84,14 +88,21 @@ class TestDHCPMessageTypes(unittest.TestCase):
 
     def test_all_abbreviations_are_5_chars(self):
         for code, abbrev in DHCP_MESSAGE_TYPES.items():
-            self.assertEqual(len(abbrev), 5,
-                             f"Type {code} abbreviation '{abbrev}' is not 5 chars")
+            self.assertEqual(len(abbrev), 5, f"Type {code} abbreviation '{abbrev}' is not 5 chars")
 
     def test_known_mappings(self):
         expected = {
-            1: "disco", 2: "offer", 3: "reqst", 4: "decln",
-            5: "dpack", 6: "dpnak", 7: "relse", 8: "infor",
-            9: "frenw", 10: "lqery", 18: "dhtls",
+            1: "disco",
+            2: "offer",
+            3: "reqst",
+            4: "decln",
+            5: "dpack",
+            6: "dpnak",
+            7: "relse",
+            8: "infor",
+            9: "frenw",
+            10: "lqery",
+            18: "dhtls",
         }
         for code, abbrev in expected.items():
             self.assertEqual(DHCP_MESSAGE_TYPES[code], abbrev)
@@ -108,10 +119,7 @@ class TestBuildOptionList(unittest.TestCase):
         self.assertEqual(build_option_list([53, 61]), "61")
 
     def test_multiple_options(self):
-        self.assertEqual(
-            build_option_list([53, 61, 57, 60, 12, 55]),
-            "61-57-60-12-55"
-        )
+        self.assertEqual(build_option_list([53, 61, 57, 60, 12, 55]), "61-57-60-12-55")
 
     def test_with_skipped_mixed(self):
         self.assertEqual(build_option_list([53, 50, 61, 81, 57]), "61-57")
@@ -130,8 +138,7 @@ class TestBuildParamList(unittest.TestCase):
 
     def test_multiple(self):
         self.assertEqual(
-            build_param_list([1, 3, 6, 15, 26, 28, 51, 58, 59]),
-            "1-3-6-15-26-28-51-58-59"
+            build_param_list([1, 3, 6, 15, 26, 28, 51, 58, 59]), "1-3-6-15-26-28-51-58-59"
         )
 
 
@@ -144,32 +151,32 @@ class TestGenerateJA4D(unittest.TestCase):
         result = generate_ja4d(pkt)
         self.assertIsNotNone(result)
         # Section a: disco + 0000 (no max size) + n (no req IP) + n (no FQDN)
-        parts = result.split('_')
+        parts = result.split("_")
         self.assertEqual(len(parts), 3)
         self.assertTrue(parts[0].startswith("disco"))
         self.assertEqual(parts[0][5:9], "0000")  # no max msg size
-        self.assertEqual(parts[0][9], "n")        # no requested IP
-        self.assertEqual(parts[0][10], "n")       # no FQDN
+        self.assertEqual(parts[0][9], "n")  # no requested IP
+        self.assertEqual(parts[0][10], "n")  # no FQDN
 
     def test_discover_with_max_size(self):
         pkt = _make_dhcp_packet(msg_type=1, max_msg_size=1500)
         result = generate_ja4d(pkt)
         self.assertIsNotNone(result)
-        parts = result.split('_')
+        parts = result.split("_")
         self.assertEqual(parts[0][5:9], "1500")
 
     def test_discover_with_request_ip_flag(self):
         pkt = _make_dhcp_packet(msg_type=1, request_ip=True)
         result = generate_ja4d(pkt)
         self.assertIsNotNone(result)
-        parts = result.split('_')
+        parts = result.split("_")
         self.assertEqual(parts[0][9], "i")
 
     def test_discover_with_fqdn_flag(self):
         pkt = _make_dhcp_packet(msg_type=1, fqdn=True)
         result = generate_ja4d(pkt)
         self.assertIsNotNone(result)
-        parts = result.split('_')
+        parts = result.split("_")
         self.assertEqual(parts[0][10], "d")
 
     def test_offer_message_type(self):
@@ -189,37 +196,37 @@ class TestGenerateJA4D(unittest.TestCase):
         pkt = _make_dhcp_packet(msg_type=1, param_request=params)
         result = generate_ja4d(pkt)
         self.assertIsNotNone(result)
-        parts = result.split('_')
+        parts = result.split("_")
         self.assertEqual(parts[2], "1-3-6-15")
 
     def test_no_param_request_section_c_is_00(self):
         pkt = _make_dhcp_packet(msg_type=1)
         result = generate_ja4d(pkt)
         self.assertIsNotNone(result)
-        parts = result.split('_')
+        parts = result.split("_")
         self.assertEqual(parts[2], "00")
 
     def test_extra_options_appear_in_section_b(self):
         pkt = _make_dhcp_packet(msg_type=1, options=[61, 12])
         result = generate_ja4d(pkt)
         self.assertIsNotNone(result)
-        parts = result.split('_')
+        parts = result.split("_")
         self.assertIn("61", parts[1])
         self.assertIn("12", parts[1])
 
     def test_skip_options_absent_from_section_b(self):
         pkt = _make_dhcp_packet(msg_type=1, options=[61])
         result = generate_ja4d(pkt)
-        parts = result.split('_')
+        parts = result.split("_")
         # 53 (msg type) is added by the builder but must not appear in section b
-        self.assertNotIn("53", parts[1].split('-'))
+        self.assertNotIn("53", parts[1].split("-"))
         # 255 (end) terminates the parse loop and is never recorded
-        self.assertNotIn("255", parts[1].split('-'))
+        self.assertNotIn("255", parts[1].split("-"))
 
     def test_max_msg_size_capped_at_9999(self):
         pkt = _make_dhcp_packet(msg_type=1, max_msg_size=65535)
         result = generate_ja4d(pkt)
-        parts = result.split('_')
+        parts = result.split("_")
         self.assertEqual(parts[0][5:9], "9999")
 
     def test_non_dhcp_port_returns_none(self):
@@ -229,6 +236,7 @@ class TestGenerateJA4D(unittest.TestCase):
 
     def test_tcp_packet_returns_none(self):
         from scapy.all import TCP
+
         pkt = IP() / TCP(sport=68, dport=67)
         self.assertIsNone(generate_ja4d(pkt))
 
@@ -258,6 +266,7 @@ class TestJA4DFingerprinter(unittest.TestCase):
 
     def test_non_dhcp_returns_none(self):
         from scapy.all import TCP
+
         pkt = IP() / TCP(sport=12345, dport=443)
         result = self.fp.process_packet(pkt)
         self.assertIsNone(result)
@@ -267,5 +276,5 @@ class TestJA4DFingerprinter(unittest.TestCase):
         self.fp.cleanup_connection("1.2.3.4", 68, "255.255.255.255", 67, "udp")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ja4d6_foxio.py
+++ b/tests/test_ja4d6_foxio.py
@@ -3,6 +3,7 @@
 Compares ja4plus output against the canonical Wireshark dissector
 expected values stored in tests/foxio_vectors/ja4_expected/.
 """
+
 import json
 import os
 
@@ -44,9 +45,7 @@ def test_ja4d6_matches_foxio_dhcpv6_pcap():
 
     for frame, want in expected.items():
         assert frame in actual, f"missing JA4D6 for frame {frame}"
-        assert actual[frame] == want, (
-            f"frame {frame}: got {actual[frame]!r}, want {want!r}"
-        )
+        assert actual[frame] == want, f"frame {frame}: got {actual[frame]!r}, want {want!r}"
 
 
 def test_message_type_table_completeness():

--- a/tests/test_ja4d_foxio.py
+++ b/tests/test_ja4d_foxio.py
@@ -3,6 +3,7 @@
 Compares ja4plus output against the canonical Wireshark dissector
 expected values stored in tests/foxio_vectors/ja4_expected/.
 """
+
 import json
 import os
 
@@ -44,6 +45,4 @@ def test_ja4d_matches_foxio_dhcp_pcapng():
 
     for frame, want in expected.items():
         assert frame in actual, f"missing JA4D for frame {frame}"
-        assert actual[frame] == want, (
-            f"frame {frame}: got {actual[frame]!r}, want {want!r}"
-        )
+        assert actual[frame] == want, f"frame {frame}: got {actual[frame]!r}, want {want!r}"

--- a/tests/test_ja4db.py
+++ b/tests/test_ja4db.py
@@ -99,9 +99,19 @@ class TestCLILookupFlag:
         import json
 
         result = subprocess.run(
-            ["python", "-m", "ja4plus.cli", "--format", "json", "--lookup",
-             "analyze", "tests/data/http.cap"],
-            capture_output=True, text=True, timeout=30,
+            [
+                "python",
+                "-m",
+                "ja4plus.cli",
+                "--format",
+                "json",
+                "--lookup",
+                "analyze",
+                "tests/data/http.cap",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode == 0 and result.stdout.strip():
             for line in result.stdout.strip().split("\n"):
@@ -113,9 +123,10 @@ class TestCLILookupFlag:
         import json
 
         result = subprocess.run(
-            ["python", "-m", "ja4plus.cli", "--format", "json",
-             "analyze", "tests/data/http.cap"],
-            capture_output=True, text=True, timeout=30,
+            ["python", "-m", "ja4plus.cli", "--format", "json", "analyze", "tests/data/http.cap"],
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode == 0 and result.stdout.strip():
             for line in result.stdout.strip().split("\n"):

--- a/tests/test_ja4h.py
+++ b/tests/test_ja4h.py
@@ -3,11 +3,12 @@ from scapy.all import IP, TCP, Raw
 from ja4plus.fingerprinters.ja4h import JA4HFingerprinter, generate_ja4h
 import binascii
 
+
 class TestJA4H(unittest.TestCase):
     def setUp(self):
         print("\nSetting up JA4H test...")
         self.ja4h_fp = JA4HFingerprinter()
-        
+
         # Create a mock HTTP request packet
         http_request = (
             "GET /index.html HTTP/1.1\r\n"
@@ -22,25 +23,30 @@ class TestJA4H(unittest.TestCase):
             "Cookie: session=abc123; theme=dark\r\n"
             "\r\n"
         )
-        
-        self.http_packet = IP(src="192.168.1.100", dst="93.184.216.34")/TCP(sport=54321, dport=80)/Raw(load=http_request)
+
+        self.http_packet = (
+            IP(src="192.168.1.100", dst="93.184.216.34")
+            / TCP(sport=54321, dport=80)
+            / Raw(load=http_request)
+        )
         print("Setup complete.")
-    
+
     def test_http_request_fingerprint(self):
         print("\nTesting JA4H with HTTP request...")
-        
+
         # Generate JA4H fingerprint
         ja4h_fp = self.ja4h_fp.process_packet(self.http_packet)
         print(f"JA4H fingerprint: {ja4h_fp}")
-        
+
         # Try direct generation
         if not ja4h_fp:
             print("Trying direct JA4H generation...")
             ja4h_fp = generate_ja4h(self.http_packet)
             print(f"Directly generated JA4H: {ja4h_fp}")
-        
+
         # Verify extracted HTTP info
         from ja4plus.utils.http_utils import extract_http_info
+
         http_info = extract_http_info(self.http_packet)
         if http_info:
             print("Extracted HTTP information:")
@@ -48,21 +54,22 @@ class TestJA4H(unittest.TestCase):
             print(f"  Path: {http_info.get('path')}")
             print(f"  Version: {http_info.get('version')}")
             print(f"  Header names: {http_info.get('headers')}")
-            if 'cookies' in http_info:
+            if "cookies" in http_info:
                 print("  Cookies:")
-                for name, value in http_info.get('cookies', {}).items():
+                for name, value in http_info.get("cookies", {}).items():
                     print(f"    {name}: {value}")
         else:
             print("No HTTP information extracted")
-        
+
         # We should get a non-None fingerprint
         self.assertIsNotNone(ja4h_fp, "JA4H fingerprinting failed")
-        
+
         # JA4H should follow the expected structure (a_b_c_d)
-        parts = ja4h_fp.split('_')
+        parts = ja4h_fp.split("_")
         self.assertEqual(len(parts), 4, f"JA4H fingerprint has incorrect format: {ja4h_fp}")
-        
+
         print("JA4H test successful.")
 
+
 if __name__ == "__main__":
-    unittest.main(verbosity=2) 
+    unittest.main(verbosity=2)

--- a/tests/test_ja4h_deep.py
+++ b/tests/test_ja4h_deep.py
@@ -12,8 +12,9 @@ from scapy.all import IP, TCP, Raw
 from ja4plus.fingerprinters.ja4h import JA4HFingerprinter, generate_ja4h
 
 
-def _make_http(method="GET", path="/", version="HTTP/1.1",
-               headers=None, cookie=None, referer=None, lang=None):
+def _make_http(
+    method="GET", path="/", version="HTTP/1.1", headers=None, cookie=None, referer=None, lang=None
+):
     """Build an HTTP request packet."""
     lines = [f"{method} {path} {version}"]
     if headers:
@@ -289,7 +290,7 @@ class TestJA4HFormat(unittest.TestCase):
         fp = generate_ja4h(packet)
         parts = fp.split("_")
         for i in range(1, 4):
-            self.assertEqual(len(parts[i]), 12, f"Part {i+1} should be 12 chars")
+            self.assertEqual(len(parts[i]), 12, f"Part {i + 1} should be 12 chars")
 
     def test_non_http_returns_none(self):
         packet = IP() / TCP(sport=12345, dport=80) / Raw(load=b"\x16\x03\x03")

--- a/tests/test_ja4h_reassembly.py
+++ b/tests/test_ja4h_reassembly.py
@@ -7,11 +7,14 @@ from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
 
 
 class TestJA4HReassembly(unittest.TestCase):
-
     def test_single_packet_still_works(self):
         fp = JA4HFingerprinter()
         http_data = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: test\r\n\r\n"
-        pkt = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=12345, dport=80, seq=100) / Raw(load=http_data)
+        pkt = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=80, seq=100)
+            / Raw(load=http_data)
+        )
         result = fp.process_packet(pkt)
         self.assertIsNotNone(result, "Single-packet HTTP should produce fingerprint")
 
@@ -19,12 +22,22 @@ class TestJA4HReassembly(unittest.TestCase):
         fp = JA4HFingerprinter()
         part1 = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n"
         part2 = b"User-Agent: Mozilla/5.0\r\nAccept: text/html\r\n\r\n"
-        pkt1 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=12345, dport=80, seq=100) / Raw(load=part1)
-        pkt2 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=12345, dport=80, seq=100 + len(part1)) / Raw(load=part2)
+        pkt1 = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=80, seq=100)
+            / Raw(load=part1)
+        )
+        pkt2 = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=80, seq=100 + len(part1))
+            / Raw(load=part2)
+        )
         result1 = fp.process_packet(pkt1)
         result2 = fp.process_packet(pkt2)
-        self.assertTrue(result1 is not None or result2 is not None,
-                        "Multi-segment HTTP should produce fingerprint")
+        self.assertTrue(
+            result1 is not None or result2 is not None,
+            "Multi-segment HTTP should produce fingerprint",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ja4h_spec.py
+++ b/tests/test_ja4h_spec.py
@@ -3,6 +3,7 @@
 - HTTP version: HTTP/1.0 -> '10', HTTP/1.1 -> '11', HTTP/2 -> '20', HTTP/3 -> '30'
 - Cookie-VALUES hash component sorts by NAME only
 """
+
 import hashlib
 import os
 
@@ -11,22 +12,24 @@ import pytest
 from ja4plus.fingerprinters.ja4h import _generate_ja4h_from_info, _http_version_to_str
 
 
-@pytest.mark.parametrize("version,expected", [
-    ("HTTP/1.0", "10"),
-    ("HTTP/1.1", "11"),
-    ("HTTP/2",   "20"),
-    ("HTTP/2.0", "20"),
-    ("HTTP/3",   "30"),
-    ("HTTP/3.0", "30"),
-    # Defensive: empty falls back to '11' (most common)
-    ("",         "11"),
-])
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("HTTP/1.0", "10"),
+        ("HTTP/1.1", "11"),
+        ("HTTP/2", "20"),
+        ("HTTP/2.0", "20"),
+        ("HTTP/3", "30"),
+        ("HTTP/3.0", "30"),
+        # Defensive: empty falls back to '11' (most common)
+        ("", "11"),
+    ],
+)
 def test_http_version_mapping(version, expected):
     assert _http_version_to_str(version) == expected
 
 
-def _info(method="GET", version="HTTP/1.1", headers=None, cookies=None,
-          referer="", language=""):
+def _info(method="GET", version="HTTP/1.1", headers=None, cookies=None, referer="", language=""):
     return {
         "method": method,
         "path": "/",
@@ -61,12 +64,16 @@ def test_http_version_in_part_a_for_http11():
 
 def test_cookie_values_hash_sorts_by_name_only():
     """Same cookie names + same values, different INPUT order -> same hash."""
-    fp1 = _generate_ja4h_from_info(_info(
-        cookies={"alpha": "1", "bravo": "2", "charlie": "3"},
-    ))
-    fp2 = _generate_ja4h_from_info(_info(
-        cookies={"charlie": "3", "alpha": "1", "bravo": "2"},
-    ))
+    fp1 = _generate_ja4h_from_info(
+        _info(
+            cookies={"alpha": "1", "bravo": "2", "charlie": "3"},
+        )
+    )
+    fp2 = _generate_ja4h_from_info(
+        _info(
+            cookies={"charlie": "3", "alpha": "1", "bravo": "2"},
+        )
+    )
     assert fp1 == fp2
 
     # The sorted-by-name string is "alpha=1,bravo=2,charlie=3"
@@ -76,9 +83,11 @@ def test_cookie_values_hash_sorts_by_name_only():
 
 def test_cookie_values_hash_input_form_is_name_value_pairs_sorted_by_name():
     """Verify the exact hash input string structure."""
-    fp = _generate_ja4h_from_info(_info(
-        cookies={"zeta": "z", "alpha": "a"},
-    ))
+    fp = _generate_ja4h_from_info(
+        _info(
+            cookies={"zeta": "z", "alpha": "a"},
+        )
+    )
     expected = hashlib.sha256(b"alpha=a,zeta=z").hexdigest()[:12]
     assert fp.split("_")[-1] == expected
 
@@ -109,6 +118,4 @@ def test_http2_with_cookies_pcap_produces_20_in_part_a():
         version = fingerprint[2:4]
         # http2 captures may also yield '11' if a fallback HTTP/1.1 parse
         # happened — accept either as long as the structure is sane.
-        assert version in {"20", "11"}, (
-            f"unexpected version {version!r} in {fingerprint}"
-        )
+        assert version in {"20", "11"}, f"unexpected version {version!r} in {fingerprint}"

--- a/tests/test_ja4l.py
+++ b/tests/test_ja4l.py
@@ -24,14 +24,14 @@ class TestJA4L(unittest.TestCase):
         # Simulate timestamps from a real handshake
         now = time.time()
         conn = {
-            'proto': 'tcp',
-            'timestamps': {
-                'A': now - 0.050,  # SYN 50ms ago
-                'B': now - 0.020,  # SYN-ACK 20ms ago
+            "proto": "tcp",
+            "timestamps": {
+                "A": now - 0.050,  # SYN 50ms ago
+                "B": now - 0.020,  # SYN-ACK 20ms ago
             },
-            'ttls': {
-                'client': 128,
-                'server': 64,
+            "ttls": {
+                "client": 128,
+                "server": 64,
             },
         }
 
@@ -46,15 +46,19 @@ class TestJA4L(unittest.TestCase):
 
         # Server should have generated from the SYN-ACK
         self.assertIsNotNone(ja4l_server, "JA4L server fingerprinting failed")
-        self.assertTrue(ja4l_server.startswith("JA4L-S="), "Server fingerprint should start with JA4L-S=")
+        self.assertTrue(
+            ja4l_server.startswith("JA4L-S="), "Server fingerprint should start with JA4L-S="
+        )
 
         # Client should have generated from the ACK
         self.assertIsNotNone(ja4l_client, "JA4L client fingerprinting failed")
-        self.assertTrue(ja4l_client.startswith("JA4L-C="), "Client fingerprint should start with JA4L-C=")
+        self.assertTrue(
+            ja4l_client.startswith("JA4L-C="), "Client fingerprint should start with JA4L-C="
+        )
 
         # Both should contain TTL
-        self.assertRegex(ja4l_server, r'JA4L-S=\d+_\d+')
-        self.assertRegex(ja4l_client, r'JA4L-C=\d+_\d+')
+        self.assertRegex(ja4l_server, r"JA4L-S=\d+_\d+")
+        self.assertRegex(ja4l_client, r"JA4L-C=\d+_\d+")
 
     def test_ja4l_fingerprinter_class(self):
         """Test the JA4LFingerprinter class processes handshake correctly."""
@@ -99,7 +103,7 @@ class TestJA4L(unittest.TestCase):
     def test_ja4l_hop_count(self):
         """Test hop count estimation."""
         self.assertEqual(self.ja4l_fp.estimate_hop_count(120), 8)  # 128 - 120
-        self.assertEqual(self.ja4l_fp.estimate_hop_count(60), 4)   # 64 - 60
+        self.assertEqual(self.ja4l_fp.estimate_hop_count(60), 4)  # 64 - 60
         self.assertEqual(self.ja4l_fp.estimate_hop_count(250), 5)  # 255 - 250
 
 

--- a/tests/test_ja4l_udp_direction.py
+++ b/tests/test_ja4l_udp_direction.py
@@ -5,6 +5,7 @@ came from the lexicographically-larger IP (direction='reverse' in the
 internal conn_key). The fix: identify the client by FIRST-PACKET ordering,
 not by conn_key direction.
 """
+
 import os
 
 import pytest
@@ -26,9 +27,7 @@ def test_udp_timing_works_with_lex_smaller_client():
     fp = JA4LFingerprinter()
     # client 10.0.0.1 -> server 10.0.0.2
     fp.process_packet(_udp_packet("10.0.0.1", "10.0.0.2", 50000, 443, t=0.0))
-    result = fp.process_packet(
-        _udp_packet("10.0.0.2", "10.0.0.1", 443, 50000, t=0.001)
-    )
+    result = fp.process_packet(_udp_packet("10.0.0.2", "10.0.0.1", 443, 50000, t=0.001))
     assert result is not None
     assert result.startswith("JA4L-S=")
 
@@ -45,9 +44,7 @@ def test_udp_timing_works_with_lex_larger_client():
     fp = JA4LFingerprinter()
     # client 10.0.0.99 -> server 10.0.0.1 — client IP is lexicographically greater
     fp.process_packet(_udp_packet("10.0.0.99", "10.0.0.1", 50000, 443, t=0.0))
-    result = fp.process_packet(
-        _udp_packet("10.0.0.1", "10.0.0.99", 443, 50000, t=0.002)
-    )
+    result = fp.process_packet(_udp_packet("10.0.0.1", "10.0.0.99", 443, 50000, t=0.002))
     assert result is not None, "JA4L-S not emitted for server-direction-first conn"
     assert result.startswith("JA4L-S=")
 

--- a/tests/test_ja4s.py
+++ b/tests/test_ja4s.py
@@ -4,40 +4,40 @@ from scapy.all import IP, TCP, Raw
 from ja4plus.fingerprinters.ja4s import JA4SFingerprinter, generate_ja4s
 
 
-def build_server_hello_bytes(version=0x0303, cipher=0xc02f, extensions=None):
+def build_server_hello_bytes(version=0x0303, cipher=0xC02F, extensions=None):
     """Build a minimal TLS ServerHello raw bytes payload."""
     if extensions is None:
         extensions = []
 
     # Handshake: ServerHello
     server_hello = bytearray()
-    server_hello += version.to_bytes(2, 'big')  # Server version
-    server_hello += b'\x00' * 32  # Random (32 bytes)
-    server_hello += b'\x00'  # Session ID length (0)
-    server_hello += cipher.to_bytes(2, 'big')  # Cipher suite
-    server_hello += b'\x00'  # Compression method
+    server_hello += version.to_bytes(2, "big")  # Server version
+    server_hello += b"\x00" * 32  # Random (32 bytes)
+    server_hello += b"\x00"  # Session ID length (0)
+    server_hello += cipher.to_bytes(2, "big")  # Cipher suite
+    server_hello += b"\x00"  # Compression method
 
     # Extensions
     ext_data = bytearray()
     for ext_type in extensions:
-        ext_data += ext_type.to_bytes(2, 'big')  # Extension type
-        ext_data += b'\x00\x00'  # Extension data length (0)
+        ext_data += ext_type.to_bytes(2, "big")  # Extension type
+        ext_data += b"\x00\x00"  # Extension data length (0)
 
     if ext_data:
-        server_hello += len(ext_data).to_bytes(2, 'big')
+        server_hello += len(ext_data).to_bytes(2, "big")
         server_hello += ext_data
 
     # Handshake header
     handshake = bytearray()
-    handshake += b'\x02'  # ServerHello type
-    handshake += len(server_hello).to_bytes(3, 'big')
+    handshake += b"\x02"  # ServerHello type
+    handshake += len(server_hello).to_bytes(3, "big")
     handshake += server_hello
 
     # TLS record header
     record = bytearray()
-    record += b'\x16'  # Handshake content type
-    record += b'\x03\x03'  # TLS 1.2 record version
-    record += len(handshake).to_bytes(2, 'big')
+    record += b"\x16"  # Handshake content type
+    record += b"\x03\x03"  # TLS 1.2 record version
+    record += len(handshake).to_bytes(2, "big")
     record += handshake
 
     return bytes(record)
@@ -54,16 +54,18 @@ class TestJA4S(unittest.TestCase):
 
     def test_server_hello_fingerprint(self):
         """Test fingerprinting a TLS ServerHello"""
-        extensions = [0x0000, 0x000b, 0xff01]
+        extensions = [0x0000, 0x000B, 0xFF01]
         raw_data = build_server_hello_bytes(
             version=0x0303,
-            cipher=0xc02f,
+            cipher=0xC02F,
             extensions=extensions,
         )
 
-        packet = IP(src="93.184.216.34", dst="192.168.1.100") / TCP(
-            sport=443, dport=54321
-        ) / Raw(load=raw_data)
+        packet = (
+            IP(src="93.184.216.34", dst="192.168.1.100")
+            / TCP(sport=443, dport=54321)
+            / Raw(load=raw_data)
+        )
 
         fingerprint = self.ja4s_fp.process_packet(packet)
 
@@ -71,20 +73,20 @@ class TestJA4S(unittest.TestCase):
         print(f"Generated JA4S fingerprint: {fingerprint}")
 
         # JA4S format: <proto><version><ext_count><alpn>_<cipher>_<ext_hash>
-        parts = fingerprint.split('_')
+        parts = fingerprint.split("_")
         self.assertEqual(len(parts), 3, "JA4S fingerprint has incorrect format")
 
         # First part: t (TCP), 12 (TLS 1.2), 03 (3 extensions), 00 (no ALPN)
-        self.assertEqual(parts[0], 't120300')
+        self.assertEqual(parts[0], "t120300")
 
         # Second part: cipher in hex
-        self.assertEqual(parts[1], 'c02f')
+        self.assertEqual(parts[1], "c02f")
 
         # Third part: 12-char hash of extensions
         self.assertEqual(len(parts[2]), 12)
 
         # Verify extension hash manually
-        ext_str = ','.join([f"{e:04x}" for e in extensions])
+        ext_str = ",".join([f"{e:04x}" for e in extensions])
         expected_hash = hashlib.sha256(ext_str.encode()).hexdigest()[:12]
         self.assertEqual(parts[2], expected_hash)
 
@@ -96,25 +98,25 @@ class TestJA4S(unittest.TestCase):
         # Build a ServerHello that advertises TLS 1.2 in record but has
         # supported_versions extension selecting TLS 1.3
         server_hello = bytearray()
-        server_hello += b'\x03\x03'  # TLS 1.2 in handshake
-        server_hello += b'\x00' * 32  # Random
-        server_hello += b'\x00'  # Session ID length
-        server_hello += b'\x13\x01'  # TLS_AES_128_GCM_SHA256
-        server_hello += b'\x00'  # Compression
+        server_hello += b"\x03\x03"  # TLS 1.2 in handshake
+        server_hello += b"\x00" * 32  # Random
+        server_hello += b"\x00"  # Session ID length
+        server_hello += b"\x13\x01"  # TLS_AES_128_GCM_SHA256
+        server_hello += b"\x00"  # Compression
 
         # Extensions with supported_versions selecting TLS 1.3
         ext_data = bytearray()
         # supported_versions extension (0x002b)
-        ext_data += b'\x00\x2b'  # Extension type
-        ext_data += b'\x00\x02'  # Length = 2
-        ext_data += b'\x03\x04'  # TLS 1.3
+        ext_data += b"\x00\x2b"  # Extension type
+        ext_data += b"\x00\x02"  # Length = 2
+        ext_data += b"\x03\x04"  # TLS 1.3
 
-        server_hello += len(ext_data).to_bytes(2, 'big')
+        server_hello += len(ext_data).to_bytes(2, "big")
         server_hello += ext_data
 
         # Wrap in handshake + record headers
-        handshake = b'\x02' + len(server_hello).to_bytes(3, 'big') + server_hello
-        record = b'\x16\x03\x03' + len(handshake).to_bytes(2, 'big') + handshake
+        handshake = b"\x02" + len(server_hello).to_bytes(3, "big") + server_hello
+        record = b"\x16\x03\x03" + len(handshake).to_bytes(2, "big") + handshake
 
         packet = IP() / TCP(sport=443, dport=54321) / Raw(load=bytes(record))
         fingerprint = self.ja4s_fp.process_packet(packet)
@@ -122,22 +124,22 @@ class TestJA4S(unittest.TestCase):
         self.assertIsNotNone(fingerprint)
         print(f"TLS 1.3 JA4S: {fingerprint}")
 
-        parts = fingerprint.split('_')
+        parts = fingerprint.split("_")
         # Should detect TLS 1.3 from supported_versions
-        self.assertTrue(parts[0].startswith('t13'))
+        self.assertTrue(parts[0].startswith("t13"))
 
     def test_non_server_hello_ignored(self):
         """Test that non-ServerHello packets are ignored."""
         # Build a ClientHello instead
         client_hello = bytearray()
-        client_hello += b'\x03\x03'  # Version
-        client_hello += b'\x00' * 32  # Random
-        client_hello += b'\x00'  # Session ID length
-        client_hello += b'\x00\x02\x13\x01'  # Cipher suites
-        client_hello += b'\x01\x00'  # Compression
+        client_hello += b"\x03\x03"  # Version
+        client_hello += b"\x00" * 32  # Random
+        client_hello += b"\x00"  # Session ID length
+        client_hello += b"\x00\x02\x13\x01"  # Cipher suites
+        client_hello += b"\x01\x00"  # Compression
 
-        handshake = b'\x01' + len(client_hello).to_bytes(3, 'big') + client_hello
-        record = b'\x16\x03\x03' + len(handshake).to_bytes(2, 'big') + handshake
+        handshake = b"\x01" + len(client_hello).to_bytes(3, "big") + client_hello
+        record = b"\x16\x03\x03" + len(handshake).to_bytes(2, "big") + handshake
 
         packet = IP() / TCP(sport=54321, dport=443) / Raw(load=bytes(record))
         fingerprint = self.ja4s_fp.process_packet(packet)
@@ -154,5 +156,5 @@ class TestJA4S(unittest.TestCase):
         self.assertEqual(len(self.ja4s_fp.fingerprints), 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ja4ssh_deep.py
+++ b/tests/test_ja4ssh_deep.py
@@ -24,27 +24,34 @@ from ja4plus.utils.ssh_utils import (
 
 def _ssh_banner(src, dst, sport, dport, banner):
     """Build an SSH banner packet."""
-    return (Ether() / IP(src=src, dst=dst)
-            / TCP(sport=sport, dport=dport)
-            / Raw(load=banner))
+    return Ether() / IP(src=src, dst=dst) / TCP(sport=sport, dport=dport) / Raw(load=banner)
 
 
 def _ssh_data(src, dst, sport, dport, size):
     """Build an SSH data packet with specified payload size."""
-    return (Ether() / IP(src=src, dst=dst)
-            / TCP(sport=sport, dport=dport)
-            / Raw(load=b"SSH-2.0-" + b"X" * (size - 8)))
+    return (
+        Ether()
+        / IP(src=src, dst=dst)
+        / TCP(sport=sport, dport=dport)
+        / Raw(load=b"SSH-2.0-" + b"X" * (size - 8))
+    )
 
 
-def _kexinit_packet(src, dst, sport, dport, kex="curve25519-sha256",
-                     enc="aes128-ctr", mac="hmac-sha2-256", comp="none"):
+def _kexinit_packet(
+    src,
+    dst,
+    sport,
+    dport,
+    kex="curve25519-sha256",
+    enc="aes128-ctr",
+    mac="hmac-sha2-256",
+    comp="none",
+):
     """Build a simplified KEXINIT packet."""
-    payload = (b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAA"
-               b"SSH_MSG_KEXINIT" +
-               f"{kex};{enc};{mac};{comp}".encode())
-    return (Ether() / IP(src=src, dst=dst)
-            / TCP(sport=sport, dport=dport)
-            / Raw(load=payload))
+    payload = (
+        b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAASSH_MSG_KEXINIT" + f"{kex};{enc};{mac};{comp}".encode()
+    )
+    return Ether() / IP(src=src, dst=dst) / TCP(sport=sport, dport=dport) / Raw(load=payload)
 
 
 class TestJA4SSHInteractiveSession(unittest.TestCase):
@@ -55,10 +62,12 @@ class TestJA4SSHInteractiveSession(unittest.TestCase):
         fp = JA4SSHFingerprinter(packet_count=10)
 
         # Banners
-        fp.process_packet(_ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22,
-                                       b"SSH-2.0-OpenSSH_8.2p1\r\n"))
-        fp.process_packet(_ssh_banner("10.0.0.2", "10.0.0.1", 22, 52416,
-                                       b"SSH-2.0-OpenSSH_7.6p1\r\n"))
+        fp.process_packet(
+            _ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22, b"SSH-2.0-OpenSSH_8.2p1\r\n")
+        )
+        fp.process_packet(
+            _ssh_banner("10.0.0.2", "10.0.0.1", 22, 52416, b"SSH-2.0-OpenSSH_7.6p1\r\n")
+        )
 
         # Interactive data: 36-byte packets (SSH-2.0- + 28 bytes)
         result = None
@@ -85,10 +94,12 @@ class TestJA4SSHFileTransfer(unittest.TestCase):
         """File download: server sends large packets."""
         fp = JA4SSHFingerprinter(packet_count=10)
 
-        fp.process_packet(_ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22,
-                                       b"SSH-2.0-OpenSSH_8.2p1\r\n"))
-        fp.process_packet(_ssh_banner("10.0.0.2", "10.0.0.1", 22, 52416,
-                                       b"SSH-2.0-OpenSSH_7.6p1\r\n"))
+        fp.process_packet(
+            _ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22, b"SSH-2.0-OpenSSH_8.2p1\r\n")
+        )
+        fp.process_packet(
+            _ssh_banner("10.0.0.2", "10.0.0.1", 22, 52416, b"SSH-2.0-OpenSSH_7.6p1\r\n")
+        )
 
         result = None
         for i in range(20):
@@ -173,8 +184,9 @@ class TestJA4SSHHASSSExtraction(unittest.TestCase):
         enc = "aes128-ctr"
         mac = "hmac-sha2-256"
         comp = "none"
-        packet = _kexinit_packet("10.0.0.1", "10.0.0.2", 52416, 22,
-                                  kex=kex, enc=enc, mac=mac, comp=comp)
+        packet = _kexinit_packet(
+            "10.0.0.1", "10.0.0.2", 52416, 22, kex=kex, enc=enc, mac=mac, comp=comp
+        )
         result = generate_ja4ssh(packet)
         hassh_value = result.split("_")[1]
 
@@ -184,10 +196,12 @@ class TestJA4SSHHASSSExtraction(unittest.TestCase):
 
     def test_different_algorithms_different_hassh(self):
         """Different algorithm sets should produce different HASSH."""
-        pkt_a = _kexinit_packet("10.0.0.1", "10.0.0.2", 52416, 22,
-                                 kex="curve25519-sha256", enc="aes128-ctr")
-        pkt_b = _kexinit_packet("10.0.0.1", "10.0.0.2", 52416, 22,
-                                 kex="diffie-hellman-group14-sha256", enc="aes256-ctr")
+        pkt_a = _kexinit_packet(
+            "10.0.0.1", "10.0.0.2", 52416, 22, kex="curve25519-sha256", enc="aes128-ctr"
+        )
+        pkt_b = _kexinit_packet(
+            "10.0.0.1", "10.0.0.2", 52416, 22, kex="diffie-hellman-group14-sha256", enc="aes256-ctr"
+        )
         result_a = generate_ja4ssh(pkt_a)
         result_b = generate_ja4ssh(pkt_b)
         self.assertNotEqual(result_a, result_b)
@@ -228,11 +242,13 @@ class TestJA4SSHConnectionTracking(unittest.TestCase):
         fp = JA4SSHFingerprinter(packet_count=5)
 
         # Connection 1
-        fp.process_packet(_ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22,
-                                       b"SSH-2.0-OpenSSH_8.2p1\r\n"))
+        fp.process_packet(
+            _ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22, b"SSH-2.0-OpenSSH_8.2p1\r\n")
+        )
         # Connection 2
-        fp.process_packet(_ssh_banner("10.0.0.3", "10.0.0.4", 52417, 22,
-                                       b"SSH-2.0-OpenSSH_8.2p1\r\n"))
+        fp.process_packet(
+            _ssh_banner("10.0.0.3", "10.0.0.4", 52417, 22, b"SSH-2.0-OpenSSH_8.2p1\r\n")
+        )
 
         self.assertEqual(len(fp.connections), 2)
 
@@ -240,8 +256,9 @@ class TestJA4SSHConnectionTracking(unittest.TestCase):
         """HASSH should be collected in connection tracking."""
         fp = JA4SSHFingerprinter(packet_count=100)
 
-        fp.process_packet(_ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22,
-                                       b"SSH-2.0-OpenSSH_8.2p1\r\n"))
+        fp.process_packet(
+            _ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22, b"SSH-2.0-OpenSSH_8.2p1\r\n")
+        )
         fp.process_packet(_kexinit_packet("10.0.0.1", "10.0.0.2", 52416, 22))
 
         hassh_fps = fp.get_hassh_fingerprints()
@@ -259,8 +276,9 @@ class TestJA4SSHFingerprinterClass(unittest.TestCase):
 
     def test_reset(self):
         fp = JA4SSHFingerprinter(packet_count=10)
-        fp.process_packet(_ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22,
-                                       b"SSH-2.0-OpenSSH_8.2p1\r\n"))
+        fp.process_packet(
+            _ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22, b"SSH-2.0-OpenSSH_8.2p1\r\n")
+        )
         fp.reset()
         self.assertEqual(len(fp.fingerprints), 0)
         self.assertEqual(len(fp.connections), 0)
@@ -269,9 +287,12 @@ class TestJA4SSHFingerprinterClass(unittest.TestCase):
     def test_non_ssh_ignored(self):
         """Non-SSH packets should be ignored."""
         fp = JA4SSHFingerprinter(packet_count=10)
-        packet = (Ether() / IP(src="10.0.0.1", dst="10.0.0.2")
-                  / TCP(sport=12345, dport=22)
-                  / Raw(load=b"GET / HTTP/1.1\r\n\r\n"))
+        packet = (
+            Ether()
+            / IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=22)
+            / Raw(load=b"GET / HTTP/1.1\r\n\r\n")
+        )
         result = fp.process_packet(packet)
         self.assertIsNone(result)
 
@@ -286,9 +307,13 @@ class TestJA4SSHFingerprinterClass(unittest.TestCase):
         """Packet without TCP should return None."""
         fp = JA4SSHFingerprinter(packet_count=10)
         from scapy.all import UDP
-        packet = (Ether() / IP(src="10.0.0.1", dst="10.0.0.2")
-                  / UDP(sport=52416, dport=22)
-                  / Raw(load=b"SSH-2.0-test\r\n"))
+
+        packet = (
+            Ether()
+            / IP(src="10.0.0.1", dst="10.0.0.2")
+            / UDP(sport=52416, dport=22)
+            / Raw(load=b"SSH-2.0-test\r\n")
+        )
         result = fp.process_packet(packet)
         self.assertIsNone(result)
 
@@ -299,10 +324,12 @@ class TestJA4SSHFormat(unittest.TestCase):
     def test_format_three_parts(self):
         fp = JA4SSHFingerprinter(packet_count=5)
 
-        fp.process_packet(_ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22,
-                                       b"SSH-2.0-OpenSSH_8.2p1\r\n"))
-        fp.process_packet(_ssh_banner("10.0.0.2", "10.0.0.1", 22, 52416,
-                                       b"SSH-2.0-OpenSSH_7.6p1\r\n"))
+        fp.process_packet(
+            _ssh_banner("10.0.0.1", "10.0.0.2", 52416, 22, b"SSH-2.0-OpenSSH_8.2p1\r\n")
+        )
+        fp.process_packet(
+            _ssh_banner("10.0.0.2", "10.0.0.1", 22, 52416, b"SSH-2.0-OpenSSH_7.6p1\r\n")
+        )
 
         result = None
         for i in range(20):

--- a/tests/test_ja4ssh_direction.py
+++ b/tests/test_ja4ssh_direction.py
@@ -7,26 +7,27 @@ from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
 
 
 class TestSSHDirectionNonStandardPort(unittest.TestCase):
-
     def test_lower_port_is_server(self):
         """Port 2222 (lower) should be server, 50000 (higher) should be client."""
         fp = JA4SSHFingerprinter(packet_count=1)
-        pkt = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
-            sport=50000, dport=2222
-        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        pkt = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=50000, dport=2222)
+            / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        )
         fp.process_packet(pkt)
         self.assertEqual(len(fp.connections), 1)
         conn = list(fp.connections.values())[0]
-        self.assertEqual(conn["client_ip"], "10.0.0.1",
-                         "Higher port (50000) should be client")
-        self.assertEqual(conn["server_ip"], "10.0.0.2",
-                         "Lower port (2222) should be server")
+        self.assertEqual(conn["client_ip"], "10.0.0.1", "Higher port (50000) should be client")
+        self.assertEqual(conn["server_ip"], "10.0.0.2", "Lower port (2222) should be server")
 
     def test_standard_port_22_unchanged(self):
         fp = JA4SSHFingerprinter(packet_count=1)
-        pkt = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
-            sport=50000, dport=22
-        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        pkt = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=50000, dport=22)
+            / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        )
         fp.process_packet(pkt)
         conn = list(fp.connections.values())[0]
         self.assertEqual(conn["client_ip"], "10.0.0.1")
@@ -34,13 +35,17 @@ class TestSSHDirectionNonStandardPort(unittest.TestCase):
 
     def test_server_to_client_nonstandard(self):
         fp = JA4SSHFingerprinter(packet_count=1)
-        pkt1 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
-            sport=50000, dport=2222
-        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        pkt1 = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=50000, dport=2222)
+            / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        )
         fp.process_packet(pkt1)
-        pkt2 = IP(src="10.0.0.2", dst="10.0.0.1") / TCP(
-            sport=2222, dport=50000
-        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9p1\r\n")
+        pkt2 = (
+            IP(src="10.0.0.2", dst="10.0.0.1")
+            / TCP(sport=2222, dport=50000)
+            / Raw(load=b"SSH-2.0-OpenSSH_8.9p1\r\n")
+        )
         fp.process_packet(pkt2)
         conn = list(fp.connections.values())[0]
         self.assertIsNotNone(conn["client_id"])
@@ -55,34 +60,34 @@ class TestSSHBareACKCounting(unittest.TestCase):
         fp = JA4SSHFingerprinter(packet_count=200)
 
         # Establish SSH connection with a banner
-        banner = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
-            sport=50000, dport=22
-        ) / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        banner = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=50000, dport=22)
+            / Raw(load=b"SSH-2.0-OpenSSH_8.9\r\n")
+        )
         fp.process_packet(banner)
 
         # Send bare ACKs (no Raw layer) — these should be counted
         for _ in range(5):
-            ack = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
-                sport=50000, dport=22, flags="A"
-            )
+            ack = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=50000, dport=22, flags="A")
             fp.process_packet(ack)
 
         conn = list(fp.connections.values())[0]
-        self.assertEqual(conn["bare_acks"]["client"], 5,
-                         "Bare ACKs should be counted for known SSH connections")
+        self.assertEqual(
+            conn["bare_acks"]["client"], 5, "Bare ACKs should be counted for known SSH connections"
+        )
 
     def test_bare_acks_not_counted_for_unknown_connections(self):
         """Bare ACKs for unknown connections should be ignored."""
         fp = JA4SSHFingerprinter(packet_count=200)
 
         # Send bare ACK without any prior SSH data
-        ack = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
-            sport=50000, dport=80, flags="A"
-        )
+        ack = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=50000, dport=80, flags="A")
         fp.process_packet(ack)
 
-        self.assertEqual(len(fp.connections), 0,
-                         "Should not create connection for non-SSH bare ACK")
+        self.assertEqual(
+            len(fp.connections), 0, "Should not create connection for non-SSH bare ACK"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ja4ssh_spec.py
+++ b/tests/test_ja4ssh_spec.py
@@ -3,6 +3,7 @@
 When multiple packet sizes have the same modal frequency, the smallest
 value must win.
 """
+
 from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
 
 

--- a/tests/test_ja4t.py
+++ b/tests/test_ja4t.py
@@ -2,22 +2,23 @@ import unittest
 from scapy.all import IP, TCP
 from ja4plus.fingerprinters.ja4t import JA4TFingerprinter, generate_ja4t
 
+
 class TestJA4T(unittest.TestCase):
     def setUp(self):
         """Set up test cases"""
         print("\nSetting up JA4T test cases...")
         self.ja4t = JA4TFingerprinter()
-        
+
         # Create a mock TCP packet with typical Chrome/Windows values
-        self.tcp_packet = IP()/TCP(
+        self.tcp_packet = IP() / TCP(
             window=65535,
             options=[
-                ('NOP', None),           # 1
-                ('MSS', 1460),           # 2
-                ('WScale', 7),           # 3
-                ('SAckOK', ''),          # 4
-                ('Timestamp', (0,0))     # 8
-            ]
+                ("NOP", None),  # 1
+                ("MSS", 1460),  # 2
+                ("WScale", 7),  # 3
+                ("SAckOK", ""),  # 4
+                ("Timestamp", (0, 0)),  # 8
+            ],
         )
         print(f"Created test packet with window size {self.tcp_packet[TCP].window}")
 
@@ -29,25 +30,27 @@ class TestJA4T(unittest.TestCase):
         self.assertIsNotNone(fingerprint)
 
         # Check format: window_options_mss_wscale
-        parts = fingerprint.split('_')
+        parts = fingerprint.split("_")
         self.assertEqual(len(parts), 4)
 
         # Check values - options preserve original packet order per JA4T spec
-        self.assertEqual(parts[0], '65535')  # Window size
-        self.assertEqual(parts[1], '1-2-3-4-8')  # Options in original order (NOP,MSS,WScale,SAckOK,Timestamp)
-        self.assertEqual(parts[2], '1460')  # MSS
-        self.assertEqual(parts[3], '7')  # Window scale
+        self.assertEqual(parts[0], "65535")  # Window size
+        self.assertEqual(
+            parts[1], "1-2-3-4-8"
+        )  # Options in original order (NOP,MSS,WScale,SAckOK,Timestamp)
+        self.assertEqual(parts[2], "1460")  # MSS
+        self.assertEqual(parts[3], "7")  # Window scale
         print("Format test passed")
 
     def test_different_window_sizes(self):
         """Test different window sizes"""
         print("\nTesting different window sizes...")
         packets = [
-            (IP()/TCP(window=65535), '65535'),
-            (IP()/TCP(window=29200), '29200'),
-            (IP()/TCP(window=16384), '16384')
+            (IP() / TCP(window=65535), "65535"),
+            (IP() / TCP(window=29200), "29200"),
+            (IP() / TCP(window=16384), "16384"),
         ]
-        
+
         for packet, expected in packets:
             fingerprint = generate_ja4t(packet)
             print(f"Window size {expected} -> {fingerprint}")
@@ -59,39 +62,40 @@ class TestJA4T(unittest.TestCase):
         print("\nTesting TCP option ordering...")
         # Test with options in a specific order - JA4T preserves original order
         options = [
-            ('MSS', 1460),
-            ('NOP', None),
-            ('WScale', 7),
-            ('SAckOK', ''),
-            ('Timestamp', (0,0))
+            ("MSS", 1460),
+            ("NOP", None),
+            ("WScale", 7),
+            ("SAckOK", ""),
+            ("Timestamp", (0, 0)),
         ]
 
-        packet = IP()/TCP(window=65535, options=options)
+        packet = IP() / TCP(window=65535, options=options)
         fingerprint = generate_ja4t(packet)
         print(f"Options in original order -> {fingerprint}")
 
         # Options should preserve original order: MSS(2), NOP(1), WScale(3), SAckOK(4), Timestamp(8)
-        self.assertTrue('2-1-3-4-8' in fingerprint)
+        self.assertTrue("2-1-3-4-8" in fingerprint)
         print("Option ordering test passed")
 
     def test_fingerprinter_class(self):
         """Test the JA4TFingerprinter class"""
         print("\nTesting JA4TFingerprinter class...")
-        
+
         # Process a packet
         fingerprint = self.ja4t.process_packet(self.tcp_packet)
         print(f"Processed fingerprint: {fingerprint}")
         self.assertIsNotNone(fingerprint)
-        
+
         # Check stored fingerprints
         stored = self.ja4t.get_fingerprints()
         self.assertEqual(len(stored), 1)
-        self.assertEqual(stored[0]['fingerprint'], fingerprint)
-        
+        self.assertEqual(stored[0]["fingerprint"], fingerprint)
+
         # Test reset
         self.ja4t.reset()
         self.assertEqual(len(self.ja4t.get_fingerprints()), 0)
         print("✓ Fingerprinter class test passed")
 
-if __name__ == '__main__':
-    unittest.main(verbosity=2) 
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_ja4t_deep.py
+++ b/tests/test_ja4t_deep.py
@@ -16,13 +16,17 @@ from ja4plus.fingerprinters.ja4ts import JA4TSFingerprinter, generate_ja4ts
 # JA4T (TCP SYN) deep tests
 # ===========================================================================
 
+
 class TestJA4TOptionOrderPreservation(unittest.TestCase):
     """CRITICAL: TCP options must preserve original order (never sorted)."""
 
     def test_mss_nop_wscale_order(self):
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=65535,
-            options=[("MSS", 1460), ("NOP", None), ("WScale", 7)]
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=65535,
+            options=[("MSS", 1460), ("NOP", None), ("WScale", 7)],
         )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "2-1-3")
@@ -30,16 +34,22 @@ class TestJA4TOptionOrderPreservation(unittest.TestCase):
     def test_nop_mss_wscale_order(self):
         """Different order should produce different options string."""
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=65535,
-            options=[("NOP", None), ("MSS", 1460), ("WScale", 7)]
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=65535,
+            options=[("NOP", None), ("MSS", 1460), ("WScale", 7)],
         )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "1-2-3")
 
     def test_wscale_sackok_mss_order(self):
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=65535,
-            options=[("WScale", 7), ("SAckOK", ""), ("MSS", 1460)]
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=65535,
+            options=[("WScale", 7), ("SAckOK", ""), ("MSS", 1460)],
         )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "3-4-2")
@@ -47,11 +57,17 @@ class TestJA4TOptionOrderPreservation(unittest.TestCase):
     def test_full_linux_option_set(self):
         """Standard Linux: MSS, SAckOK, Timestamp, NOP, WScale."""
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=29200,
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=29200,
             options=[
-                ("MSS", 1460), ("SAckOK", ""), ("Timestamp", (0, 0)),
-                ("NOP", None), ("WScale", 7)
-            ]
+                ("MSS", 1460),
+                ("SAckOK", ""),
+                ("Timestamp", (0, 0)),
+                ("NOP", None),
+                ("WScale", 7),
+            ],
         )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "2-4-8-1-3")
@@ -59,11 +75,18 @@ class TestJA4TOptionOrderPreservation(unittest.TestCase):
     def test_full_windows_option_set(self):
         """Standard Windows: NOP, NOP, MSS, WScale, NOP, SAckOK."""
         packet = IP() / TCP(
-            sport=54321, dport=443, flags="S", window=65535,
+            sport=54321,
+            dport=443,
+            flags="S",
+            window=65535,
             options=[
-                ("NOP", None), ("NOP", None), ("MSS", 1460),
-                ("WScale", 8), ("NOP", None), ("SAckOK", "")
-            ]
+                ("NOP", None),
+                ("NOP", None),
+                ("MSS", 1460),
+                ("WScale", 8),
+                ("NOP", None),
+                ("SAckOK", ""),
+            ],
         )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "1-1-2-3-1-4")
@@ -81,40 +104,46 @@ class TestJA4TAllOptionTypes(unittest.TestCase):
     """Test all recognized TCP option types."""
 
     def test_mss_option(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("MSS", 1460)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("MSS", 1460)]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "2")
         self.assertEqual(fp.split("_")[2], "1460")
 
     def test_nop_option(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("NOP", None)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("NOP", None)]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "1")
 
     def test_wscale_option(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("WScale", 7)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("WScale", 7)]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "3")
         self.assertEqual(fp.split("_")[3], "7")
 
     def test_sackok_option(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("SAckOK", "")])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("SAckOK", "")]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "4")
 
     def test_timestamp_option(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("Timestamp", (0, 0))])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("Timestamp", (0, 0))]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "8")
 
     def test_eol_option(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("EOL", None)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("EOL", None)]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[1], "0")
 
@@ -126,14 +155,12 @@ class TestJA4TWindowSizes(unittest.TestCase):
         windows = [65535, 29200, 14600, 16384, 8192, 0]
         for win in windows:
             with self.subTest(window=win):
-                packet = IP() / TCP(sport=54321, dport=443, flags="S",
-                                    window=win, options=[])
+                packet = IP() / TCP(sport=54321, dport=443, flags="S", window=win, options=[])
                 fp = generate_ja4t(packet)
                 self.assertEqual(fp.split("_")[0], str(win))
 
     def test_max_window(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S",
-                            window=65535, options=[])
+        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535, options=[])
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[0], "65535")
 
@@ -142,26 +169,28 @@ class TestJA4TMSSValues(unittest.TestCase):
     """Test MSS extraction."""
 
     def test_standard_mss(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("MSS", 1460)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("MSS", 1460)]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[2], "1460")
 
     def test_jumbo_mss(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("MSS", 9000)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("MSS", 9000)]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[2], "9000")
 
     def test_small_mss(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("MSS", 536)])
+        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535, options=[("MSS", 536)])
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[2], "536")
 
     def test_no_mss_gives_zero(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("NOP", None)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("NOP", None)]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[2], "0")
 
@@ -172,14 +201,16 @@ class TestJA4TWScaleValues(unittest.TestCase):
     def test_common_wscale_values(self):
         for wscale in [0, 1, 7, 8, 14]:
             with self.subTest(wscale=wscale):
-                packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                                    options=[("WScale", wscale)])
+                packet = IP() / TCP(
+                    sport=54321, dport=443, flags="S", window=65535, options=[("WScale", wscale)]
+                )
                 fp = generate_ja4t(packet)
                 self.assertEqual(fp.split("_")[3], str(wscale))
 
     def test_no_wscale_gives_zero(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("NOP", None)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("NOP", None)]
+        )
         fp = generate_ja4t(packet)
         self.assertEqual(fp.split("_")[3], "0")
 
@@ -217,15 +248,15 @@ class TestJA4TFormat(unittest.TestCase):
     """Test JA4T fingerprint format: window_options_mss_wscale."""
 
     def test_format_four_parts(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[("MSS", 1460), ("WScale", 7)])
+        packet = IP() / TCP(
+            sport=54321, dport=443, flags="S", window=65535, options=[("MSS", 1460), ("WScale", 7)]
+        )
         fp = generate_ja4t(packet)
         parts = fp.split("_")
         self.assertEqual(len(parts), 4)
 
     def test_no_options_format(self):
-        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535,
-                            options=[])
+        packet = IP() / TCP(sport=54321, dport=443, flags="S", window=65535, options=[])
         fp = generate_ja4t(packet)
         parts = fp.split("_")
         self.assertEqual(parts[0], "65535")
@@ -240,8 +271,9 @@ class TestJA4TFingerprinterClass(unittest.TestCase):
     def test_collect_multiple(self):
         fpr = JA4TFingerprinter()
         for i in range(5):
-            packet = IP() / TCP(sport=54321 + i, dport=443, flags="S",
-                                window=65535, options=[("MSS", 1460)])
+            packet = IP() / TCP(
+                sport=54321 + i, dport=443, flags="S", window=65535, options=[("MSS", 1460)]
+            )
             fpr.process_packet(packet)
         self.assertEqual(len(fpr.get_fingerprints()), 5)
 
@@ -257,12 +289,14 @@ class TestJA4TFingerprinterClass(unittest.TestCase):
 # JA4TS (TCP SYN-ACK) deep tests
 # ===========================================================================
 
+
 class TestJA4TSFlagFiltering(unittest.TestCase):
     """Test that JA4TS only accepts SYN-ACK."""
 
     def test_synack_accepted(self):
-        packet = IP() / TCP(sport=443, dport=54321, flags="SA", window=14600,
-                            options=[("MSS", 1460)])
+        packet = IP() / TCP(
+            sport=443, dport=54321, flags="SA", window=14600, options=[("MSS", 1460)]
+        )
         fp = generate_ja4ts(packet)
         self.assertIsNotNone(fp)
 
@@ -284,9 +318,18 @@ class TestJA4TSOptionPreservation(unittest.TestCase):
 
     def test_order_preserved(self):
         packet = IP() / TCP(
-            sport=443, dport=54321, flags="SA", window=14600,
-            options=[("MSS", 1460), ("NOP", None), ("WScale", 0),
-                     ("SAckOK", b""), ("NOP", None), ("NOP", None)]
+            sport=443,
+            dport=54321,
+            flags="SA",
+            window=14600,
+            options=[
+                ("MSS", 1460),
+                ("NOP", None),
+                ("WScale", 0),
+                ("SAckOK", b""),
+                ("NOP", None),
+                ("NOP", None),
+            ],
         )
         fp = generate_ja4ts(packet)
         self.assertEqual(fp.split("_")[1], "2-1-3-4-1-1")
@@ -304,18 +347,31 @@ class TestJA4TSServerResponses(unittest.TestCase):
 
     def test_f5_bigip_to_windows(self):
         packet = IP() / TCP(
-            flags="SA", window=14600,
-            options=[("MSS", 1460), ("NOP", None), ("WScale", 0),
-                     ("SAckOK", b""), ("NOP", None), ("NOP", None)]
+            flags="SA",
+            window=14600,
+            options=[
+                ("MSS", 1460),
+                ("NOP", None),
+                ("WScale", 0),
+                ("SAckOK", b""),
+                ("NOP", None),
+                ("NOP", None),
+            ],
         )
         fp = generate_ja4ts(packet)
         self.assertEqual(fp, "14600_2-1-3-4-1-1_1460_0")
 
     def test_f5_bigip_to_linux(self):
         packet = IP() / TCP(
-            flags="SA", window=14600,
-            options=[("MSS", 1460), ("NOP", None), ("WScale", 0),
-                     ("SAckOK", b""), ("Timestamp", (0, 0))]
+            flags="SA",
+            window=14600,
+            options=[
+                ("MSS", 1460),
+                ("NOP", None),
+                ("WScale", 0),
+                ("SAckOK", b""),
+                ("Timestamp", (0, 0)),
+            ],
         )
         fp = generate_ja4ts(packet)
         self.assertEqual(fp, "14600_2-1-3-4-8_1460_0")
@@ -330,16 +386,16 @@ class TestJA4TSFormat(unittest.TestCase):
     """Test JA4TS format: window_options_mss_wscale."""
 
     def test_four_parts(self):
-        packet = IP() / TCP(flags="SA", window=14600,
-                            options=[("MSS", 1460)])
+        packet = IP() / TCP(flags="SA", window=14600, options=[("MSS", 1460)])
         fp = generate_ja4ts(packet)
         parts = fp.split("_")
         self.assertEqual(len(parts), 4)
 
     def test_large_mss(self):
         """All MSS values recorded as-is per spec."""
-        packet = IP() / TCP(flags="SA", window=22000,
-                            options=[("MSS", 65495), ("NOP", None), ("WScale", 7)])
+        packet = IP() / TCP(
+            flags="SA", window=22000, options=[("MSS", 65495), ("NOP", None), ("WScale", 7)]
+        )
         fp = generate_ja4ts(packet)
         self.assertEqual(fp, "22000_2-1-3_65495_7")
 
@@ -350,8 +406,9 @@ class TestJA4TSFingerprinterClass(unittest.TestCase):
     def test_collect(self):
         fpr = JA4TSFingerprinter()
         for i in range(3):
-            packet = IP() / TCP(sport=443, dport=54321 + i, flags="SA",
-                                window=14600, options=[("MSS", 1460)])
+            packet = IP() / TCP(
+                sport=443, dport=54321 + i, flags="SA", window=14600, options=[("MSS", 1460)]
+            )
             fpr.process_packet(packet)
         self.assertEqual(len(fpr.get_fingerprints()), 3)
 

--- a/tests/test_ja4ts.py
+++ b/tests/test_ja4ts.py
@@ -2,123 +2,124 @@ import unittest
 from scapy.all import IP, TCP, Raw
 from ja4plus.fingerprinters.ja4ts import JA4TSFingerprinter, generate_ja4ts
 
+
 class TestJA4TS(unittest.TestCase):
     def setUp(self):
         """Set up test cases."""
         self.ja4ts_fp = JA4TSFingerprinter()
-        
+
         # Create sample SYN-ACK packets based on real server responses
-        
+
         # F5 BIG-IP response to Windows 10
-        self.bigip_to_win = IP()/TCP(
-            flags='SA',  # SYN-ACK
+        self.bigip_to_win = IP() / TCP(
+            flags="SA",  # SYN-ACK
             window=14600,
             options=[
-                ('MSS', 1460),
-                ('NOP', None),
-                ('WScale', 0),
-                ('SAckOK', b''),
-                ('NOP', None),
-                ('NOP', None)
-            ]
+                ("MSS", 1460),
+                ("NOP", None),
+                ("WScale", 0),
+                ("SAckOK", b""),
+                ("NOP", None),
+                ("NOP", None),
+            ],
         )
-        
+
         # F5 BIG-IP response to Linux
-        self.bigip_to_linux = IP()/TCP(
-            flags='SA',  # SYN-ACK
+        self.bigip_to_linux = IP() / TCP(
+            flags="SA",  # SYN-ACK
             window=14600,
             options=[
-                ('MSS', 1460),
-                ('NOP', None),
-                ('WScale', 0),
-                ('SAckOK', b''),
-                ('Timestamp', (0, 0))
-            ]
+                ("MSS", 1460),
+                ("NOP", None),
+                ("WScale", 0),
+                ("SAckOK", b""),
+                ("Timestamp", (0, 0)),
+            ],
         )
-        
+
         # F5 BIG-IP response to Linux Proxy
-        self.bigip_to_proxy = IP()/TCP(
-            flags='SA',  # SYN-ACK
+        self.bigip_to_proxy = IP() / TCP(
+            flags="SA",  # SYN-ACK
             window=13960,
             options=[
-                ('MSS', 1460),
-                ('NOP', None),
-                ('WScale', 0),
-                ('SAckOK', b''),
-                ('Timestamp', (0, 0))
-            ]
+                ("MSS", 1460),
+                ("NOP", None),
+                ("WScale", 0),
+                ("SAckOK", b""),
+                ("Timestamp", (0, 0)),
+            ],
         )
-        
+
     def test_bigip_responses(self):
         """Test F5 BIG-IP server responses."""
         print("\nTesting F5 BIG-IP responses...")
-        
+
         # Test response to Windows 10
         fp = generate_ja4ts(self.bigip_to_win)
         print(f"BIG-IP -> Windows 10: {fp}")
-        self.assertEqual(fp, "14600_2-1-3-4-1-1_1460_0", 
-                        "Incorrect fingerprint for BIG-IP response to Windows")
-        
+        self.assertEqual(
+            fp, "14600_2-1-3-4-1-1_1460_0", "Incorrect fingerprint for BIG-IP response to Windows"
+        )
+
         # Test response to Linux
         fp = generate_ja4ts(self.bigip_to_linux)
         print(f"BIG-IP -> Linux: {fp}")
-        self.assertEqual(fp, "14600_2-1-3-4-8_1460_0",
-                        "Incorrect fingerprint for BIG-IP response to Linux")
-        
+        self.assertEqual(
+            fp, "14600_2-1-3-4-8_1460_0", "Incorrect fingerprint for BIG-IP response to Linux"
+        )
+
         # Test response to Linux Proxy
         fp = generate_ja4ts(self.bigip_to_proxy)
         print(f"BIG-IP -> Linux Proxy: {fp}")
-        self.assertEqual(fp, "13960_2-1-3-4-8_1460_0",
-                        "Incorrect fingerprint for BIG-IP response to Proxy")
-    
+        self.assertEqual(
+            fp, "13960_2-1-3-4-8_1460_0", "Incorrect fingerprint for BIG-IP response to Proxy"
+        )
+
     def test_fingerprinter_collection(self):
         """Test that fingerprinter collects fingerprints correctly."""
         print("\nTesting fingerprint collection...")
-        
+
         # Process all test packets
         self.ja4ts_fp.process_packet(self.bigip_to_win)
         self.ja4ts_fp.process_packet(self.bigip_to_linux)
         self.ja4ts_fp.process_packet(self.bigip_to_proxy)
-        
+
         # Check collected fingerprints
         fingerprints = self.ja4ts_fp.get_fingerprints()
-        self.assertEqual(len(fingerprints), 3, 
-                        "Should have collected 3 fingerprints")
-        
+        self.assertEqual(len(fingerprints), 3, "Should have collected 3 fingerprints")
+
         # Print collected fingerprints
         for fp in fingerprints:
             print(f"Collected: {fp['fingerprint']}")
-    
+
     def test_non_synack_packets(self):
         """Test that non-SYN-ACK packets are ignored."""
         print("\nTesting non-SYN-ACK packet handling...")
-        
+
         # Create a non-SYN-ACK packet
-        regular_packet = IP()/TCP(
-            flags='A',  # ACK only
+        regular_packet = IP() / TCP(
+            flags="A",  # ACK only
             window=14600,
-            options=[('MSS', 1460)]
+            options=[("MSS", 1460)],
         )
-        
+
         fp = generate_ja4ts(regular_packet)
         self.assertIsNone(fp, "Should ignore non-SYN-ACK packets")
         print("Successfully ignored non-SYN-ACK packet")
 
     def test_large_mss(self):
         """Test handling of large MSS values - all values recorded as-is per spec."""
-        pkt = IP()/TCP(
-            flags='SA',  # SYN-ACK
+        pkt = IP() / TCP(
+            flags="SA",  # SYN-ACK
             window=22000,
-            options=[
-                ('MSS', 65495),
-                ('NOP', None),
-                ('WScale', 7)
-            ]
+            options=[("MSS", 65495), ("NOP", None), ("WScale", 7)],
         )
 
         fp = generate_ja4ts(pkt)
-        self.assertEqual(fp, "22000_2-1-3_65495_7",
-                        "All MSS values should be recorded as-is per spec")
+        self.assertEqual(
+            fp, "22000_2-1-3_65495_7", "All MSS values should be recorded as-is per spec"
+        )
 
-if __name__ == '__main__':
-    unittest.main() 
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ja4x.py
+++ b/tests/test_ja4x.py
@@ -15,114 +15,109 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding
 
+
 class TestJA4X(unittest.TestCase):
     """Test JA4X fingerprinting functionality"""
-    
+
     def setUp(self):
         """Set up test environment"""
         print("\nSetting up JA4X test...")
-        
+
         # Generate a self-signed test certificate
         self.cert_data = self.generate_test_certificate()
         print(f"Generated certificate with size {len(self.cert_data)} bytes")
-        
+
         print("Setup complete.\n")
-    
+
     def generate_test_certificate(self):
         """Generate a test certificate for fingerprinting"""
         # Generate a private key
         private_key = rsa.generate_private_key(
-            public_exponent=65537,
-            key_size=2048,
-            backend=default_backend()
+            public_exponent=65537, key_size=2048, backend=default_backend()
         )
-        
+
         # Prepare certificate details
-        subject = issuer = x509.Name([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test Organization"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.example.com"),
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-        ])
-        
+        subject = issuer = x509.Name(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test Organization"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.example.com"),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            ]
+        )
+
         # Time range for certificate validity
         now = datetime.datetime.now(datetime.timezone.utc)
         valid_from = now
         valid_to = now + datetime.timedelta(days=365)
-        
+
         # Create the certificate
-        builder = x509.CertificateBuilder().subject_name(
-            subject
-        ).issuer_name(
-            issuer
-        ).public_key(
-            private_key.public_key()
-        ).serial_number(
-            x509.random_serial_number()
-        ).not_valid_before(
-            valid_from
-        ).not_valid_after(
-            valid_to
-        ).add_extension(
-            x509.BasicConstraints(ca=True, path_length=None), 
-            critical=True
-        ).add_extension(
-            x509.KeyUsage(
-                digital_signature=True,
-                content_commitment=False,
-                key_encipherment=False,
-                data_encipherment=False,
-                key_agreement=False,
-                key_cert_sign=True,
-                crl_sign=True,
-                encipher_only=False,
-                decipher_only=False),
-            critical=True
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(valid_from)
+            .not_valid_after(valid_to)
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
         )
-        
+
         # Sign the certificate
         certificate = builder.sign(
-            private_key=private_key, 
-            algorithm=hashes.SHA256(),
-            backend=default_backend()
+            private_key=private_key, algorithm=hashes.SHA256(), backend=default_backend()
         )
-        
+
         # Return DER encoded certificate
         return certificate.public_bytes(encoding=Encoding.DER)
-    
+
     def test_ja4x_direct_certificate(self):
         """Test JA4X fingerprinting with a certificate directly."""
         print("Testing JA4X with direct certificate data...")
-        
+
         try:
             # Parse the test certificate
             cert = x509.load_der_x509_certificate(self.cert_data, default_backend())
             print("Successfully parsed X.509 certificate:")
             print(f"  Subject: {cert.subject}")
             print(f"  Issuer: {cert.issuer}")
-            
+
             # Extract certificate details
             cert_info = self.extract_cert_details(cert)
             print("Certificate details extracted successfully")
             print(f"  Issuer RDNs: {cert_info.get('issuer_rdns')}")
             print(f"  Subject RDNs: {cert_info.get('subject_rdns')}")
             print(f"  Extensions: {cert_info.get('extensions')}")
-            
+
             # Manually generate JA4X fingerprint
             ja4x = generate_ja4x(cert_info)
             print(f"Manually constructed JA4X: {ja4x}")
-            
+
             # Use fingerprinter on raw certificate data
             fingerprinter = JA4XFingerprinter()
             fingerprint = fingerprinter.fingerprint_certificate(self.cert_data)
             print(f"JA4X fingerprint from fingerprinter: {fingerprint}")
-            
+
             self.assertIsNotNone(fingerprint, "JA4X fingerprinting failed")
             self.assertEqual(ja4x, fingerprint, "JA4X fingerprints should match")
-            
+
         except Exception as e:
             print(f"Error in certificate processing: {e}")
             self.fail(f"Certificate processing failed: {e}")
-    
+
     def extract_cert_details(self, cert):
         """Extract certificate details matching the fingerprinter implementation"""
         if not cert:
@@ -148,12 +143,13 @@ class TestJA4X(unittest.TestCase):
                 extensions.append(oid_to_hex(ext.oid.dotted_string))
 
             return {
-                'issuer_rdns': issuer_rdns,
-                'subject_rdns': subject_rdns,
-                'extensions': extensions
+                "issuer_rdns": issuer_rdns,
+                "subject_rdns": subject_rdns,
+                "extensions": extensions,
             }
         except Exception:
             return None
 
-if __name__ == '__main__':
-    unittest.main() 
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ja4x_deep.py
+++ b/tests/test_ja4x_deep.py
@@ -63,16 +63,20 @@ class TestJA4XOIDHashing(unittest.TestCase):
 
     def test_same_structure_same_hash(self):
         """Two certs with same OID structure but different values should have same fingerprint."""
-        cert_a = _make_cert([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Org A"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "a.com"),
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-        ])
-        cert_b = _make_cert([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Org B"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "b.com"),
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "GB"),
-        ])
+        cert_a = _make_cert(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Org A"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "a.com"),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            ]
+        )
+        cert_b = _make_cert(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Org B"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "b.com"),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, "GB"),
+            ]
+        )
         fp = JA4XFingerprinter()
         fp_a = fp.fingerprint_certificate(cert_a)
         fp_b = fp.fingerprint_certificate(cert_b)
@@ -85,15 +89,19 @@ class TestJA4XDifferentStructures(unittest.TestCase):
 
     def test_different_subject_oids(self):
         """Different number/types of subject OIDs should differ."""
-        cert_a = _make_cert([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "a.com"),
-        ])
-        cert_b = _make_cert([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "b.com"),
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-        ])
+        cert_a = _make_cert(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "a.com"),
+            ]
+        )
+        cert_b = _make_cert(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "b.com"),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            ]
+        )
         fp = JA4XFingerprinter()
         fp_a = fp.fingerprint_certificate(cert_a)
         fp_b = fp.fingerprint_certificate(cert_b)
@@ -124,18 +132,32 @@ class TestJA4XDifferentStructures(unittest.TestCase):
             x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
             x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
         ]
-        cert_a = _make_cert(subject, extensions=[
-            (x509.BasicConstraints(ca=True, path_length=None), True),
-        ])
-        cert_b = _make_cert(subject, extensions=[
-            (x509.BasicConstraints(ca=True, path_length=None), True),
-            (x509.KeyUsage(
-                digital_signature=True, content_commitment=False,
-                key_encipherment=False, data_encipherment=False,
-                key_agreement=False, key_cert_sign=True,
-                crl_sign=True, encipher_only=False, decipher_only=False
-            ), True),
-        ])
+        cert_a = _make_cert(
+            subject,
+            extensions=[
+                (x509.BasicConstraints(ca=True, path_length=None), True),
+            ],
+        )
+        cert_b = _make_cert(
+            subject,
+            extensions=[
+                (x509.BasicConstraints(ca=True, path_length=None), True),
+                (
+                    x509.KeyUsage(
+                        digital_signature=True,
+                        content_commitment=False,
+                        key_encipherment=False,
+                        data_encipherment=False,
+                        key_agreement=False,
+                        key_cert_sign=True,
+                        crl_sign=True,
+                        encipher_only=False,
+                        decipher_only=False,
+                    ),
+                    True,
+                ),
+            ],
+        )
         fp = JA4XFingerprinter()
         fp_a = fp.fingerprint_certificate(cert_a)
         fp_b = fp.fingerprint_certificate(cert_b)
@@ -146,13 +168,16 @@ class TestJA4XDeterminism(unittest.TestCase):
     """Test that same certificate always produces same fingerprint."""
 
     def test_same_cert_same_result(self):
-        cert = _make_cert([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-        ], extensions=[
-            (x509.BasicConstraints(ca=True, path_length=None), True),
-        ])
+        cert = _make_cert(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            ],
+            extensions=[
+                (x509.BasicConstraints(ca=True, path_length=None), True),
+            ],
+        )
         fp = JA4XFingerprinter()
         r1 = fp.fingerprint_certificate(cert)
         r2 = fp.fingerprint_certificate(cert)
@@ -165,9 +190,11 @@ class TestJA4XFormat(unittest.TestCase):
     """Test JA4X fingerprint format: issuer_hash_subject_hash_ext_hash."""
 
     def test_three_parts(self):
-        cert = _make_cert([
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
-        ])
+        cert = _make_cert(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
+            ]
+        )
         fp = JA4XFingerprinter()
         result = fp.fingerprint_certificate(cert)
         self.assertIsNotNone(result)
@@ -175,11 +202,14 @@ class TestJA4XFormat(unittest.TestCase):
         self.assertEqual(len(parts), 3)
 
     def test_each_part_12_chars(self):
-        cert = _make_cert([
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
-        ], extensions=[
-            (x509.BasicConstraints(ca=True, path_length=None), True),
-        ])
+        cert = _make_cert(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
+            ],
+            extensions=[
+                (x509.BasicConstraints(ca=True, path_length=None), True),
+            ],
+        )
         fp = JA4XFingerprinter()
         result = fp.fingerprint_certificate(cert)
         parts = result.split("_")
@@ -187,9 +217,11 @@ class TestJA4XFormat(unittest.TestCase):
             self.assertEqual(len(part), 12, f"Part {i} should be 12 chars, got {len(part)}")
 
     def test_parts_are_hex(self):
-        cert = _make_cert([
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
-        ])
+        cert = _make_cert(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
+            ]
+        )
         fp = JA4XFingerprinter()
         result = fp.fingerprint_certificate(cert)
         parts = result.split("_")
@@ -201,18 +233,24 @@ class TestJA4XNoExtensions(unittest.TestCase):
     """Test certificate without extensions."""
 
     def test_no_extensions_still_fingerprints(self):
-        cert = _make_cert([
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
-        ], extensions=[])
+        cert = _make_cert(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
+            ],
+            extensions=[],
+        )
         fp = JA4XFingerprinter()
         result = fp.fingerprint_certificate(cert)
         self.assertIsNotNone(result)
 
     def test_no_extensions_hash_is_zero_sentinel(self):
         """Empty extensions should produce '000000000000' sentinel per spec."""
-        cert = _make_cert([
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
-        ], extensions=[])
+        cert = _make_cert(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
+            ],
+            extensions=[],
+        )
         fp = JA4XFingerprinter()
         result = fp.fingerprint_certificate(cert)
         parts = result.split("_")
@@ -281,9 +319,11 @@ class TestJA4XFingerprinterClass(unittest.TestCase):
     """Test JA4XFingerprinter class methods."""
 
     def test_fingerprint_certificate(self):
-        cert = _make_cert([
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
-        ])
+        cert = _make_cert(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
+            ]
+        )
         fp = JA4XFingerprinter()
         result = fp.fingerprint_certificate(cert)
         self.assertIsNotNone(result)
@@ -304,12 +344,15 @@ class TestJA4XFingerprinterClass(unittest.TestCase):
 
     def test_get_cert_details(self):
         """get_cert_details should extract OID hex lists."""
-        cert_data = _make_cert([
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
-        ], extensions=[
-            (x509.BasicConstraints(ca=True, path_length=None), True),
-        ])
+        cert_data = _make_cert(
+            [
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "test.com"),
+            ],
+            extensions=[
+                (x509.BasicConstraints(ca=True, path_length=None), True),
+            ],
+        )
         cert = x509.load_der_x509_certificate(cert_data, default_backend())
         fp = JA4XFingerprinter()
         details = fp.get_cert_details(cert)

--- a/tests/test_ja4x_reassembly.py
+++ b/tests/test_ja4x_reassembly.py
@@ -7,11 +7,14 @@ from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
 
 
 class TestJA4XReassembly(unittest.TestCase):
-
     def test_in_order_still_works(self):
         fp = JA4XFingerprinter()
         data = b"\x16\x03\x01\x00\x05\x0b\x00\x00\x01\x00"
-        pkt = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=443, dport=12345, seq=100) / Raw(load=data)
+        pkt = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=443, dport=12345, seq=100)
+            / Raw(load=data)
+        )
         result = fp.process_packet(pkt)
         # May return None (not enough cert data), but should not crash
 
@@ -21,13 +24,17 @@ class TestJA4XReassembly(unittest.TestCase):
         tls_body = b"\x0b\x00\x00\x06\x00\x00\x03\x00\x00\x00"
         part1 = tls_header + tls_body[:5]
         part2 = tls_body[5:]
-        pkt2 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
-            sport=443, dport=12345, seq=100 + len(part1)
-        ) / Raw(load=part2)
+        pkt2 = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=443, dport=12345, seq=100 + len(part1))
+            / Raw(load=part2)
+        )
         fp.process_packet(pkt2)
-        pkt1 = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(
-            sport=443, dport=12345, seq=100
-        ) / Raw(load=part1)
+        pkt1 = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=443, dport=12345, seq=100)
+            / Raw(load=part1)
+        )
         result = fp.process_packet(pkt1)
         # Should not crash; reassembly should handle ordering
 

--- a/tests/test_packet_utils.py
+++ b/tests/test_packet_utils.py
@@ -5,9 +5,9 @@ from scapy.all import IP, TCP, Raw, IPv6
 
 
 class TestGetIPLayer(unittest.TestCase):
-
     def test_ipv4_packet(self):
         from ja4plus.utils.packet_utils import get_ip_layer
+
         pkt = IP(src="1.2.3.4", dst="5.6.7.8") / TCP()
         layer = get_ip_layer(pkt)
         self.assertIsNotNone(layer)
@@ -15,6 +15,7 @@ class TestGetIPLayer(unittest.TestCase):
 
     def test_ipv6_packet(self):
         from ja4plus.utils.packet_utils import get_ip_layer
+
         pkt = IPv6(src="::1", dst="::2") / TCP()
         layer = get_ip_layer(pkt)
         self.assertIsNotNone(layer)
@@ -22,31 +23,35 @@ class TestGetIPLayer(unittest.TestCase):
 
     def test_no_ip_returns_none(self):
         from ja4plus.utils.packet_utils import get_ip_layer
+
         pkt = TCP()
         layer = get_ip_layer(pkt)
         self.assertIsNone(layer)
 
     def test_ipv4_preferred_when_both(self):
         from ja4plus.utils.packet_utils import get_ip_layer
+
         pkt = IPv6(src="::1", dst="::2") / IP(src="1.2.3.4") / TCP()
         layer = get_ip_layer(pkt)
         self.assertIsNotNone(layer)
 
 
 class TestGetTTL(unittest.TestCase):
-
     def test_ipv4_ttl(self):
         from ja4plus.utils.packet_utils import get_ttl
+
         pkt = IP(ttl=128) / TCP()
         self.assertEqual(get_ttl(pkt), 128)
 
     def test_ipv6_hlim(self):
         from ja4plus.utils.packet_utils import get_ttl
+
         pkt = IPv6(hlim=64) / TCP()
         self.assertEqual(get_ttl(pkt), 64)
 
     def test_no_ip_returns_none(self):
         from ja4plus.utils.packet_utils import get_ttl
+
         pkt = TCP()
         self.assertIsNone(get_ttl(pkt))
 

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -32,11 +32,12 @@ def test_compute_ja4x_from_der_module_helper():
     import datetime
 
     # Generate a self-signed cert in-memory
-    key = rsa.generate_private_key(public_exponent=65537, key_size=2048,
-                                   backend=default_backend())
-    name = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, "test.example.com"),
-    ])
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+    name = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, "test.example.com"),
+        ]
+    )
     cert = (
         x509.CertificateBuilder()
         .subject_name(name)
@@ -68,8 +69,7 @@ def test_compute_ja4x_from_pem_matches_der():
     from cryptography.hazmat.primitives import hashes
     import datetime
 
-    key = rsa.generate_private_key(public_exponent=65537, key_size=2048,
-                                   backend=default_backend())
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test.example.com")])
     cert = (
         x509.CertificateBuilder()
@@ -109,6 +109,7 @@ def test_ja4_fingerprinter_exposes_raw_and_raw_original_order():
         pytest.skip("tls-handshake.pcapng fixture missing")
 
     from scapy.all import rdpcap
+
     pkts = rdpcap(pcap)
     fingerprinted = False
     for pkt in pkts:
@@ -141,6 +142,7 @@ def test_ja4s_fingerprinter_exposes_raw_and_raw_original_order():
         pytest.skip("tls-handshake.pcapng fixture missing")
 
     from scapy.all import rdpcap
+
     pkts = rdpcap(pcap)
     fingerprinted = False
     for pkt in pkts:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -3,6 +3,7 @@
 Mirrors the surface area of ja4plus-go's ja4plus.Processor:
 process_packet, reset, cleanup_connection, get_shard_key.
 """
+
 import os
 
 import pytest
@@ -13,8 +14,16 @@ def test_processor_constructs_with_all_ten_fingerprinters():
 
     p = Processor()
     expected = {
-        "ja4", "ja4s", "ja4h", "ja4t", "ja4ts", "ja4l",
-        "ja4x", "ja4ssh", "ja4d", "ja4d6",
+        "ja4",
+        "ja4s",
+        "ja4h",
+        "ja4t",
+        "ja4ts",
+        "ja4l",
+        "ja4x",
+        "ja4ssh",
+        "ja4d",
+        "ja4d6",
     }
     assert set(p.fingerprinters.keys()) == expected
 
@@ -79,7 +88,8 @@ def test_processor_cleanup_connection_propagates():
     p = Processor()
     # Manually plant some state in one of the stateful fingerprinters
     p.ja4ssh.connections["1.2.3.4:22-5.6.7.8:55000"] = {
-        "client_ip": "5.6.7.8", "server_ip": "1.2.3.4",
+        "client_ip": "5.6.7.8",
+        "server_ip": "1.2.3.4",
         "ssh_packets": {"client": [], "server": []},
         "bare_acks": {"client": 0, "server": 0},
     }

--- a/tests/test_quic_integration.py
+++ b/tests/test_quic_integration.py
@@ -8,17 +8,19 @@ from ja4plus.utils.tls_utils import extract_tls_info
 
 
 class TestExtractTlsInfoQuicPath(unittest.TestCase):
-
     def _make_udp_packet(self, payload):
         return IP(src="10.0.0.1", dst="10.0.0.2") / UDP(sport=12345, dport=443) / Raw(load=payload)
 
     @patch("ja4plus.utils.tls_utils.parse_quic_initial")
     def test_udp_triggers_quic(self, mock_quic):
         mock_quic.return_value = {
-            "type": "client_hello", "is_quic": True,
-            "version": 0x0303, "ciphers": [0x1301], "extensions": [],
+            "type": "client_hello",
+            "is_quic": True,
+            "version": 0x0303,
+            "ciphers": [0x1301],
+            "extensions": [],
         }
-        result = extract_tls_info(self._make_udp_packet(b"\xC0" + b"\x00" * 50))
+        result = extract_tls_info(self._make_udp_packet(b"\xc0" + b"\x00" * 50))
         mock_quic.assert_called_once()
         self.assertTrue(result["is_quic"])
 
@@ -36,15 +38,20 @@ class TestExtractTlsInfoQuicPath(unittest.TestCase):
 
 
 class TestQuicJA4Integration(unittest.TestCase):
-
     def test_quic_ja4_starts_with_q(self):
         from ja4plus.fingerprinters.ja4 import generate_ja4
+
         tls_info = {
-            "type": "client_hello", "is_quic": True, "is_dtls": False,
-            "version": 0x0303, "supported_versions": [0x0304],
-            "sni": "example.com", "ciphers": [0x1301, 0x1302, 0x1303],
+            "type": "client_hello",
+            "is_quic": True,
+            "is_dtls": False,
+            "version": 0x0303,
+            "supported_versions": [0x0304],
+            "sni": "example.com",
+            "ciphers": [0x1301, 0x1302, 0x1303],
             "extensions": [0x0000, 0x000A, 0x000B, 0x002B, 0x0010],
-            "alpn_protocols": ["h2"], "signature_algorithms": [0x0804],
+            "alpn_protocols": ["h2"],
+            "signature_algorithms": [0x0804],
         }
         result = generate_ja4(tls_info)
         self.assertIsNotNone(result)

--- a/tests/test_quic_multipacket.py
+++ b/tests/test_quic_multipacket.py
@@ -5,6 +5,7 @@ real for clients carrying many extensions, e.g. ECH grease + many ALPN
 options), the CRYPTO frame is fragmented across multiple Initial
 packets sharing the same Destination Connection ID.
 """
+
 import os
 
 import pytest
@@ -66,13 +67,19 @@ def test_ja4_fingerprinter_buffers_quic_fragments():
     fp = JA4Fingerprinter()
 
     # Stub out decryption to produce predictable fragments per datagram.
-    fake_ch_bytes = bytes([
-        # TLS handshake header: type=01, length=0x000010 (16 bytes)
-        0x01, 0x00, 0x00, 0x10,
-        # 16 bytes of opaque body (parse_tls_handshake will reject as
-        # malformed, returning None — so the test stops short of asserting
-        # a real fingerprint, but it does assert that fragments accumulate).
-    ] + [0] * 16)
+    fake_ch_bytes = bytes(
+        [
+            # TLS handshake header: type=01, length=0x000010 (16 bytes)
+            0x01,
+            0x00,
+            0x00,
+            0x10,
+            # 16 bytes of opaque body (parse_tls_handshake will reject as
+            # malformed, returning None — so the test stops short of asserting
+            # a real fingerprint, but it does assert that fragments accumulate).
+        ]
+        + [0] * 16
+    )
     half = len(fake_ch_bytes) // 2
     frag1 = (0, fake_ch_bytes[:half])
     frag2 = (half, fake_ch_bytes[half:])
@@ -93,8 +100,17 @@ def test_ja4_fingerprinter_buffers_quic_fragments():
 
     # Drive process_packet with two synthetic UDP packets.
     from scapy.all import IP, UDP, Raw
-    pkt1 = IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=50000, dport=443) / Raw(load=b"\x80" + b"\x00" * 30)
-    pkt2 = IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=50000, dport=443) / Raw(load=b"\x80" + b"\x00" * 30)
+
+    pkt1 = (
+        IP(src="1.1.1.1", dst="2.2.2.2")
+        / UDP(sport=50000, dport=443)
+        / Raw(load=b"\x80" + b"\x00" * 30)
+    )
+    pkt2 = (
+        IP(src="1.1.1.1", dst="2.2.2.2")
+        / UDP(sport=50000, dport=443)
+        / Raw(load=b"\x80" + b"\x00" * 30)
+    )
 
     # First call: no full ClientHello yet
     r1 = fp.process_packet(pkt1)

--- a/tests/test_quic_utils.py
+++ b/tests/test_quic_utils.py
@@ -4,57 +4,62 @@ import unittest
 
 
 class TestDecodeVarint(unittest.TestCase):
-
     def test_1byte(self):
         from ja4plus.utils.quic_utils import _decode_varint
+
         val, consumed = _decode_varint(b"\x25")
         self.assertEqual(val, 37)
         self.assertEqual(consumed, 1)
 
     def test_2byte(self):
         from ja4plus.utils.quic_utils import _decode_varint
+
         val, consumed = _decode_varint(b"\x7b\xbd")
         self.assertEqual(val, 15293)
         self.assertEqual(consumed, 2)
 
     def test_4byte(self):
         from ja4plus.utils.quic_utils import _decode_varint
+
         val, consumed = _decode_varint(b"\x9d\x7f\x3e\x7d")
         self.assertEqual(val, 494878333)
         self.assertEqual(consumed, 4)
 
     def test_zero(self):
         from ja4plus.utils.quic_utils import _decode_varint
+
         val, consumed = _decode_varint(b"\x00")
         self.assertEqual(val, 0)
         self.assertEqual(consumed, 1)
 
 
 class TestHKDFExpandLabel(unittest.TestCase):
-
     def test_output_length(self):
         from ja4plus.utils.quic_utils import hkdf_expand_label
+
         result = hkdf_expand_label(b"\x00" * 32, b"quic key", b"", 16)
         self.assertEqual(len(result), 16)
 
     def test_iv_length(self):
         from ja4plus.utils.quic_utils import hkdf_expand_label
+
         result = hkdf_expand_label(b"\x00" * 32, b"quic iv", b"", 12)
         self.assertEqual(len(result), 12)
 
 
 class TestDeriveInitialSecrets(unittest.TestCase):
-
     DCID = bytes.fromhex("8394c8f03e515708")
 
     def test_secret_lengths(self):
         from ja4plus.utils.quic_utils import derive_initial_secrets
+
         cs, ss = derive_initial_secrets(self.DCID, version=1)
         self.assertEqual(len(cs), 32)
         self.assertEqual(len(ss), 32)
 
     def test_key_iv_hp_lengths(self):
         from ja4plus.utils.quic_utils import derive_initial_secrets, derive_key_iv_hp
+
         cs, _ = derive_initial_secrets(self.DCID, version=1)
         key, iv, hp = derive_key_iv_hp(cs)
         self.assertEqual(len(key), 16)
@@ -63,9 +68,9 @@ class TestDeriveInitialSecrets(unittest.TestCase):
 
 
 class TestFindPnOffset(unittest.TestCase):
-
     def test_minimal_initial(self):
         from ja4plus.utils.quic_utils import _find_pn_offset
+
         packet = bytearray()
         packet.append(0xC0)
         packet += b"\x00\x00\x00\x01"
@@ -79,22 +84,25 @@ class TestFindPnOffset(unittest.TestCase):
 
 
 class TestParseQuicInitial(unittest.TestCase):
-
     def test_too_short(self):
         from ja4plus.utils.quic_utils import parse_quic_initial
+
         self.assertIsNone(parse_quic_initial(b"\x00" * 10))
 
     def test_short_header(self):
         from ja4plus.utils.quic_utils import parse_quic_initial
+
         self.assertIsNone(parse_quic_initial(b"\x40" + b"\x00" * 30))
 
     def test_version_negotiation(self):
         from ja4plus.utils.quic_utils import parse_quic_initial
-        pkt = bytearray(b"\xC0") + b"\x00\x00\x00\x00" + b"\x00" * 30
+
+        pkt = bytearray(b"\xc0") + b"\x00\x00\x00\x00" + b"\x00" * 30
         self.assertIsNone(parse_quic_initial(bytes(pkt)))
 
     def test_non_initial_type(self):
         from ja4plus.utils.quic_utils import parse_quic_initial
+
         pkt = bytearray()
         pkt.append(0xC0 | (0x02 << 4))
         pkt += b"\x00\x00\x00\x01" + b"\x00" * 30
@@ -103,6 +111,7 @@ class TestParseQuicInitial(unittest.TestCase):
     def test_v2_initial_type_not_rejected(self):
         """QUIC v2 Initial uses packet type 0x01, not 0x00. Must not be rejected."""
         from ja4plus.utils.quic_utils import parse_quic_initial
+
         # Build a v2 long header: bit7 set, packet_type=0x01 in bits 4-5
         first_byte = 0x80 | (0x01 << 4)  # long header + type 0x01
         pkt = bytearray()
@@ -112,7 +121,9 @@ class TestParseQuicInitial(unittest.TestCase):
         pkt += b"\x00" * 8  # DCID
         pkt.append(0)  # SCID length
         pkt.append(0)  # token length
-        pkt += b"\x00" * 50  # payload (will fail decryption, but should not be rejected at type check)
+        pkt += (
+            b"\x00" * 50
+        )  # payload (will fail decryption, but should not be rejected at type check)
         result = parse_quic_initial(bytes(pkt))
         # Will return None (decryption fails on dummy data), but crucially
         # should NOT be rejected at the packet_type check — it should reach
@@ -121,6 +132,7 @@ class TestParseQuicInitial(unittest.TestCase):
     def test_v2_non_initial_rejected(self):
         """QUIC v2 Handshake type (0x03) should be rejected."""
         from ja4plus.utils.quic_utils import parse_quic_initial
+
         first_byte = 0x80 | (0x03 << 4)  # long header + type 0x03 (not Initial for v2)
         pkt = bytearray()
         pkt.append(first_byte)
@@ -130,23 +142,26 @@ class TestParseQuicInitial(unittest.TestCase):
 
 
 class TestExtractCryptoFrames(unittest.TestCase):
-
     def test_single_crypto_frame(self):
         from ja4plus.utils.quic_utils import extract_crypto_frames
+
         result = extract_crypto_frames(b"\x06\x00\x05hello")
         self.assertEqual(result, b"hello")
 
     def test_padding_then_crypto(self):
         from ja4plus.utils.quic_utils import extract_crypto_frames
+
         result = extract_crypto_frames(b"\x00\x06\x00\x03abc")
         self.assertEqual(result, b"abc")
 
     def test_no_crypto_returns_none(self):
         from ja4plus.utils.quic_utils import extract_crypto_frames
+
         self.assertIsNone(extract_crypto_frames(b"\x00\x00\x00"))
 
     def test_multiple_frames_reassembled(self):
         from ja4plus.utils.quic_utils import extract_crypto_frames
+
         result = extract_crypto_frames(b"\x06\x00\x03abc\x06\x03\x03def")
         self.assertEqual(result, b"abcdef")
 
@@ -156,25 +171,30 @@ class TestParseQuicServerInitial(unittest.TestCase):
 
     def test_too_short_returns_none(self):
         from ja4plus.utils.quic_utils import parse_quic_server_initial
+
         self.assertIsNone(parse_quic_server_initial(b"\x00" * 4, b"\x01" * 8))
 
     def test_empty_client_dcid_returns_none(self):
         from ja4plus.utils.quic_utils import parse_quic_server_initial
-        self.assertIsNone(parse_quic_server_initial(b"\xC0" + b"\x00" * 40, b""))
+
+        self.assertIsNone(parse_quic_server_initial(b"\xc0" + b"\x00" * 40, b""))
 
     def test_short_header_returns_none(self):
         from ja4plus.utils.quic_utils import parse_quic_server_initial
+
         # Short header: bit 7 clear
         pkt = b"\x40" + b"\x00\x00\x00\x01" + b"\x00" * 40
         self.assertIsNone(parse_quic_server_initial(pkt, b"\x01" * 8))
 
     def test_version_negotiation_returns_none(self):
         from ja4plus.utils.quic_utils import parse_quic_server_initial
-        pkt = b"\xC0" + b"\x00\x00\x00\x00" + b"\x00" * 40
+
+        pkt = b"\xc0" + b"\x00\x00\x00\x00" + b"\x00" * 40
         self.assertIsNone(parse_quic_server_initial(pkt, b"\x01" * 8))
 
     def test_wrong_packet_type_returns_none(self):
         from ja4plus.utils.quic_utils import parse_quic_server_initial
+
         # QUIC v1 Handshake type (0x02 in bits 4-5), not Initial (0x00)
         first_byte = 0xC0 | (0x02 << 4)
         pkt = bytes([first_byte]) + b"\x00\x00\x00\x01" + b"\x00" * 40
@@ -186,24 +206,24 @@ class TestParseQuicServerInitial(unittest.TestCase):
         import struct
 
         # Build a minimal QUIC v1 Initial long header (server direction)
-        dcid = b"\x01" * 8   # fake DCID
-        scid = b"\x02" * 4   # fake SCID
+        dcid = b"\x01" * 8  # fake DCID
+        scid = b"\x02" * 4  # fake SCID
         payload = b"\x00" * 80  # garbage (will fail AES-GCM decryption)
 
         pkt = bytearray()
-        pkt.append(0xC0)                         # long header, Initial type
-        pkt += struct.pack("!I", 0x00000001)     # QUIC v1
+        pkt.append(0xC0)  # long header, Initial type
+        pkt += struct.pack("!I", 0x00000001)  # QUIC v1
         pkt.append(len(dcid))
         pkt += dcid
         pkt.append(len(scid))
         pkt += scid
-        pkt.append(0)                            # token length = 0
+        pkt.append(0)  # token length = 0
         # payload length as varint (2-byte form for safety)
         pkt.append(0x40 | (len(payload) >> 8))
         pkt.append(len(payload) & 0xFF)
         pkt += payload
 
-        client_dcid = b"\xAA" * 8
+        client_dcid = b"\xaa" * 8
         result = parse_quic_server_initial(bytes(pkt), client_dcid)
         # Decryption fails on garbage ciphertext — must return None, not raise
         self.assertIsNone(result)
@@ -212,28 +232,31 @@ class TestParseQuicServerInitial(unittest.TestCase):
 class TestJA4SQUICTracking(unittest.TestCase):
     """Tests for JA4SFingerprinter DCID state tracking."""
 
-    def _make_quic_client_initial(self, dcid=b"\xAB" * 8, sport=54321, dport=443):
+    def _make_quic_client_initial(self, dcid=b"\xab" * 8, sport=54321, dport=443):
         """Build a fake QUIC v1 client Initial UDP packet with a known DCID."""
         import struct
         from scapy.all import IP, UDP, Raw
 
         pkt = bytearray()
-        pkt.append(0xC0)                         # long header, Initial (type 0x00)
-        pkt += struct.pack("!I", 0x00000001)     # QUIC v1
+        pkt.append(0xC0)  # long header, Initial (type 0x00)
+        pkt += struct.pack("!I", 0x00000001)  # QUIC v1
         pkt.append(len(dcid))
         pkt += dcid
-        pkt.append(0)                            # SCID length = 0
-        pkt.append(0)                            # token length = 0
-        pkt += b"\x40\x01"                      # payload length = 1 (varint)
-        pkt += b"\x00"                           # dummy payload (will fail to parse ClientHello)
+        pkt.append(0)  # SCID length = 0
+        pkt.append(0)  # token length = 0
+        pkt += b"\x40\x01"  # payload length = 1 (varint)
+        pkt += b"\x00"  # dummy payload (will fail to parse ClientHello)
 
-        return (IP(src="10.0.0.1", dst="10.0.0.2") /
-                UDP(sport=sport, dport=dport) /
-                Raw(load=bytes(pkt)))
+        return (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / UDP(sport=sport, dport=dport)
+            / Raw(load=bytes(pkt))
+        )
 
     def test_client_initial_does_not_produce_ja4s(self):
         """Client Initial packet should not generate a JA4S fingerprint."""
         from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+
         fp = JA4SFingerprinter()
         result = fp.process_packet(self._make_quic_client_initial())
         self.assertIsNone(result)
@@ -241,8 +264,9 @@ class TestJA4SQUICTracking(unittest.TestCase):
     def test_dcid_captured_from_client_initial(self):
         """Fingerprinter captures the DCID from a client Initial for later server decryption."""
         from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+
         fp = JA4SFingerprinter()
-        dcid = b"\xDE\xAD\xBE\xEF" * 2
+        dcid = b"\xde\xad\xbe\xef" * 2
         pkt = self._make_quic_client_initial(dcid=dcid, sport=54321, dport=443)
         fp.process_packet(pkt)
         # Check internal state: the forward connection key should map to the DCID
@@ -253,8 +277,9 @@ class TestJA4SQUICTracking(unittest.TestCase):
     def test_cleanup_connection_removes_dcid(self):
         """cleanup_connection() removes the stored DCID for that flow."""
         from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+
         fp = JA4SFingerprinter()
-        dcid = b"\xDE\xAD\xBE\xEF" * 2
+        dcid = b"\xde\xad\xbe\xef" * 2
         pkt = self._make_quic_client_initial(dcid=dcid, sport=54321, dport=443)
         fp.process_packet(pkt)
 
@@ -265,6 +290,7 @@ class TestJA4SQUICTracking(unittest.TestCase):
     def test_reset_clears_dcid_state(self):
         """reset() clears all stored DCID state."""
         from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+
         fp = JA4SFingerprinter()
         pkt = self._make_quic_client_initial()
         fp.process_packet(pkt)

--- a/tests/test_spec_validation.py
+++ b/tests/test_spec_validation.py
@@ -5,6 +5,7 @@ Validates ja4plus output against FoxIO's official reference test vectors.
 Download vectors first: python tests/download_test_vectors.py
 Run with: pytest -m spec_validation -v
 """
+
 import pytest
 import json
 import os
@@ -12,7 +13,7 @@ import sys
 from pathlib import Path
 
 # Add parent dir to path for imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
 
@@ -24,6 +25,7 @@ def have_vectors():
 # Attempt to download vectors if not present
 try:
     from tests.download_test_vectors import download as _download_vectors
+
     if not have_vectors():
         _download_vectors()
 except Exception:
@@ -33,6 +35,7 @@ except Exception:
 if not have_vectors():
     try:
         import importlib.util
+
         _dl_path = Path(__file__).parent / "download_test_vectors.py"
         _spec = importlib.util.spec_from_file_location("download_test_vectors", _dl_path)
         _mod = importlib.util.module_from_spec(_spec)
@@ -53,13 +56,8 @@ KNOWN_DEVIATIONS = {
     # JA4L requires per-packet arrival timestamps and TTL values that are not
     # reliably preserved in pcapng files captured offline.  ja4plus omits JA4L
     # from its fingerprinter set so these values are never produced.
-    "JA4L-C": (
-        "JA4L requires live-capture timing; not available from offline PCAPs"
-    ),
-    "JA4L-S": (
-        "JA4L requires live-capture timing; not available from offline PCAPs"
-    ),
-
+    "JA4L-C": ("JA4L requires live-capture timing; not available from offline PCAPs"),
+    "JA4L-S": ("JA4L requires live-capture timing; not available from offline PCAPs"),
     # JA4SSH uses a sliding packet-count window.  FoxIO's reference groups
     # packets by TCP stream; ja4plus currently uses a global window so the
     # per-stream values differ when multiple SSH sessions appear in one PCAP.
@@ -67,7 +65,6 @@ KNOWN_DEVIATIONS = {
         "JA4SSH stream-grouping differs: ja4plus uses a global window while "
         "FoxIO's reference groups by TCP stream"
     ),
-
     # JA4X certificate fingerprints require parsing DER-encoded certificates
     # embedded in the TLS handshake.  ja4plus extracts these only when scapy's
     # TLS layer is fully dissected; some pcapng captures lack the TLS layer
@@ -76,7 +73,6 @@ KNOWN_DEVIATIONS = {
         "JA4X certificate chain extraction depends on full TLS dissection "
         "which is not always available from pcapng captures"
     ),
-
     # JA4 extension count: in certain ClientHello packets ja4plus counts one
     # more extension than FoxIO's tshark-based reference (16 vs 15).  This
     # occurs when an extension that FoxIO's parser treats as non-countable
@@ -120,7 +116,12 @@ def _fingerprint_keys(record: dict):
         # Strip stream-index suffix (.1, .2, …) to get the base key name
         base = k.rsplit(".", 1)[0] if "." in k else k
         # Skip raw/original variants
-        if base.endswith("_r") or base.endswith("_ro") or base.endswith("_o") or base.endswith("_raw"):
+        if (
+            base.endswith("_r")
+            or base.endswith("_ro")
+            or base.endswith("_o")
+            or base.endswith("_raw")
+        ):
             continue
         result[k] = v
     return result
@@ -169,6 +170,7 @@ def _collect_ja4_fingerprints(pcap_path: Path):
 # ---------------------------------------------------------------------------
 # Helpers for per-file test parametrization
 # ---------------------------------------------------------------------------
+
 
 def _vector_params():
     """Yield (pcap_path, json_path) pairs for each available test vector."""
@@ -244,6 +246,7 @@ class TestSpecValidation:
     def test_vectors_parseable(self, pcap_path, json_path):
         """Basic sanity: PCAP can be read and expected JSON is valid."""
         from scapy.all import rdpcap
+
         packets = rdpcap(str(pcap_path))
         assert len(packets) > 0, f"No packets in {pcap_path.name}"
 

--- a/tests/test_tcp_stream.py
+++ b/tests/test_tcp_stream.py
@@ -4,9 +4,9 @@ import unittest
 
 
 class TestTCPStreamReassembler(unittest.TestCase):
-
     def test_in_order_reassembly(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         r = TCPStreamReassembler()
         key = "10.0.0.1:1234-10.0.0.2:443"
         r.add_segment(key, seq=100, data=b"hello")
@@ -15,6 +15,7 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
     def test_out_of_order_reassembly(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         r = TCPStreamReassembler()
         key = "stream1"
         r.add_segment(key, seq=105, data=b" world")
@@ -23,6 +24,7 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
     def test_duplicate_segment_ignored(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         r = TCPStreamReassembler()
         key = "stream1"
         r.add_segment(key, seq=100, data=b"hello")
@@ -31,6 +33,7 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
     def test_overlapping_segment(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         r = TCPStreamReassembler()
         key = "stream1"
         r.add_segment(key, seq=100, data=b"hello world")
@@ -40,6 +43,7 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
     def test_gap_in_stream(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         r = TCPStreamReassembler()
         key = "stream1"
         r.add_segment(key, seq=100, data=b"hello")
@@ -48,6 +52,7 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
     def test_remove_stream(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         r = TCPStreamReassembler()
         key = "stream1"
         r.add_segment(key, seq=100, data=b"hello")
@@ -56,6 +61,7 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
     def test_max_streams_cleanup(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         r = TCPStreamReassembler(max_streams=3)
         r.add_segment("s1", seq=0, data=b"a")
         r.add_segment("s2", seq=0, data=b"b")
@@ -65,6 +71,7 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
     def test_max_stream_size(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
         r = TCPStreamReassembler(max_stream_bytes=10)
         key = "stream1"
         r.add_segment(key, seq=0, data=b"a" * 20)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,10 +34,22 @@ class TestGREASEDetection(unittest.TestCase):
     """Exhaustive GREASE value detection tests."""
 
     GREASE_VALUES = [
-        0x0A0A, 0x1A1A, 0x2A2A, 0x3A3A,
-        0x4A4A, 0x5A5A, 0x6A6A, 0x7A7A,
-        0x8A8A, 0x9A9A, 0xAAAA, 0xBABA,
-        0xCACA, 0xDADA, 0xEAEA, 0xFAFA,
+        0x0A0A,
+        0x1A1A,
+        0x2A2A,
+        0x3A3A,
+        0x4A4A,
+        0x5A5A,
+        0x6A6A,
+        0x7A7A,
+        0x8A8A,
+        0x9A9A,
+        0xAAAA,
+        0xBABA,
+        0xCACA,
+        0xDADA,
+        0xEAEA,
+        0xFAFA,
     ]
 
     def test_all_16_grease_values(self):
@@ -121,8 +133,15 @@ class TestGREASEDetection(unittest.TestCase):
 class TestTLSParsing(unittest.TestCase):
     """Tests for TLS handshake parsing."""
 
-    def _build_client_hello(self, version=0x0303, ciphers=None, sni=None,
-                            alpn=None, supported_versions=None, sig_algs=None):
+    def _build_client_hello(
+        self,
+        version=0x0303,
+        ciphers=None,
+        sni=None,
+        alpn=None,
+        supported_versions=None,
+        sig_algs=None,
+    ):
         """Build a raw TLS ClientHello record."""
         if ciphers is None:
             ciphers = [0x1301]
@@ -396,7 +415,9 @@ class TestSSHParsing(unittest.TestCase):
 
     def test_is_ssh_kexinit_test_format(self):
         """Test format KEXINIT should be detected."""
-        data = b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAA" + b"SSH_MSG_KEXINIT" + b"algo1;algo2;algo3;algo4"
+        data = (
+            b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAA" + b"SSH_MSG_KEXINIT" + b"algo1;algo2;algo3;algo4"
+        )
         self.assertTrue(is_ssh_packet(data))
 
     def test_is_not_ssh(self):
@@ -416,18 +437,22 @@ class TestSSHParsing(unittest.TestCase):
 
     def test_parse_test_kexinit(self):
         """Test format KEXINIT should parse algorithm lists."""
-        data = (b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAA"
-                b"SSH_MSG_KEXINIT"
-                b"curve25519-sha256;aes128-ctr;hmac-sha2-256;none")
+        data = (
+            b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAA"
+            b"SSH_MSG_KEXINIT"
+            b"curve25519-sha256;aes128-ctr;hmac-sha2-256;none"
+        )
         result = parse_ssh_packet(data)
         self.assertIsNotNone(result)
         self.assertEqual(result["type"], "kexinit")
 
     def test_extract_hassh_from_kexinit(self):
         """HASSH should be extracted as MD5 of algorithm string."""
-        data = (b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAA"
-                b"SSH_MSG_KEXINIT"
-                b"curve25519-sha256;aes128-ctr;hmac-sha2-256;none")
+        data = (
+            b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAA"
+            b"SSH_MSG_KEXINIT"
+            b"curve25519-sha256;aes128-ctr;hmac-sha2-256;none"
+        )
         hassh = extract_hassh(data)
         self.assertIsNotNone(hassh)
         self.assertEqual(len(hassh), 32)  # MD5 hex length


### PR DESCRIPTION
Closes #21.

Apply `ruff format` once across `ja4plus/` and `tests/`, and add the `ruff`
configuration to `pyproject.toml`.

## The suite result is identical before and after

The acceptance criterion is that the format changes no test result. Both runs use
`python -m pytest tests/ -q` on the same virtual environment.

| | summary line |
|---|---|
| before | `2 failed, 582 passed, 12 skipped, 1 warning, 86 subtests passed` |
| after | `2 failed, 582 passed, 12 skipped, 1 warning, 86 subtests passed` |

The same two tests fail before and after, for the same reason:

```
FAILED tests/test_ja4db.py::TestCLILookupFlag::test_analyze_with_lookup_json
FAILED tests/test_ja4db.py::TestCLILookupFlag::test_analyze_without_lookup_json
  - FileNotFoundError: [Errno 2] No such file or directory: 'python'
```

Both belong to issue #25. They call a bare `python` in a subprocess. This branch
leaves them failing.

The 12 skips are the conformance tests. The vectors are not committed yet, which
is issue #22's work.

## Proof that no code changed

The formatter touched 62 Python files. A script parsed every one of them at
`HEAD~2` and at the format commit, then compared the two abstract syntax trees.

- 6 files differed. In all 6, the difference was the text of a docstring.
- `ruff format` removes trailing whitespace from a blank line inside a docstring.
- After the script removed trailing whitespace from every string constant on both
  sides, 0 of 62 files differed.

So the format changed indentation, quote style, line breaks and trailing
whitespace. It changed no statement, no expression and no non-docstring string
value.

## The line length

`ruff format --diff` reports this many changed lines at each width:

| line length | changed lines |
|---|---|
| 79 | 1048 |
| 88 | 958 |
| 100 | 926 |
| 110 | 925 |
| 120 | 925 |

The curve is flat from 100 columns up, a spread of one line, so "the smallest
diff" does not choose between 100, 110 and 120. The branch takes 100, the
tightest width that reaches the floor. A different width is a one-line change to
`pyproject.toml`.

## Two points for the reviewer

1. **`target-version` contradicts `requires-python`.** The plan asked for `py39`.
   `pyproject.toml` declares `requires-python = ">=3.8"`, and the classifiers list
   3.8. The branch sets `py39` as asked. Once issue #24 turns the lint gate on,
   `py39` lets a 3.9-only idiom through in a package that claims 3.8 support. Set
   `target-version = "py38"`, or drop 3.8 from the metadata.
2. **`select` includes `I`, and that changes nothing here.** `ruff format` does not
   sort imports; only `ruff check` acts on `I`. Import order stays untouched on
   this branch. Issue #24 will report and fix it.

## Out of scope

No `ruff check` finding is fixed here. A behaviour change hidden inside a format
commit is unreviewable.

## Blame

`.git-blame-ignore-revs` records the format commit `b42e385`. Enable it once per
clone:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

## Commits

- `2ae4d11` — the `ruff` configuration, `pyproject.toml` only
- `b42e385` — the format, 62 Python files, no other change
- `8715c27` — `.git-blame-ignore-revs`

The configuration and the blame file are separate commits so that the recorded
SHA covers the format and nothing else.
