### PR TITLE
Compare one method on one stream at a time in the conformance suite

### DIFF
--- a/docs/specs/features/01-spec-conformance.md
+++ b/docs/specs/features/01-spec-conformance.md
@@ -114,6 +114,8 @@ This feature set has no screen. Its output is the test report.
 - Changed file `ja4plus/fingerprinters/ja4s.py`.
 - Changed file `ja4plus/fingerprinters/ja4l.py`.
 - Changed file `tests/test_spec_validation.py`.
+- New file `tests/conformance_index.py`. It groups a fingerprint by stream, by
+  method and by occurrence, so one test case compares one value.
 - Changed file `tests/test_parity.py`.
 - Changed file `docs/implementation_notes.md`.
 

--- a/tests/conformance_index.py
+++ b/tests/conformance_index.py
@@ -1,0 +1,248 @@
+"""Group JA4+ fingerprints by stream, method and occurrence.
+
+The FoxIO expected-output file is a JSON array. Each element describes one event on
+one stream. A key is a method name, and an optional occurrence counter follows a dot.
+`JA4SSH.1` is the first JA4SSH fingerprint on the stream, and `JA4SSH.2` is the second.
+A key without a counter, such as `JA4H`, holds one occurrence, and the reference writes
+one such element for each occurrence.
+
+This module reads that file into a map of stream to method to occurrence, and it builds
+the same shape from the fingerprints ja4plus produces. The conformance suite then
+compares one method on one stream at a time.
+
+A stream identity holds the address pair and the port pair, and it ignores the
+direction. The reference records the client direction and the server direction under
+one stream index, so a direction-sensitive identity would split one stream into two.
+"""
+
+import logging
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+# The suffixes of a raw form and an original-order form. The reference holds these
+# next to the fingerprint, and they are intermediate values, not fingerprint output.
+RAW_SUFFIXES = ("_r", "_ro", "_o", "_raw")
+
+# The fingerprinters the conformance suite runs. JA4L is absent because ja4plus
+# produces no JA4L value.
+FINGERPRINTER_METHODS = ("JA4", "JA4S", "JA4H", "JA4X", "JA4SSH")
+
+
+class ReferenceStream:
+    """One stream of a FoxIO expected-output file.
+
+    Attributes:
+        identity: The direction-free stream identity.
+        index: The stream index the reference gives.
+        label: A one-line description that names the index and both endpoints.
+        src_port: The source port of the first record on the stream.
+        methods: A map of method name to a map of occurrence number to value.
+    """
+
+    def __init__(self, identity, index, label, src_port, methods):
+        self.identity = identity
+        self.index = index
+        self.label = label
+        self.src_port = src_port
+        self.methods = methods
+
+    def __repr__(self):
+        return "ReferenceStream({!r})".format(self.label)
+
+
+def stream_identity(src, src_port, dst, dst_port):
+    """Return the direction-free identity of one stream.
+
+    Args:
+        src: The source address.
+        src_port: The source port, as a string or an integer.
+        dst: The destination address.
+        dst_port: The destination port, as a string or an integer.
+
+    Returns:
+        A sorted pair of (address, port) pairs. The identity of one direction equals
+        the identity of the other direction.
+    """
+    endpoints = ((str(src), str(src_port)), (str(dst), str(dst_port)))
+    return tuple(sorted(endpoints))
+
+
+def method_and_occurrence(key):
+    """Return the method name and the occurrence number of a reference key.
+
+    Args:
+        key: A key of one expected-output record, such as `JA4SSH.2` or `JA4H`.
+
+    Returns:
+        A (method, occurrence) pair. The occurrence is None when the key carries no
+        counter. Returns None when the key names no method, or when it names a raw
+        form or an original-order form.
+    """
+    head, _, tail = key.rpartition(".")
+    if head and tail.isdigit():
+        method, occurrence = head, int(tail)
+    else:
+        method, occurrence = key, None
+    if not method.startswith("JA4"):
+        return None
+    if any(method.endswith(suffix) for suffix in RAW_SUFFIXES):
+        return None
+    return method, occurrence
+
+
+def index_expected(records):
+    """Return the streams of one FoxIO expected-output file.
+
+    Args:
+        records: The expected-output records, as read from the JSON file.
+
+    Returns:
+        A map of stream identity to ReferenceStream.
+    """
+    streams = {}
+    for record in records:
+        identity = stream_identity(
+            record["src"], record["srcport"], record["dst"], record["dstport"]
+        )
+        stream = streams.get(identity)
+        if stream is None:
+            stream = ReferenceStream(
+                identity=identity,
+                index=record.get("stream", "?"),
+                label="stream={} {}:{} -> {}:{}".format(
+                    record.get("stream", "?"),
+                    record["src"],
+                    record["srcport"],
+                    record["dst"],
+                    record["dstport"],
+                ),
+                src_port=str(record["srcport"]),
+                methods={},
+            )
+            streams[identity] = stream
+        for key, value in record.items():
+            parsed = method_and_occurrence(key)
+            if parsed is None:
+                continue
+            method, occurrence = parsed
+            occurrences = stream.methods.setdefault(method, {})
+            if occurrence is None:
+                # A key without a counter holds one occurrence. The reference writes
+                # one record for each occurrence, so record order gives the number.
+                occurrence = len(occurrences) + 1
+            occurrences[occurrence] = value
+    return streams
+
+
+@lru_cache(maxsize=None)
+def index_produced(pcap_path):
+    """Return the fingerprints ja4plus produces for one capture, grouped by stream.
+
+    The result is cached on the capture path, because one capture carries many test
+    cases and a capture is read once for all of them. Do not change the result.
+
+    Args:
+        pcap_path: The path of the capture file.
+
+    Returns:
+        A map of stream identity to a map of method name to a tuple of values. The
+        tuple holds the values in the order the fingerprinter produced them. A
+        fingerprint whose stream the suite cannot identify is held under the identity
+        None.
+    """
+    from scapy.all import rdpcap
+
+    from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+    from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
+    from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+    from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+    from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
+
+    fingerprinters = {
+        "JA4": JA4Fingerprinter(),
+        "JA4S": JA4SFingerprinter(),
+        "JA4H": JA4HFingerprinter(),
+        "JA4X": JA4XFingerprinter(),
+        "JA4SSH": JA4SSHFingerprinter(),
+    }
+
+    for packet in rdpcap(str(pcap_path)):
+        for name, fingerprinter in fingerprinters.items():
+            try:
+                fingerprinter.process_packet(packet)
+            except Exception as error:  # noqa: BLE001 - a parser crash is a finding
+                logger.debug("%s raised on a packet of %s: %s", name, pcap_path.name, error)
+
+    produced = {}
+    for name, fingerprinter in fingerprinters.items():
+        for entry in fingerprinter.get_fingerprints():
+            identity = _entry_identity(entry)
+            methods = produced.setdefault(identity, {})
+            methods.setdefault(name, []).append(entry["fingerprint"])
+
+    return {
+        identity: {name: tuple(values) for name, values in methods.items()}
+        for identity, methods in produced.items()
+    }
+
+
+def _entry_identity(entry):
+    """Return the stream identity of one fingerprint entry, or None.
+
+    A stateless fingerprinter holds the packet that produced the value. JA4SSH holds
+    the connection key of the window instead.
+    """
+    connection = entry.get("connection")
+    if connection:
+        return _connection_identity(connection)
+    packet = entry.get("packet")
+    if packet is not None:
+        return _packet_identity(packet)
+    return None
+
+
+def _connection_identity(connection):
+    """Return the stream identity of a JA4SSH connection key, or None.
+
+    The key has the form `<address>:<port>-<address>:<port>`. An IPv6 address holds a
+    colon and no hyphen, so the hyphen separates the two endpoints.
+    """
+    client, separator, server = connection.partition("-")
+    if not separator:
+        return None
+    client_host, _, client_port = client.rpartition(":")
+    server_host, _, server_port = server.rpartition(":")
+    if not client_host or not server_host:
+        return None
+    return stream_identity(client_host, client_port, server_host, server_port)
+
+
+def _packet_identity(packet):
+    """Return the stream identity of a packet, or None.
+
+    Reads the innermost address layer and the innermost port layer, because a tunnelled
+    capture holds an outer header that the reference does not describe.
+    """
+    from scapy.layers.inet import IP, TCP, UDP
+    from scapy.layers.inet6 import IPv6
+
+    address_layer = _innermost(packet, (IP, IPv6))
+    port_layer = _innermost(packet, (TCP, UDP))
+    if address_layer is None or port_layer is None:
+        return None
+    return stream_identity(address_layer.src, port_layer.sport, address_layer.dst, port_layer.dport)
+
+
+def _innermost(packet, layer_classes):
+    """Return the innermost layer of the packet that has one of the classes, or None."""
+    found = None
+    for layer_class in layer_classes:
+        index = 0
+        while True:
+            layer = packet.getlayer(layer_class, nb=index + 1)
+            if layer is None:
+                break
+            found = layer
+            index += 1
+    return found

--- a/tests/test_spec_validation.py
+++ b/tests/test_spec_validation.py
@@ -1,35 +1,60 @@
 """
-FoxIO JA4+ Spec Validation Tests.
+FoxIO JA4+ conformance suite.
 
-Validates ja4plus output against FoxIO's official reference test vectors.
-The vectors are committed under tests/foxio_vectors, so this suite needs no
-network access. To move the vectors to a newer upstream commit, run
+The suite compares one method on one stream at a time. Each comparison is one test
+case, and its identifier names the vector, the stream and the occurrence key, so a
+failure names the vector, the stream, the method, the expected value and the produced
+value on its own.
+
+`tests/conformance_index.py` holds the index. It reads the FoxIO expected-output file
+into a map of stream to method to occurrence, and it builds the same shape from the
+fingerprints ja4plus produces.
+
+The suite holds three groups of test:
+
+- `TestConformanceIndex` checks the index itself. It needs no vector.
+- `test_the_produced_fingerprint_equals_the_reference` compares one value.
+- `test_the_produced_occurrence_keys_equal_the_reference` compares the occurrence keys
+  of one method on one vector. It names an extra occurrence key and a missing one, and
+  it reports a method that the vector does not exercise as not applicable.
+
+The vectors are committed under `tests/foxio_vectors`, so this suite needs no network
+access. To move the vectors to a newer upstream commit, run
 `python tests/download_test_vectors.py` by hand.
+
 Run with: pytest -m spec_validation -v
 """
 
-import pytest
 import json
-import os
-import sys
+import logging
 from pathlib import Path
 
-# Add parent dir to path for imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+
+from tests.conformance_index import (
+    index_expected,
+    index_produced,
+    method_and_occurrence,
+    stream_identity,
+)
+
+logger = logging.getLogger(__name__)
 
 VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+
+# The methods this suite reports on every vector. A method that a vector does not
+# exercise is reported as not applicable, so the report separates it from a pass.
+REPORTED_METHODS = ("JA4", "JA4H", "JA4S", "JA4SSH", "JA4X")
 
 
 def have_vectors():
     return VECTORS_DIR.exists() and any(VECTORS_DIR.glob("*.pcap*"))
 
 
-
 # ---------------------------------------------------------------------------
 # Known deviations from FoxIO reference output.
-# Keys use glob-style prefix matching on "<pcap_filename>/<fingerprint_key>".
-# Tests that hit a known deviation emit a pytest.skip (with reason) instead
-# of failing so CI stays green while deviations are tracked.
+# Keys are method names. A test that hits a known deviation emits a pytest.skip
+# (with reason) instead of failing so CI stays green while deviations are tracked.
 # ---------------------------------------------------------------------------
 KNOWN_DEVIATIONS = {
     # JA4L requires per-packet arrival timestamps and TTL values that are not
@@ -65,7 +90,7 @@ KNOWN_DEVIATIONS = {
 }
 
 # Per-PCAP/stream overrides for deviations that only apply to specific records.
-# Keys: "<pcap_name>/<stream_index>/<base_key>" -> deviation reason string.
+# Keys: "<pcap_name>/<stream_index>/<method>" -> deviation reason string.
 STREAM_DEVIATIONS = {
     "tls-handshake.pcapng/38/JA4": KNOWN_DEVIATIONS["JA4_ext_count"],
     "tls-handshake.pcapng/41/JA4": KNOWN_DEVIATIONS["JA4_ext_count"],
@@ -75,84 +100,27 @@ STREAM_DEVIATIONS = {
 }
 
 
-def _load_expected(json_path: Path):
-    """Load expected fingerprints from a FoxIO testdata JSON file."""
-    with open(json_path) as f:
-        return json.load(f)
+def _deviation_reason(pcap_name, stream_index, method):
+    """Return the known-deviation reason for one method on one stream, or None."""
+    stream_key = "{}/{}/{}".format(pcap_name, stream_index, method)
+    if stream_key in STREAM_DEVIATIONS:
+        return STREAM_DEVIATIONS[stream_key]
+    return KNOWN_DEVIATIONS.get(method)
 
 
-def _fingerprint_keys(record: dict):
-    """Return canonical JA4* keys present in a record.
-
-    Excludes raw/original variants (JA4_r, JA4_ro, JA4_o and their dotted
-    stream-indexed forms like JA4_r.1) since those are intermediate values
-    not produced as fingerprint output.  Also excludes JA4S_r.
-    """
-    result = {}
-    for k, v in record.items():
-        if not k.startswith("JA4"):
-            continue
-        # Strip stream-index suffix (.1, .2, …) to get the base key name
-        base = k.rsplit(".", 1)[0] if "." in k else k
-        # Skip raw/original variants
-        if (
-            base.endswith("_r")
-            or base.endswith("_ro")
-            or base.endswith("_o")
-            or base.endswith("_raw")
-        ):
-            continue
-        result[k] = v
-    return result
-
-
-def _base_key(key: str) -> str:
-    """Strip the stream suffix (.1, .2 …) from a fingerprint key, e.g. 'JA4.1' -> 'JA4'."""
-    if "." in key:
-        return key.rsplit(".", 1)[0]
-    return key
-
-
-def _collect_ja4_fingerprints(pcap_path: Path):
-    """Run all ja4plus fingerprinters over a PCAP and return a list of non-None results."""
-    from scapy.all import rdpcap
-    from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
-    from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
-    from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
-    from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
-    from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
-
-    fps = {
-        "JA4": JA4Fingerprinter(),
-        "JA4S": JA4SFingerprinter(),
-        "JA4H": JA4HFingerprinter(),
-        "JA4X": JA4XFingerprinter(),
-        "JA4SSH": JA4SSHFingerprinter(),
-    }
-
-    packets = rdpcap(str(pcap_path))
-    for pkt in packets:
-        for fp in fps.values():
-            try:
-                fp.process_packet(pkt)
-            except Exception:
-                pass
-
-    results = {}
-    for name, fp in fps.items():
-        seen = fp.get_fingerprints()
-        if seen:
-            results[name] = [entry["fingerprint"] for entry in seen]
-    return results
+def _load_expected(json_path):
+    """Return the expected records from a FoxIO expected-output file."""
+    with open(json_path) as handle:
+        return json.load(handle)
 
 
 # ---------------------------------------------------------------------------
-# Helpers for per-file test parametrization
+# Test parameters
 # ---------------------------------------------------------------------------
 
 
-def _vector_params():
-    """Yield (pcap_path, json_path) pairs for each available test vector."""
+def _vector_files():
+    """Return the (pcap_path, json_path) pair of every available vector."""
     if not have_vectors():
         return []
     pairs = []
@@ -160,77 +128,310 @@ def _vector_params():
         pcap_name = json_path.stem  # e.g. "tls12.pcap" or "tls-handshake.pcapng"
         pcap_path = VECTORS_DIR / pcap_name
         if pcap_path.exists():
-            pairs.append(pytest.param(pcap_path, json_path, id=pcap_name))
+            pairs.append((pcap_path, json_path))
     return pairs
+
+
+def _vector_params():
+    """Return one parameter set for every vector."""
+    return [
+        pytest.param(pcap_path, json_path, id=pcap_path.name)
+        for pcap_path, json_path in _vector_files()
+    ]
+
+
+def _value_params():
+    """Return one parameter set for every expected (vector, stream, occurrence)."""
+    params = []
+    for pcap_path, json_path in _vector_files():
+        streams = index_expected(_load_expected(json_path))
+        for stream in sorted(streams.values(), key=lambda item: (item.index, item.identity)):
+            for method in sorted(stream.methods):
+                for occurrence, expected in sorted(stream.methods[method].items()):
+                    params.append(
+                        pytest.param(
+                            pcap_path,
+                            stream,
+                            method,
+                            occurrence,
+                            expected,
+                            id="{}-stream{}:{}-{}.{}".format(
+                                pcap_path.name,
+                                stream.index,
+                                stream.src_port,
+                                method,
+                                occurrence,
+                            ),
+                        )
+                    )
+    return params
+
+
+def _method_params():
+    """Return one parameter set for every (vector, method) pair the suite reports."""
+    params = []
+    for pcap_path, json_path in _vector_files():
+        streams = index_expected(_load_expected(json_path))
+        methods = set(REPORTED_METHODS)
+        for stream in streams.values():
+            methods.update(stream.methods)
+        for method in sorted(methods):
+            params.append(
+                pytest.param(
+                    pcap_path,
+                    json_path,
+                    method,
+                    id="{}-{}".format(pcap_path.name, method),
+                )
+            )
+    return params
+
+
+def _occurrence_keys(streams_methods, method, label_of):
+    """Return the set of "<stream label>/<method>.<n>" keys for one method."""
+    keys = set()
+    for identity, methods in streams_methods.items():
+        occurrences = methods.get(method)
+        if not occurrences:
+            continue
+        for occurrence in occurrences:
+            keys.add("{}/{}.{}".format(label_of(identity), method, occurrence))
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# The index itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec_validation
+class TestConformanceIndex:
+    """Check the index that the conformance comparison depends on."""
+
+    def test_the_stream_identity_ignores_the_direction(self):
+        client = stream_identity("10.0.0.1", "1234", "10.0.0.2", 443)
+        server = stream_identity("10.0.0.2", 443, "10.0.0.1", "1234")
+        assert client == server
+
+    def test_the_stream_identity_separates_two_ports(self):
+        first = stream_identity("10.0.0.1", "1234", "10.0.0.2", 443)
+        second = stream_identity("10.0.0.1", "1235", "10.0.0.2", 443)
+        assert first != second
+
+    def test_the_key_reader_reads_the_occurrence_counter(self):
+        assert method_and_occurrence("JA4SSH.2") == ("JA4SSH", 2)
+
+    def test_the_key_reader_reports_no_counter_on_a_plain_key(self):
+        assert method_and_occurrence("JA4L-C") == ("JA4L-C", None)
+
+    def test_the_key_reader_rejects_a_raw_form(self):
+        assert method_and_occurrence("JA4_r.1") is None
+        assert method_and_occurrence("JA4_ro.1") is None
+        assert method_and_occurrence("JA4_o.1") is None
+        assert method_and_occurrence("JA4S_r") is None
+        assert method_and_occurrence("JA4H_ro") is None
+
+    def test_the_key_reader_rejects_a_key_that_names_no_method(self):
+        assert method_and_occurrence("domain") is None
+        assert method_and_occurrence("ssh_extras") is None
+
+    def test_the_index_holds_one_stream_for_both_directions(self):
+        records = [
+            {
+                "stream": 0,
+                "src": "10.0.0.1",
+                "srcport": "1234",
+                "dst": "10.0.0.2",
+                "dstport": "443",
+                "JA4H": "ge11nn020000_aaa_bbb_ccc",
+            },
+            {
+                "stream": 0,
+                "src": "10.0.0.2",
+                "srcport": "443",
+                "dst": "10.0.0.1",
+                "dstport": "1234",
+                "JA4H": "ge11nn020000_ddd_eee_fff",
+            },
+        ]
+        streams = index_expected(records)
+        assert len(streams) == 1
+        stream = next(iter(streams.values()))
+        assert stream.methods["JA4H"] == {
+            1: "ge11nn020000_aaa_bbb_ccc",
+            2: "ge11nn020000_ddd_eee_fff",
+        }
+
+    def test_the_index_keeps_the_occurrence_counter_of_the_reference(self):
+        records = [
+            {
+                "stream": 3,
+                "src": "10.0.0.1",
+                "srcport": "1234",
+                "dst": "10.0.0.2",
+                "dstport": "22",
+                "JA4SSH.1": "c36s36_c76s124_c0s0",
+                "JA4SSH.2": "c36s36_c77s123_c0s0",
+            }
+        ]
+        streams = index_expected(records)
+        stream = next(iter(streams.values()))
+        assert stream.index == 3
+        assert stream.methods["JA4SSH"] == {
+            1: "c36s36_c76s124_c0s0",
+            2: "c36s36_c77s123_c0s0",
+        }
+
+    def test_the_index_drops_a_raw_form(self):
+        records = [
+            {
+                "stream": 0,
+                "src": "10.0.0.1",
+                "srcport": "1234",
+                "dst": "10.0.0.2",
+                "dstport": "443",
+                "JA4.1": "t13d1715h2_5b57614c22b0_3d5424432f57",
+                "JA4_r.1": "t13d1715h2_002f,0035_0005,000a_0403",
+            }
+        ]
+        streams = index_expected(records)
+        stream = next(iter(streams.values()))
+        assert set(stream.methods) == {"JA4"}
+
+    def test_the_index_names_the_stream_in_its_label(self):
+        records = [
+            {
+                "stream": 7,
+                "src": "10.0.0.1",
+                "srcport": "1234",
+                "dst": "10.0.0.2",
+                "dstport": "443",
+                "JA4.1": "t13d1715h2_5b57614c22b0_3d5424432f57",
+            }
+        ]
+        stream = next(iter(index_expected(records).values()))
+        assert "stream=7" in stream.label
+        assert "10.0.0.1:1234" in stream.label
+        assert "10.0.0.2:443" in stream.label
+
+
+# ---------------------------------------------------------------------------
+# The comparison against the FoxIO reference
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.spec_validation
 @pytest.mark.skipif(not have_vectors(), reason="FoxIO test vectors not downloaded")
-class TestSpecValidation:
-    """Validate ja4plus against FoxIO reference output."""
+@pytest.mark.parametrize("pcap_path,stream,method,occurrence,expected", _value_params())
+def test_the_produced_fingerprint_equals_the_reference(
+    pcap_path, stream, method, occurrence, expected
+):
+    """Compare one occurrence of one method on one stream against the reference."""
+    reason = _deviation_reason(pcap_path.name, stream.index, method)
+    if reason:
+        pytest.skip("known deviation: {}".format(reason))
 
-    @pytest.mark.parametrize("pcap_path,json_path", _vector_params())
-    def test_fingerprint_matches(self, pcap_path, json_path):
-        """
-        For each record in the expected JSON, check that ja4plus produces
-        at least one matching fingerprint value.
-
-        Strategy:
-        - Collect all fingerprints generated by ja4plus over the PCAP.
-        - For each JA4* key in the expected JSON, assert that the expected
-          value appears somewhere in our output (we don't enforce stream
-          ordering because ja4plus does not reconstruct TCP streams).
-        - If a mismatch matches a KNOWN_DEVIATIONS entry, warn instead of fail.
-        """
-        expected_records = _load_expected(json_path)
-        actual = _collect_ja4_fingerprints(pcap_path)
-
-        mismatches = []
-        matched = 0
-
-        for record in expected_records:
-            stream_idx = record.get("stream", "?")
-            fp_fields = _fingerprint_keys(record)
-
-            for raw_key, expected_value in fp_fields.items():
-                base = _base_key(raw_key)  # e.g. "JA4", "JA4S", "JA4H", "JA4SSH", "JA4X"
-
-                # Check type-level deviation first
-                if base in KNOWN_DEVIATIONS:
-                    continue
-
-                # Check per-stream deviation
-                stream_key = f"{pcap_path.name}/{stream_idx}/{base}"
-                if stream_key in STREAM_DEVIATIONS:
-                    continue
-
-                our_values = actual.get(base, [])
-                if expected_value in our_values:
-                    matched += 1
-                else:
-                    mismatches.append(
-                        f"stream={stream_idx} {base}: expected={expected_value!r} "
-                        f"got={our_values!r}"
-                    )
-
-        if mismatches:
-            # Report all mismatches but also note how many matched.
-            mismatch_report = "\n  ".join(mismatches)
-            pytest.fail(
-                f"{pcap_path.name}: {len(mismatches)} mismatch(es), "
-                f"{matched} match(es):\n  {mismatch_report}"
+    produced = index_produced(pcap_path).get(stream.identity, {}).get(method, ())
+    if len(produced) < occurrence:
+        pytest.fail(
+            "{} {} {}.{}: expected={!r} produced=<none>, {} produced {} value(s) "
+            "on this stream".format(
+                pcap_path.name,
+                stream.label,
+                method,
+                occurrence,
+                expected,
+                method,
+                len(produced),
             )
+        )
 
-    @pytest.mark.parametrize("pcap_path,json_path", _vector_params())
-    def test_vectors_parseable(self, pcap_path, json_path):
-        """Basic sanity: PCAP can be read and expected JSON is valid."""
-        from scapy.all import rdpcap
+    actual = produced[occurrence - 1]
+    if actual != expected:
+        pytest.fail(
+            "{} {} {}.{}: expected={!r} produced={!r}".format(
+                pcap_path.name, stream.label, method, occurrence, expected, actual
+            )
+        )
 
-        packets = rdpcap(str(pcap_path))
-        assert len(packets) > 0, f"No packets in {pcap_path.name}"
 
-        expected = _load_expected(json_path)
-        # FoxIO ships an empty array for a capture that its Python implementation
-        # produces no fingerprint for, such as dhcp.pcapng. That file is still a
-        # valid vector, so an empty array is not a defect.
-        assert isinstance(expected, list), "Expected JSON should be a list of records"
+@pytest.mark.spec_validation
+@pytest.mark.skipif(not have_vectors(), reason="FoxIO test vectors not downloaded")
+@pytest.mark.parametrize("pcap_path,json_path,method", _method_params())
+def test_the_produced_occurrence_keys_equal_the_reference(pcap_path, json_path, method):
+    """Compare the occurrence keys of one method on one vector against the reference.
+
+    A vector that produces more fingerprints than the reference fails, and the failure
+    names the extra occurrence keys. A vector that exercises the method nowhere is
+    reported as not applicable.
+    """
+    streams = index_expected(_load_expected(json_path))
+    produced = index_produced(pcap_path)
+
+    labels = {identity: stream.label for identity, stream in streams.items()}
+
+    def label_of(identity):
+        return labels.get(identity, _unlabelled(identity))
+
+    expected_methods = {identity: stream.methods for identity, stream in streams.items()}
+    expected_keys = _occurrence_keys(expected_methods, method, label_of)
+    produced_keys = _occurrence_keys(
+        {
+            identity: {name: dict(enumerate(values, start=1)) for name, values in methods.items()}
+            for identity, methods in produced.items()
+        },
+        method,
+        label_of,
+    )
+
+    if not expected_keys and not produced_keys:
+        pytest.skip(
+            "not applicable: {} holds no {} value and ja4plus produces none".format(
+                pcap_path.name, method
+            )
+        )
+
+    reason = _deviation_reason(pcap_path.name, "*", method)
+    if reason:
+        pytest.skip("known deviation: {}".format(reason))
+
+    extra = sorted(produced_keys - expected_keys)
+    missing = sorted(expected_keys - produced_keys)
+    if extra or missing:
+        pytest.fail(
+            "{} {}: {} extra occurrence key(s) {}; {} missing occurrence key(s) {}".format(
+                pcap_path.name, method, len(extra), extra, len(missing), missing
+            )
+        )
+
+
+def _unlabelled(identity):
+    """Return a label for a stream that the reference does not hold."""
+    if identity is None:
+        return "stream=? address unknown"
+    (first_host, first_port), (second_host, second_port) = identity
+    return "stream=? {}:{} -> {}:{}".format(first_host, first_port, second_host, second_port)
+
+
+@pytest.mark.spec_validation
+@pytest.mark.skipif(not have_vectors(), reason="FoxIO test vectors not downloaded")
+@pytest.mark.parametrize("pcap_path,json_path", _vector_params())
+def test_the_vector_is_readable(pcap_path, json_path):
+    """Read the capture and the expected-output file of one vector."""
+    from scapy.all import rdpcap
+
+    packets = rdpcap(str(pcap_path))
+    assert len(packets) > 0, "No packets in {}".format(pcap_path.name)
+
+    expected = _load_expected(json_path)
+    # FoxIO ships an empty array for a capture that its Python implementation
+    # produces no fingerprint for, such as dhcp.pcapng. That file is still a
+    # valid vector, so an empty array is not a defect.
+    assert isinstance(expected, list), "Expected JSON should be a list of records"
+
+
+@pytest.mark.spec_validation
+def test_the_suite_collects_at_least_one_vector():
+    """Fail when no vector is available, because an empty suite proves nothing."""
+    assert have_vectors(), "No FoxIO vector under {}".format(VECTORS_DIR)
+    assert _vector_files(), "No capture and expected-output pair under {}".format(VECTORS_DIR)


### PR DESCRIPTION
Closes #27.

## What changed

The suite compared one expected fingerprint against a flat list of every fingerprint in
the capture. A failure read `stream=38 JA4: expected=<one value> got=[80 values]`, so it
named neither the stream nor the occurrence. A value that belonged to another stream
still counted as a match, so the failure count was wrong in both directions.

`tests/conformance_index.py` reads the FoxIO expected-output file into a map of stream
to method to occurrence. It builds the same shape from the fingerprints ja4plus
produces. `tests/test_spec_validation.py` then compares one method on one stream at a
time.

A stream identity holds the address pair and the port pair, and it ignores the
direction. The reference records the client direction and the server direction under one
stream index, so a direction-sensitive identity would split one stream into two. A
stateless fingerprinter carries the packet that produced the value, and JA4SSH carries
the connection key of the window. Both give the identity.

## The three acceptance criteria

**A failure names the vector, the stream, the method, the expected value and the
produced value.** One test case is one comparison, and the identifier carries the same
five facts:

```
FAILED tests/test_spec_validation.py::test_the_produced_fingerprint_equals_the_reference[tls-non-ascii-alpn.pcapng-stream0:50112-JA4.1]
E   Failed: tls-non-ascii-alpn.pcapng stream=0 192.168.1.168:50112 -> 142.251.16.94:443 JA4.1: expected='t13d151699_8daaf6152771_e5627efa2ab1' produced='t13d1516bd_8daaf6152771_e5627efa2ab1'
```

**A method absent from a vector is reported as not applicable and does not count as a
pass.** `test_the_produced_occurrence_keys_equal_the_reference` runs on every vector for
every method in `REPORTED_METHODS`. When the reference holds no value and ja4plus
produces none, the case skips:

```
SKIPPED [1] tests/test_spec_validation.py:388: not applicable: CVE-2018-6794.pcap holds no JA4 value and ja4plus produces none
```

The case skips only when both sides are empty. A method that the reference does not hold
and ja4plus does produce fails and names the extra keys.

**A vector that produces more fingerprints than the reference fails and names the extra
occurrence keys.**

```
E   Failed: tls-handshake.pcapng JA4S: 5 extra occurrence key(s) ['stream=38 192.168.1.168:50159 -> 13.107.237.40:443/JA4S.2', 'stream=41 192.168.1.168:50165 -> 13.107.238.40:443/JA4S.2', 'stream=42 192.168.1.168:50166 -> 13.107.237.40:443/JA4S.2', 'stream=44 192.168.1.168:50168 -> 13.107.238.40:443/JA4S.2', 'stream=45 192.168.1.168:50169 -> 13.107.237.40:443/JA4S.2']; 0 missing occurrence key(s) []
```

A produced fingerprint on a stream the reference does not hold carries the label
`stream=?` and both endpoints, because the reference gives it no stream index.

## The required measurement

Both runs use the committed vectors and no network access, on `04d3e3e`, which merges
`02ee772`. Both runs return the same result as they did on `84954df`, before the merge.
The failing-case list of run 2 is byte-identical across the two bases, so the lint and
type-check work of #24 moved no fingerprint.

| Run | Result |
|---|---|
| 1. As committed, `KNOWN_DEVIATIONS` active | **37 failed, 379 passed, 387 skipped** |
| 2. `KNOWN_DEVIATIONS` and `STREAM_DEVIATIONS` emptied in the working copy | **263 failed, 421 passed, 119 skipped** |

`STREAM_DEVIATIONS` reads its values from `KNOWN_DEVIATIONS`, so run 2 empties both.
Neither table changed on this branch. #23 replaces them.

For reference, the old harness on the same base reported **5 failed, 69 passed, 0
skipped** over 74 cases. The new harness collects 803 cases. The rise from 5 to 37 is a
report change, not a behaviour change: no file under `ja4plus/` changed.

### Run 2 is the true conformance baseline

263 failing cases: 184 value mismatches and 79 occurrence-key mismatches.

| Method | Value mismatches | Occurrence-key mismatches |
|---|---|---|
| JA4L-C | 56 | 24 |
| JA4L-S | 58 | 24 |
| JA4X | 27 | 8 |
| JA4H | 17 | 4 |
| JA4SSH | 15 | 9 |
| JA4 | 11 | 8 |
| JA4S | 0 | 2 |
| **Total** | **184** | **79** |

JA4L carries 114 of the 184 value mismatches and 48 of the 79 key mismatches. ja4plus
runs no JA4L fingerprinter in this suite, so every JA4L case fails. Without JA4L the
baseline is **70 value mismatches and 31 occurrence-key mismatches**.

#### Every failing (vector, stream, method) value triple

`stream.occurrence` names the stream index and the occurrence number.

| Vector | Method | Streams |
|---|---|---|
| `badcurveball.pcap` | JA4L-C | 0.1 |
| `badcurveball.pcap` | JA4L-S | 0.1 |
| `browsers-x509.pcapng` | JA4L-C | 0.1, 1.1, 2.1 |
| `browsers-x509.pcapng` | JA4L-S | 0.1, 1.1, 2.1 |
| `browsers-x509.pcapng` | JA4X | 0.1, 0.2 |
| `chrome-cloudflare-quic-with-secrets.pcapng` | JA4H | 0.1 |
| `chrome-cloudflare-quic-with-secrets.pcapng` | JA4L-C | 0.1 (port 50280), 0.1 (port 57098) |
| `chrome-cloudflare-quic-with-secrets.pcapng` | JA4L-S | 0.1 (port 50280), 0.1 (port 57098) |
| `chrome-cloudflare-quic-with-secrets.pcapng` | JA4X | 0.1, 0.2 |
| `gre-erspan-vxlan.pcap` | JA4L-C | 0.1 |
| `gre-erspan-vxlan.pcap` | JA4L-S | 0.1 |
| `gre-sample.pcap` | JA4L-C | 0.1 |
| `gre-sample.pcap` | JA4L-S | 0.1 |
| `http-empty-useragent.pcap` | JA4H | 0.1 |
| `http-empty-useragent.pcap` | JA4L-C | 0.1 |
| `http-empty-useragent.pcap` | JA4L-S | 0.1 |
| `http1-with-cookies.pcapng` | JA4L-C | 0.1 |
| `http1-with-cookies.pcapng` | JA4L-S | 0.1 |
| `http2-with-cookies.pcapng` | JA4H | 0.1 through 0.15 |
| `http2-with-cookies.pcapng` | JA4L-C | 0.1 |
| `http2-with-cookies.pcapng` | JA4L-S | 0.1 |
| `http2-with-cookies.pcapng` | JA4X | 0.1, 0.2, 0.3 |
| `https3-301-get.pcap` | JA4L-C | 0.1 |
| `https3-301-get.pcap` | JA4L-S | 0.1 |
| `ipv6.pcapng` | JA4L-C | 0.1 |
| `ipv6.pcapng` | JA4L-S | 0.1 |
| `latest.pcapng` | JA4L-C | 1.1, 3.1, 5.1, 6.1, 9.1, 10.1 |
| `latest.pcapng` | JA4L-S | 1.1, 3.1, 5.1, 6.1, 9.1, 10.1 |
| `latest.pcapng` | JA4X | 9.1, 9.2, 10.1, 10.2 |
| `macos_tcp_flags.pcap` | JA4L-C | 0.1 |
| `macos_tcp_flags.pcap` | JA4L-S | 0.1 |
| `socks-https-example.pcap` | JA4L-C | 0.1, 2.1, 4.1 |
| `socks-https-example.pcap` | JA4L-S | 0.1, 2.1, 4.1 |
| `socks-https-example.pcap` | JA4X | 2.1, 2.2, 4.1, 4.2 |
| `socks4-https.pcap` | JA4L-C | 0.1 |
| `socks4-https.pcap` | JA4L-S | 0.1 |
| `ssh-r.pcap` | JA4L-C | 0.1, 1.1, 2.1 |
| `ssh-r.pcap` | JA4L-S | 0.1, 1.1, 2.1 |
| `ssh-r.pcap` | JA4SSH | 0.1, 0.2, 1.1, 2.1, 2.2, 2.3, 2.4, 2.5 |
| `ssh-scp-1050.pcap` | JA4L-C | 0.1 |
| `ssh-scp-1050.pcap` | JA4L-S | 0.1 |
| `ssh-scp-1050.pcap` | JA4SSH | 0.1, 0.2, 0.3, 0.4 |
| `ssh.pcapng` | JA4SSH | 0.1 |
| `ssh2-malformed.pcap` | JA4L-C | 0.1 |
| `ssh2-malformed.pcap` | JA4L-S | 0.1 |
| `ssh2-moloch-crash.pcap` | JA4L-C | 0.1 |
| `ssh2-moloch-crash.pcap` | JA4L-S | 0.1 |
| `ssh2.pcapng` | JA4L-C | 5.1, 8.1, 11.1, 12.1, 13.1, 14.1, 15.1, 22.1, 36.1 |
| `ssh2.pcapng` | JA4L-S | 5.1, 8.1, 11.1, 12.1, 13.1, 14.1, 15.1, 22.1, 33.1, 36.1 |
| `ssh2.pcapng` | JA4SSH | 14.1, 14.2 |
| `ssh2.pcapng` | JA4X | 11.1, 11.2, 12.1, 12.2 |
| `sshv1.pcap` | JA4L-C | 0.1 |
| `sshv1.pcap` | JA4L-S | 0.1 |
| `tcpdump-geneve.pcap` | JA4L-C | 0.1 |
| `tcpdump-geneve.pcap` | JA4L-S | 0.1 |
| `tls-alpn-h2.pcap` | JA4L-C | 0.1 |
| `tls-alpn-h2.pcap` | JA4L-S | 0.1 |
| `tls-handshake.pcapng` | JA4 | 38.2, 41.2, 42.2, 44.2, 45.2 |
| `tls-handshake.pcapng` | JA4X | 34.1, 34.2, 40.2, 40.3, 43.1, 43.2, 46.2, 46.3 |
| `tls-non-ascii-alpn.pcapng` | JA4 | 0.1 |
| `tls-sni.pcapng` | JA4 | 38.2, 41.2, 42.2, 44.2, 45.2 |
| `tls3.pcapng` | JA4L-C | 7.1, 8.1, 9.1, 10.1, 11.1, 12.1, 13.1, 14.1, 21.1, 22.1, 23.1, 24.1, 28.1 |
| `tls3.pcapng` | JA4L-S | 7.1, 8.1, 9.1, 10.1, 11.1, 12.1, 13.1, 14.1, 21.1, 22.1, 23.1, 24.1, 25.1, 28.1 |
| `v6.pcap` | JA4L-C | 0.1 |
| `v6.pcap` | JA4L-S | 0.1 |

#### Every failing (vector, method) occurrence-key pair

| Vector | Methods |
|---|---|
| `CVE-2018-6794.pcap` | JA4H |
| `badcurveball.pcap` | JA4L-C, JA4L-S |
| `browsers-x509.pcapng` | JA4L-C, JA4L-S, JA4X |
| `chrome-cloudflare-quic-with-secrets.pcapng` | JA4, JA4H, JA4L-C, JA4L-S, JA4X |
| `gre-erspan-vxlan.pcap` | JA4L-C, JA4L-S |
| `gre-sample.pcap` | JA4L-C, JA4L-S, JA4SSH |
| `http-empty-useragent.pcap` | JA4H, JA4L-C, JA4L-S |
| `http1-with-cookies.pcapng` | JA4L-C, JA4L-S |
| `http2-with-cookies.pcapng` | JA4H, JA4L-C, JA4L-S, JA4X |
| `https-connect.pcap` | JA4, JA4S, JA4X |
| `https3-301-get.pcap` | JA4L-C, JA4L-S |
| `ipv6.pcapng` | JA4L-C, JA4L-S |
| `latest.pcapng` | JA4L-C, JA4L-S, JA4X |
| `macos_tcp_flags.pcap` | JA4L-C, JA4L-S |
| `quic-tls-handshake.pcapng` | JA4 |
| `quic-with-several-tls-frames.pcapng` | JA4 |
| `socks-https-example.pcap` | JA4L-C, JA4L-S, JA4X |
| `socks4-https.pcap` | JA4L-C, JA4L-S |
| `ssh-r.pcap` | JA4L-C, JA4L-S, JA4SSH |
| `ssh-scp-1050.pcap` | JA4L-C, JA4L-S, JA4SSH |
| `ssh.pcapng` | JA4SSH |
| `ssh2-malformed.pcap` | JA4L-C, JA4L-S, JA4SSH |
| `ssh2-moloch-crash.pcap` | JA4L-C, JA4L-S, JA4SSH |
| `ssh2.pcapng` | JA4, JA4L-C, JA4L-S, JA4SSH, JA4X |
| `sshv1.pcap` | JA4L-C, JA4L-S, JA4SSH |
| `tcpdump-geneve.pcap` | JA4L-C, JA4L-S |
| `tls-alpn-h2.pcap` | JA4L-C, JA4L-S |
| `tls-handshake.pcapng` | JA4, JA4S, JA4X |
| `tls-sni.pcapng` | JA4 |
| `tls3.pcapng` | JA4, JA4L-C, JA4L-S |
| `v6.pcap` | JA4L-C, JA4L-S, JA4SSH |

### Four findings the old harness hid

1. `tls-sni.pcapng` streams 38, 41, 42, 44 and 45 miss `JA4.2`. `STREAM_DEVIATIONS`
   names the same five streams of `tls-handshake.pcapng` and not of `tls-sni.pcapng`.
   The old harness passed `tls-sni.pcapng` because the expected value appeared under
   another stream of the same capture.
2. `tls-handshake.pcapng` and `tls-sni.pcapng` each produce 20 extra JA4 values on
   streams the reference does not hold. Each extra comes from a server-side address
   pair on port 443.
3. `https-connect.pcap` produces JA4 and JA4S on the proxy stream `10.11.12.13:54723 ->
   10.9.8.7:8080`, which the reference does not hold.
4. `CVE-2018-6794.pcap` produces 6 JA4H values on each of streams 0 and 1, and the
   reference holds one.

## Verification

Every check runs on `04d3e3e`.

| Check | Result |
|---|---|
| `pytest tests/ -m "not spec_validation"` | 572 passed, 12 skipped, 86 subtests passed |
| `pytest tests/ -m spec_validation` | 37 failed, 379 passed, 387 skipped |
| `ruff check ja4plus/ tests/` | All checks passed |
| `ruff format --check ja4plus/ tests/` | 68 files already formatted |
| `mypy ja4plus/` | Success: no issues found in 25 source files |

The unit suite holds 584 test items: 572 pass and 12 skip. The count is the same on
`02ee772` and on this branch. No file under `ja4plus/` changed.

`02ee772` added the `[dev]` extra that carries `mypy`, so the type check now runs. Both
lint jobs are clean across the whole repository, so this branch leaves the `lint` job of
#24 green.

## Scope

- No file under `ja4plus/` changed.
- No file under `tests/foxio_vectors/` changed.
- No file under `.github/workflows/` changed.
- No `xfail` marker was added or removed. #23 owns that decision.
- `KNOWN_DEVIATIONS` and `STREAM_DEVIATIONS` keep their entries. #23 replaces them.

## Note for #23

The suite is red as committed, at 37 failing cases. The base was red at 5. #23 owns the
`xfail` decision and the deviation table, so this branch leaves both in place.

## Note for #24

`pyproject.toml` at `02ee772` holds this comment on the `I001` exemption:

> Never enable I001 by hand. `tests/test_ja4.py` and `tests/test_spec_validation.py`
> call `sys.path.insert` before their imports.

That is no longer true of `tests/test_spec_validation.py`. The rewrite drops the
`sys.path.insert` call, and its imports are sorted, so `I001` reports nothing on it.
`tests/test_ja4.py` still holds the call. The comment needs one word changed once this
branch lands, and I did not edit `pyproject.toml` because #24 owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
