### PR TITLE
Start every test subprocess with sys.executable

### DIFF
--- a/tests/test_ja4db.py
+++ b/tests/test_ja4db.py
@@ -1,6 +1,5 @@
 """Tests for ja4db fingerprint lookup."""
 
-import pytest
 from unittest.mock import patch, MagicMock
 
 from ja4plus.ja4db import JA4DBClient, lookup, _load_bundled_db

--- a/tests/test_ja4db.py
+++ b/tests/test_ja4db.py
@@ -97,10 +97,13 @@ class TestCLILookupFlag:
     def test_analyze_with_lookup_json(self):
         import subprocess
         import json
+        import sys
 
         result = subprocess.run(
             [
-                "python",
+                # The interpreter that runs the test holds the installed package. The name
+                # `python` is absent from a plain virtual environment path.
+                sys.executable,
                 "-m",
                 "ja4plus.cli",
                 "--format",
@@ -111,7 +114,9 @@ class TestCLILookupFlag:
             ],
             capture_output=True,
             text=True,
-            timeout=30,
+            # Every fingerprint the bundled database does not hold costs one remote
+            # lookup of 5 seconds. The file produces enough of them to pass 30 seconds.
+            timeout=180,
         )
         if result.returncode == 0 and result.stdout.strip():
             for line in result.stdout.strip().split("\n"):
@@ -121,9 +126,20 @@ class TestCLILookupFlag:
     def test_analyze_without_lookup_json(self):
         import subprocess
         import json
+        import sys
 
         result = subprocess.run(
-            ["python", "-m", "ja4plus.cli", "--format", "json", "analyze", "tests/data/http.cap"],
+            [
+                # The interpreter that runs the test holds the installed package. The name
+                # `python` is absent from a plain virtual environment path.
+                sys.executable,
+                "-m",
+                "ja4plus.cli",
+                "--format",
+                "json",
+                "analyze",
+                "tests/data/http.cap",
+            ],
             capture_output=True,
             text=True,
             timeout=30,


### PR DESCRIPTION
Closes #25.

## The defect

`tests/test_ja4db.py` started two CLI subprocesses with the bare name `python`.
A plain virtual environment holds `python3` only, so both tests failed:

```
FAILED tests/test_ja4db.py::TestCLILookupFlag::test_analyze_with_lookup_json - FileNotFoundError: [Errno 2] No such file or directory: 'python'
FAILED tests/test_ja4db.py::TestCLILookupFlag::test_analyze_without_lookup_json - FileNotFoundError: [Errno 2] No such file or directory: 'python'
```

Continuous integration passed because the setup-python action puts the name
`python` on the path.

## The change

Both subprocesses now start `sys.executable`. A search of `tests/` found these
two occurrences only. No other test starts a Python subprocess.

## One change beyond the substitution

The lookup test ran for the first time after the fix, and it reached its 30
second timeout. `--lookup` asks ja4db.com about every fingerprint the bundled
database does not hold, and each of those requests costs 5 seconds. The capture
file `tests/data/http.cap` produces enough of them to need 33 seconds. The
timeout is now 180 seconds.

The command below shows the cost, with the network reachable:

```
$ time ./.venv/bin/python -m ja4plus.cli --format json --lookup analyze tests/data/http.cap
1.00s user 0.12s system 3% cpu 33.637 total
```

The remote lookup cost itself is a separate matter and this pull request does
not address it.

## Proof

The suite ran under a path that holds no name `python`
(`PATH=/usr/bin:/bin`, and `/usr/bin` holds `python3` only):

Before:

```
2 failed, 11 passed, 1 warning in 0.90s        (tests/test_ja4db.py)
```

After:

```
584 passed, 12 skipped, 1 warning, 86 subtests passed in 40.12s
```
