### PR TITLE
feat(ja4): expose the JA4_o original-order value on JA4 and JA4S

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ JA4 and JA4S result dicts include the unhashed `raw` and
 `raw_original_order` variants — useful for human-readable output and
 fingerprint debugging.
 
+The same dicts include `fingerprint_original_order`, the FoxIO `JA4_o` value.
+It is the hashed form of `raw_original_order`, and its relationship to
+`fingerprint` matches the relationship of `raw_original_order` to `raw`. The
+`JA4Fingerprinter` and `JA4SFingerprinter` classes also hold the most recent
+one on `last_fingerprint_original_order`.
+
 ### X.509 Helpers
 
 ```python

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -45,6 +45,21 @@ Raw fingerprints use prefixed output: `JA4_r = {fp}` and `JA4_ro = {fp}`.
 Note the spaces around `=`. This is a display convention, not part of the
 fingerprint value itself.
 
+### The original-order hashed value
+
+`JA4_o` hashes the original-order raw value. It keeps the ciphers in wire
+order. It keeps every extension in wire order, and it holds SNI (`0x0000`) and
+ALPN (`0x0010`), which `JA4` removes. The vector
+`tests/foxio_vectors/tls12.pcap.json` gives `JA4_o.1` as
+`t13d1715h2_5b234860e130_014157ec0da2`, and that value is the hash of the
+`JA4_ro.1` fields.
+
+FoxIO publishes no `JA4S_o` key. JA4S hashes its extensions in wire order, and
+the published `JA4S_r` value holds that same wire order. The original-order
+hashed value of JA4S therefore equals the JA4S fingerprint. The
+`fingerprint_original_order` key carries it, so one caller reads one name on
+JA4 and on JA4S.
+
 ---
 
 ## JA4L - Latency

--- a/ja4plus/fingerprinters/ja4.py
+++ b/ja4plus/fingerprinters/ja4.py
@@ -56,15 +56,16 @@ def compute_alpn_value(first_alpn_bytes):
     return hex_str[0] + hex_str[-1]
 
 
-def generate_ja4(tls_info):
-    """
-    Generate a JA4 fingerprint from TLS Client Hello info.
+def generate_ja4(tls_info, original_order=False):
+    """Return the JA4 fingerprint of one TLS Client Hello.
 
     Args:
-        tls_info: A dictionary with TLS handshake information
+        tls_info: A dictionary with TLS handshake information.
+        original_order: True returns the `JA4_o` value, which hashes the wire
+            order. False returns the `JA4` value, which hashes the sorted order.
 
     Returns:
-        A JA4 fingerprint string or None if not applicable
+        A JA4 fingerprint string, or None when the info describes no Client Hello.
     """
     if not tls_info or tls_info.get("type") != "client_hello":
         return None
@@ -136,31 +137,33 @@ def generate_ja4(tls_info):
         # Form part_a of the fingerprint
         part_a = f"{proto}{version_str}{sni_type}{cipher_count_str}{ext_count_str}{alpn_value}"
 
-        # Generate cipher hash - sort ciphers first
+        # Generate cipher hash. The original-order form hashes the wire order.
         if ciphers:
-            sorted_ciphers = sorted(ciphers)
-            cipher_str = ",".join([f"{c:04x}" for c in sorted_ciphers])
+            hashed_ciphers = ciphers if original_order else sorted(ciphers)
+            cipher_str = ",".join([f"{c:04x}" for c in hashed_ciphers])
             cipher_hash = hashlib.sha256(cipher_str.encode()).hexdigest()[:12]
         else:
             cipher_hash = "000000000000"
 
         # Generate extension hash
-        # 1. Remove SNI (0x0000) and ALPN (0x0010) from extensions for hashing
-        filtered_extensions = [e for e in extensions if e != 0x0000 and e != 0x0010]
+        # 1. Select the extensions to hash. The sorted form removes SNI (0x0000)
+        #    and ALPN (0x0010), because both appear in part_a. The original-order
+        #    form keeps every extension, as `JA4_ro` in the FoxIO vectors shows.
+        if original_order:
+            hashed_extensions = extensions
+        else:
+            hashed_extensions = sorted(e for e in extensions if e != 0x0000 and e != 0x0010)
 
-        # 2. Sort filtered extensions
-        sorted_extensions = sorted(filtered_extensions)
-
-        # 3. Get signature algorithms in original order
+        # 2. Get signature algorithms in original order
         sig_algs = tls_info.get("signature_algorithms", [])
 
-        # 4. Form extension string - sorted extensions + underscore + sig algorithms if present
-        ext_str = ",".join([f"{e:04x}" for e in sorted_extensions])
+        # 3. Form extension string - extensions + underscore + sig algorithms if present
+        ext_str = ",".join([f"{e:04x}" for e in hashed_extensions])
         if sig_algs:
             sig_alg_str = ",".join([f"{s:04x}" for s in sig_algs])
             ext_str = f"{ext_str}_{sig_alg_str}"
 
-        # 5. Generate extension hash
+        # 4. Generate extension hash
         if ext_str:
             ext_hash = hashlib.sha256(ext_str.encode()).hexdigest()[:12]
         else:
@@ -297,12 +300,17 @@ class JA4Fingerprinter(BaseFingerprinter):
     ``get_fingerprints()`` and on ``last_raw`` / ``last_raw_original_order``
     for the most recent successful parse, mirroring the Go reference's
     FingerprintResult.Raw / RawOriginalOrder fields.
+
+    Every entry also carries ``fingerprint_original_order``, the FoxIO `JA4_o`
+    value. It is the hashed form of ``raw_original_order``, and the most recent
+    one is on ``last_fingerprint_original_order``.
     """
 
     def __init__(self):
         super().__init__()
         self.last_raw = None
         self.last_raw_original_order = None
+        self.last_fingerprint_original_order = None
         # DCID -> list[(offset, data)] for multi-datagram QUIC CRYPTO reassembly.
         # Keyed by DCID hex so packets with the same connection ID accumulate
         # together regardless of UDP 5-tuple changes.
@@ -326,11 +334,14 @@ class JA4Fingerprinter(BaseFingerprinter):
         if fingerprint:
             raw = get_raw_fingerprint(tls_info, original_order=False)
             raw_oo = get_raw_fingerprint(tls_info, original_order=True)
+            fingerprint_oo = generate_ja4(tls_info, original_order=True)
             self.last_raw = raw
             self.last_raw_original_order = raw_oo
+            self.last_fingerprint_original_order = fingerprint_oo
             self.fingerprints.append(
                 {
                     "fingerprint": fingerprint,
+                    "fingerprint_original_order": fingerprint_oo,
                     "raw": raw,
                     "raw_original_order": raw_oo,
                     "packet": packet,
@@ -381,6 +392,7 @@ class JA4Fingerprinter(BaseFingerprinter):
         super().reset()
         self.last_raw = None
         self.last_raw_original_order = None
+        self.last_fingerprint_original_order = None
         self._quic_fragments = {}
         self._quic_dcid_to_tuple = {}
 

--- a/ja4plus/fingerprinters/ja4s.py
+++ b/ja4plus/fingerprinters/ja4s.py
@@ -32,6 +32,7 @@ class JA4SFingerprinter(BaseFingerprinter):
         self._quic_dcids = {}
         self.last_raw = None
         self.last_raw_original_order = None
+        self.last_fingerprint_original_order = None
 
     def process_packet(self, packet):
         """
@@ -92,11 +93,17 @@ class JA4SFingerprinter(BaseFingerprinter):
         """Append a JA4S fingerprint result with raw / raw_original_order."""
         raw = _generate_ja4s_raw_from_tls_info(tls_info, original_order=False)
         raw_oo = _generate_ja4s_raw_from_tls_info(tls_info, original_order=True)
+        # JA4S hashes the extensions in wire order, and the FoxIO `JA4S_r` value
+        # holds that same wire order. The original-order hashed value therefore
+        # equals the fingerprint. FoxIO publishes no `JA4S_o` key. The field
+        # exists so one caller reads one name on JA4 and on JA4S.
         self.last_raw = raw
         self.last_raw_original_order = raw_oo
+        self.last_fingerprint_original_order = fingerprint
         self.fingerprints.append(
             {
                 "fingerprint": fingerprint,
+                "fingerprint_original_order": fingerprint,
                 "raw": raw,
                 "raw_original_order": raw_oo,
                 "packet": packet,
@@ -116,6 +123,7 @@ class JA4SFingerprinter(BaseFingerprinter):
         self._quic_dcids = {}
         self.last_raw = None
         self.last_raw_original_order = None
+        self.last_fingerprint_original_order = None
 
 
 def _get_ip_pair(packet):

--- a/tests/test_ja4_original_order.py
+++ b/tests/test_ja4_original_order.py
@@ -1,0 +1,116 @@
+"""The JA4 and JA4S fingerprinters expose the original-order hashed value.
+
+`JA4_o` is the hashed form of the original-order raw value. `JA4_ro` is that raw
+value unhashed. The relationship matches the one between `JA4` and `JA4_r`.
+
+The FoxIO expected-output file `tests/foxio_vectors/tls12.pcap.json` names the JA4
+value. FoxIO publishes no `JA4S_o` key, so each JA4S test derives the value it
+expects from the published `JA4S_r` value.
+"""
+
+import hashlib
+import json
+import os
+
+import pytest
+
+JA4_PCAP = "tests/foxio_vectors/tls12.pcap"
+JA4_EXPECTED = "tests/foxio_vectors/tls12.pcap.json"
+JA4S_PCAP = "tests/foxio_vectors/latest.pcapng"
+JA4S_EXPECTED = "tests/foxio_vectors/latest.pcapng.json"
+
+
+pytestmark = pytest.mark.skipif(
+    not all(os.path.exists(path) for path in (JA4_PCAP, JA4_EXPECTED, JA4S_PCAP, JA4S_EXPECTED)),
+    reason="FoxIO vectors not available (download to tests/foxio_vectors/)",
+)
+
+
+def _first_expected(path, key):
+    """Return the value of one key, from the first record that holds the key."""
+    with open(path) as handle:
+        records = json.load(handle)
+    for record in records:
+        if key in record:
+            return record[key]
+    raise AssertionError(f"{path} holds no {key} key")
+
+
+def _run(fingerprinter, pcap_path):
+    """Run one fingerprinter over one capture and return its result entries."""
+    from scapy.all import rdpcap
+
+    for packet in rdpcap(pcap_path):
+        fingerprinter.process_packet(packet)
+    return fingerprinter.get_fingerprints()
+
+
+def _hash12(value):
+    """Return the first 12 characters of the SHA-256 hexadecimal digest."""
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+def test_ja4_emits_the_original_order_value_of_the_foxio_vector():
+    from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+
+    fingerprinter = JA4Fingerprinter()
+    entries = _run(fingerprinter, JA4_PCAP)
+
+    assert len(entries) == 1
+    expected = _first_expected(JA4_EXPECTED, "JA4_o.1")
+    assert expected == "t13d1715h2_5b234860e130_014157ec0da2"
+    assert entries[0]["fingerprint_original_order"] == expected
+    assert fingerprinter.last_fingerprint_original_order == expected
+
+
+def test_ja4_original_order_value_hashes_the_original_order_raw_value():
+    from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+
+    entries = _run(JA4Fingerprinter(), JA4_PCAP)
+    raw_original_order = _first_expected(JA4_EXPECTED, "JA4_ro.1")
+
+    part_a, ciphers, extensions, signature_algorithms = raw_original_order.split("_")
+    expected = "{}_{}_{}".format(
+        part_a,
+        _hash12(ciphers),
+        _hash12(f"{extensions}_{signature_algorithms}"),
+    )
+    assert entries[0]["fingerprint_original_order"] == expected
+
+
+def test_ja4_reset_clears_the_original_order_value():
+    from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+
+    fingerprinter = JA4Fingerprinter()
+    _run(fingerprinter, JA4_PCAP)
+    assert fingerprinter.last_fingerprint_original_order is not None
+
+    fingerprinter.reset()
+    assert fingerprinter.last_fingerprint_original_order is None
+
+
+def test_ja4s_emits_the_original_order_value_of_the_foxio_vector():
+    from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+
+    fingerprinter = JA4SFingerprinter()
+    entries = _run(fingerprinter, JA4S_PCAP)
+
+    assert entries
+    raw = _first_expected(JA4S_EXPECTED, "JA4S_r")
+    part_a, cipher, extensions = raw.split("_")
+    expected = f"{part_a}_{cipher}_{_hash12(extensions)}"
+
+    produced = [entry["fingerprint_original_order"] for entry in entries]
+    assert expected in produced
+    assert fingerprinter.last_fingerprint_original_order is not None
+
+
+def test_ja4s_reset_clears_the_original_order_value():
+    from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+
+    fingerprinter = JA4SFingerprinter()
+    _run(fingerprinter, JA4S_PCAP)
+    assert fingerprinter.last_fingerprint_original_order is not None
+
+    fingerprinter.reset()
+    assert fingerprinter.last_fingerprint_original_order is None


### PR DESCRIPTION
Closes #29. Part of #12.

## What changed

`generate_ja4` takes an `original_order` argument. The original-order form
hashes the ciphers in wire order. It hashes every extension in wire order, and
it holds SNI (`0x0000`) and ALPN (`0x0010`), which the sorted form removes. The
signature-algorithm field does not change.

`JA4Fingerprinter` and `JA4SFingerprinter` carry the value on every result entry
under `fingerprint_original_order`. Each class holds the most recent one on
`last_fingerprint_original_order`, and `reset()` clears it.

## The vector decides

`tests/foxio_vectors/tls12.pcap.json` gives `JA4_o.1` as
`t13d1715h2_5b234860e130_014157ec0da2`. `tests/test_ja4_original_order.py`
asserts that value, and a second test asserts that the value is the hash of the
`JA4_ro.1` fields.

FoxIO publishes no `JA4S_o` key. JA4S hashes its extensions in wire order, and
the published `JA4S_r` value holds that same wire order. The original-order
hashed value of JA4S therefore equals the JA4S fingerprint. The JA4S test
derives its expected value from `JA4S_r` in
`tests/foxio_vectors/latest.pcapng.json`. `docs/implementation_notes.md` records
the reading.

## Verification

- `pytest tests/ -m "not spec_validation"` — 606 passed, 12 skipped, 86 subtests.
  The baseline was 601 passed, and the five new tests account for the difference.
- `pytest tests/ -m spec_validation` — 425 passed, 119 skipped, 263 xfailed, 0
  failed. This equals the baseline, so the deviation register needs no entry.
- Coverage 72%, above the floor of 70.
- `ruff check`, `ruff format --check` and `mypy ja4plus/` pass.

## Out of scope

- `ja4plus/fingerprinters/ja4.py:271` still holds the `if original_order:` branch
  whose two arms build the same string. No vector forces the fix. Epic 2 owns it.
- `tests/conformance_index.py` and `tests/foxio_deviations.json` are untouched.
  `RAW_SUFFIXES` already holds `_o`, so the harness compares no new method.
- `Processor` and the command-line program do not carry the new field. The
  structured-output schema and `FingerprintResult` define no field for it, and a
  change there is a spec change.

Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata (retrieved 2026-08-06)