### PR TITLE
fix(ja4ssh): emit one fingerprint every 200 SSH packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to ja4plus are documented here. The format is based
 on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING — JA4SSH emits one fingerprint for every 200 SSH packets** (#28).
+  The window triggered at `min(packet_count, 10)`, and a complete key exchange
+  also triggered it. A caller who relies on a fingerprint at 10 packets gets no
+  fingerprint now. FoxIO states the interval verbatim in
+  `technical_details/JA4SSH.png`: `(runs every 200 SSH packets by default)`. The
+  constructor argument `packet_count` sets the window, and it defaults to 200. A
+  bare ACK is not an SSH packet, and it does not advance the window. `ssh.pcapng`
+  now produces exactly one JA4SSH fingerprint, `c36s36_c76s124_c0s0`, which
+  equals the reference.
+
 ## [0.6.0] - 2026-05
 
 Major spec-compliance update against the May 2026 FoxIO JA4+ spec

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -79,11 +79,33 @@ not the round-trip time divided by 2.
 
 ## JA4SSH - SSH Traffic
 
-### Early fingerprint trigger
+### The fingerprint window
 
-The fingerprint window triggers at `min(configured_packet_count, 10)`,
-not at the configured count. Additionally triggers immediately when both
-HASSH fingerprints are available.
+The window holds 200 SSH packets by default, and the constructor argument
+`packet_count` sets it. `technical_details/JA4SSH.png` states the interval
+verbatim: `(runs every 200 SSH packets by default)`.
+
+The window counts the SSH packets of both directions. A bare ACK is not an SSH
+packet, and it does not advance the window. The image lists `SSH packets sent
+from client`, `SSH packets sent from server`, `Bare ACKs sent from client` and
+`Bare ACKs sent from server` as four separate fields. `ssh-scp-1050.pcap` confirms
+the reading: the reference holds four windows, each of 200 SSH packets, and the
+bare ACK counts of the four differ.
+
+Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/technical_details
+(retrieved 2026-08-06).
+
+**BUG (fixed by #28):** Before #28 the window triggered at
+`min(configured_packet_count, 10)`, and a complete key exchange also triggered
+it. A capture of 10 SSH packets produced a fingerprint that no reference
+implementation matches.
+
+### The remainder of a stream
+
+The reference emits the packets that remain when a stream ends. On `ssh-r.pcap`
+stream 1 the reference holds `c64s64_c6s5_c4s5`, which counts 11 SSH packets.
+ja4plus emits no such fingerprint, because it holds no end-of-capture step. The
+deviation register records the cases.
 
 ### Direction detection on non-standard ports
 

--- a/docs/specs/spec.md
+++ b/docs/specs/spec.md
@@ -182,7 +182,7 @@ change, and files nothing there.
 | Remote lookup | The command-line flag `--lookup` is opt-in, but `JA4DBClient.lookup` then calls `ja4db.com` on every miss with no second opt-in. | The remote fallback is a separate opt-in. | 2 | Separate the local lookup from the remote lookup. Epic 7. |
 | Mapping file refresh | `db update` and `db info` already exist. | The same two subcommands. | — | Already at parity. Keep a test that proves it. |
 | Shard key format | `tcp:ip:port->ip:port`. | The same format. | — | Already at parity. Keep a test that proves it. |
-| JA4SSH window | Emits at `min(packet_count, 10)`. | Emits at `min(packetCount, 10)`. | 1 | Both are wrong. FoxIO specifies 200. Fix here. Epic 1. |
+| JA4SSH window | Emits at `packet_count`, which defaults to 200. | Emits at `min(packetCount, 10)`. | 1 | Fixed here by #28. The port carries the defect at `ja4ssh.go:176`. |
 | Parity test | 6 tests that assert names exist. | Not applicable. | 3 | Replace with the shared vector suite. Epic 1. |
 
 Verified against: https://github.com/Crank-Git/ja4plus-go (`types.go`,

--- a/ja4plus/fingerprinters/ja4ssh.py
+++ b/ja4plus/fingerprinters/ja4ssh.py
@@ -16,6 +16,11 @@ from ja4plus.fingerprinters.base import BaseFingerprinter
 
 logger = logging.getLogger(__name__)
 
+# FoxIO emits one fingerprint for every 200 SSH packets. `technical_details/JA4SSH.png`
+# states it verbatim: `(runs every 200 SSH packets by default)`. A smaller window
+# produces a fingerprint that no reference implementation matches.
+DEFAULT_PACKET_COUNT = 200
+
 
 class JA4SSHFingerprinter(BaseFingerprinter):
     """
@@ -25,12 +30,12 @@ class JA4SSHFingerprinter(BaseFingerprinter):
     Also supports HASSH fingerprinting for client/server identification.
     """
 
-    def __init__(self, packet_count=200):
-        """
-        Initialize the fingerprinter.
+    def __init__(self, packet_count=DEFAULT_PACKET_COUNT):
+        """Build the fingerprinter.
 
         Args:
-            packet_count: Number of packets to analyze before generating a fingerprint
+            packet_count: The number of SSH packets in one window. A bare ACK is not an
+                SSH packet, and it does not advance the window.
         """
         super().__init__()
         self.connections = {}
@@ -158,19 +163,12 @@ class JA4SSHFingerprinter(BaseFingerprinter):
                 else:
                     conn["bare_acks"]["server"] += 1
 
-        # Check if we have enough packets to generate a fingerprint
-        total_packets = (
-            len(conn["ssh_packets"]["client"])
-            + len(conn["ssh_packets"]["server"])
-            + conn["bare_acks"]["client"]
-            + conn["bare_acks"]["server"]
-        )
+        # The window counts the SSH packets of both directions. The FoxIO image lists
+        # the SSH packet counts and the bare ACK counts as separate fields, so a bare
+        # ACK does not advance the window.
+        total_packets = len(conn["ssh_packets"]["client"]) + len(conn["ssh_packets"]["server"])
 
-        # For testing purposes, make sure we actually generate some fingerprints
-        # This ensures our tests will pass even with small sample packets
-        if total_packets >= min(self.packet_count, 10) or (
-            total_packets > 0 and conn["hassh"] and conn["hasshServer"]
-        ):
+        if total_packets >= self.packet_count:
             # Calculate most common packet sizes
             client_sizes = conn["ssh_packets"]["client"]
             server_sizes = conn["ssh_packets"]["server"]

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -139,10 +139,6 @@
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
   },
-  "gre-sample.pcap/JA4SSH": {
-    "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
-  },
   "http-empty-useragent.pcap/0:57722/JA4H.1": {
     "issue": 35,
     "cause": "ja4plus produces no JA4H value on this stream."
@@ -481,7 +477,7 @@
   },
   "ssh-r.pcap/0:64980/JA4SSH.2": {
     "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh-r.pcap/1:46394/JA4L-C.1": {
     "issue": 88,
@@ -493,7 +489,7 @@
   },
   "ssh-r.pcap/1:46394/JA4SSH.1": {
     "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh-r.pcap/2:46396/JA4L-C.1": {
     "issue": 88,
@@ -507,21 +503,9 @@
     "issue": 28,
     "cause": "The produced JA4SSH value differs from the reference."
   },
-  "ssh-r.pcap/2:46396/JA4SSH.2": {
-    "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
-  "ssh-r.pcap/2:46396/JA4SSH.3": {
-    "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
-  "ssh-r.pcap/2:46396/JA4SSH.4": {
-    "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
   "ssh-r.pcap/2:46396/JA4SSH.5": {
     "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh-r.pcap/JA4L-C": {
     "issue": 34,
@@ -529,7 +513,7 @@
   },
   "ssh-r.pcap/JA4SSH": {
     "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
+    "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
   },
   "ssh-scp-1050.pcap/0:49237/JA4L-C.1": {
     "issue": 88,
@@ -540,10 +524,6 @@
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.1": {
-    "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
-  "ssh-scp-1050.pcap/0:49237/JA4SSH.2": {
     "issue": 28,
     "cause": "The produced JA4SSH value differs from the reference."
   },
@@ -559,18 +539,6 @@
     "issue": 34,
     "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
   },
-  "ssh-scp-1050.pcap/JA4SSH": {
-    "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
-  },
-  "ssh.pcapng/0:57377/JA4SSH.1": {
-    "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
-  "ssh.pcapng/JA4SSH": {
-    "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
-  },
   "ssh2-malformed.pcap/0:61672/JA4L-C.1": {
     "issue": 88,
     "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
@@ -583,10 +551,6 @@
     "issue": 34,
     "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
   },
-  "ssh2-malformed.pcap/JA4SSH": {
-    "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
-  },
   "ssh2-moloch-crash.pcap/0:61672/JA4L-C.1": {
     "issue": 88,
     "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
@@ -598,10 +562,6 @@
   "ssh2-moloch-crash.pcap/JA4L-C": {
     "issue": 34,
     "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "ssh2-moloch-crash.pcap/JA4SSH": {
-    "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
   },
   "ssh2.pcapng/11:57374/JA4L-C.1": {
     "issue": 88,
@@ -657,7 +617,7 @@
   },
   "ssh2.pcapng/14:57377/JA4SSH.2": {
     "issue": 28,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh2.pcapng/15:57380/JA4L-C.1": {
     "issue": 88,
@@ -717,7 +677,7 @@
   },
   "ssh2.pcapng/JA4SSH": {
     "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
+    "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
   },
   "ssh2.pcapng/JA4X": {
     "issue": 78,
@@ -738,10 +698,6 @@
   "sshv1.pcap/JA4L-S": {
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
-  },
-  "sshv1.pcap/JA4SSH": {
-    "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
   },
   "tcpdump-geneve.pcap/0:51225/JA4L-C.1": {
     "issue": 88,
@@ -1002,9 +958,5 @@
   "v6.pcap/JA4L-S": {
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
-  },
-  "v6.pcap/JA4SSH": {
-    "issue": 28,
-    "cause": "ja4plus produces a JA4SSH fingerprint the reference does not hold."
   }
 }

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -472,11 +472,11 @@
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
   "ssh-r.pcap/0:64980/JA4SSH.1": {
-    "issue": 28,
+    "issue": 92,
     "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-r.pcap/0:64980/JA4SSH.2": {
-    "issue": 28,
+    "issue": 92,
     "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh-r.pcap/1:46394/JA4L-C.1": {
@@ -488,7 +488,7 @@
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
   "ssh-r.pcap/1:46394/JA4SSH.1": {
-    "issue": 28,
+    "issue": 92,
     "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh-r.pcap/2:46396/JA4L-C.1": {
@@ -500,11 +500,11 @@
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
   "ssh-r.pcap/2:46396/JA4SSH.1": {
-    "issue": 28,
+    "issue": 92,
     "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-r.pcap/2:46396/JA4SSH.5": {
-    "issue": 28,
+    "issue": 92,
     "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh-r.pcap/JA4L-C": {
@@ -512,7 +512,7 @@
     "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
   },
   "ssh-r.pcap/JA4SSH": {
-    "issue": 28,
+    "issue": 92,
     "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
   },
   "ssh-scp-1050.pcap/0:49237/JA4L-C.1": {
@@ -524,15 +524,15 @@
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.1": {
-    "issue": 28,
+    "issue": 92,
     "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.3": {
-    "issue": 28,
+    "issue": 92,
     "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.4": {
-    "issue": 28,
+    "issue": 92,
     "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-scp-1050.pcap/JA4L-C": {
@@ -612,11 +612,11 @@
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
   "ssh2.pcapng/14:57377/JA4SSH.1": {
-    "issue": 28,
+    "issue": 92,
     "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh2.pcapng/14:57377/JA4SSH.2": {
-    "issue": 28,
+    "issue": 92,
     "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh2.pcapng/15:57380/JA4L-C.1": {
@@ -676,7 +676,7 @@
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
   },
   "ssh2.pcapng/JA4SSH": {
-    "issue": 28,
+    "issue": 92,
     "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
   },
   "ssh2.pcapng/JA4X": {

--- a/tests/generate_foxio_baseline.py
+++ b/tests/generate_foxio_baseline.py
@@ -42,11 +42,15 @@ from tests.foxio_deviations import (  # noqa: E402 - the path insert must run fi
 from tests.foxio_manifest import MANIFEST_PATH  # noqa: E402 - the path insert must run first
 
 # The issue that owns each method. #12 records the measurement that assigns them.
+#
+# #28 fixed the JA4SSH window, and it owns no case now. Every JA4SSH case that
+# remains sits on a capture that holds more than one window. A capture of one window
+# conforms, and a capture of several does not. #92 owns them.
 OWNING_ISSUES = {
     "JA4": 13,
     "JA4S": 13,
     "JA4H": 35,
-    "JA4SSH": 28,
+    "JA4SSH": 92,
     "JA4X": 78,
 }
 

--- a/tests/test_ja4ssh_window.py
+++ b/tests/test_ja4ssh_window.py
@@ -1,0 +1,138 @@
+"""Tests for the JA4SSH window.
+
+FoxIO states the interval verbatim in `technical_details/JA4SSH.png`:
+`(runs every 200 SSH packets by default)`. The image lists the SSH packet counts and
+the bare ACK counts as separate fields, so a bare ACK does not advance the window.
+
+Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/technical_details
+(retrieved 2026-08-06).
+"""
+
+import struct
+from pathlib import Path
+
+import pytest
+from scapy.all import IP, TCP, Raw
+
+from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+
+CLIENT = "10.0.0.1"
+SERVER = "10.0.0.2"
+CLIENT_PORT = 50000
+SERVER_PORT = 22
+
+VECTOR = Path(__file__).parent / "foxio_vectors" / "ssh.pcapng"
+
+# The reference value for `ssh.pcapng`, stream 0.
+# Verified against:
+# https://github.com/FoxIO-LLC/ja4/blob/main/python/test/testdata/ssh.pcapng.json
+# (retrieved 2026-08-06).
+SSH_PCAPNG_EXPECTED = "c36s36_c76s124_c0s0"
+
+
+def ssh_packet(to_server=True, size=36):
+    """Return one SSH data packet of the given payload size.
+
+    Args:
+        to_server: True for a client packet, False for a server packet.
+        size: The payload length in bytes. The minimum is 6.
+
+    Returns:
+        A scapy packet that `is_ssh_packet` accepts.
+    """
+    payload = struct.pack(">I", size - 4) + bytes([4, 94]) + b"A" * (size - 6)
+    if to_server:
+        return (
+            IP(src=CLIENT, dst=SERVER)
+            / TCP(sport=CLIENT_PORT, dport=SERVER_PORT)
+            / Raw(load=payload)
+        )
+    return (
+        IP(src=SERVER, dst=CLIENT) / TCP(sport=SERVER_PORT, dport=CLIENT_PORT) / Raw(load=payload)
+    )
+
+
+def bare_ack(to_server=True):
+    """Return one bare ACK packet, which carries no payload."""
+    if to_server:
+        return IP(src=CLIENT, dst=SERVER) / TCP(sport=CLIENT_PORT, dport=SERVER_PORT, flags="A")
+    return IP(src=SERVER, dst=CLIENT) / TCP(sport=SERVER_PORT, dport=CLIENT_PORT, flags="A")
+
+
+def test_the_default_window_emits_no_fingerprint_at_ten_packets():
+    fingerprinter = JA4SSHFingerprinter()
+    for index in range(10):
+        assert fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0)) is None
+    assert fingerprinter.get_fingerprints() == []
+
+
+def test_the_default_window_emits_one_fingerprint_at_two_hundred_packets():
+    fingerprinter = JA4SSHFingerprinter()
+    results = [
+        fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0)) for index in range(200)
+    ]
+    assert results[:199] == [None] * 199
+    assert results[199] == "c36s36_c100s100_c0s0"
+    assert len(fingerprinter.get_fingerprints()) == 1
+
+
+def test_a_bare_ack_does_not_advance_the_window():
+    fingerprinter = JA4SSHFingerprinter()
+    for index in range(199):
+        fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0))
+    for _ in range(50):
+        assert fingerprinter.process_packet(bare_ack()) is None
+    assert fingerprinter.process_packet(ssh_packet(to_server=False)) == "c36s36_c100s100_c50s0"
+
+
+def test_the_window_counters_reset_after_a_fingerprint():
+    fingerprinter = JA4SSHFingerprinter()
+    for index in range(200):
+        fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0))
+    for index in range(200):
+        result = fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0))
+    assert result == "c36s36_c100s100_c0s0"
+    assert len(fingerprinter.get_fingerprints()) == 2
+
+
+def test_the_caller_sets_the_window_size():
+    fingerprinter = JA4SSHFingerprinter(packet_count=10)
+    results = [
+        fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0)) for index in range(10)
+    ]
+    assert results[:9] == [None] * 9
+    assert results[9] == "c36s36_c5s5_c0s0"
+
+
+def test_both_hassh_values_do_not_emit_a_fingerprint():
+    """A complete key exchange fills no window. Only 200 SSH packets do."""
+    fingerprinter = JA4SSHFingerprinter()
+    kexinit = (
+        b"\x00\x00\x05\xdc\x06\x14AAAAAAAAAASSH_MSG_KEXINIT"
+        b"curve25519-sha256@libssh.org,ecdh-sha2-nistp256;"
+        b"aes128-ctr,aes256-ctr;hmac-sha1,hmac-sha2-256;none"
+    )
+    client = (
+        IP(src=CLIENT, dst=SERVER) / TCP(sport=CLIENT_PORT, dport=SERVER_PORT) / Raw(load=kexinit)
+    )
+    server = (
+        IP(src=SERVER, dst=CLIENT) / TCP(sport=SERVER_PORT, dport=CLIENT_PORT) / Raw(load=kexinit)
+    )
+    assert fingerprinter.process_packet(client) is None
+    assert fingerprinter.process_packet(server) is None
+    connection = list(fingerprinter.connections.values())[0]
+    assert connection["hassh"] is not None
+    assert connection["hasshServer"] is not None
+    assert fingerprinter.get_fingerprints() == []
+
+
+@pytest.mark.skipif(not VECTOR.exists(), reason="the FoxIO vector is not available")
+def test_the_ssh_vector_produces_one_fingerprint():
+    from scapy.all import rdpcap
+
+    fingerprinter = JA4SSHFingerprinter()
+    for packet in rdpcap(str(VECTOR)):
+        fingerprinter.process_packet(packet)
+
+    values = [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
+    assert values == [SSH_PCAPNG_EXPECTED]


### PR DESCRIPTION
Closes #28.

## What changed

`ja4plus/fingerprinters/ja4ssh.py` triggered the window at
`min(self.packet_count, 10)`, above a comment that read `# For testing purposes`.
A complete key exchange also triggered it. The window now triggers at
`self.packet_count`, which defaults to 200.

The window counts the SSH packets of both directions. It no longer counts bare
ACKs. The bare ACK counters still reset with the window.

**This is a breaking change.** A caller who relies on a JA4SSH fingerprint at 10
packets gets no fingerprint now. `CHANGELOG.md` records it under `[Unreleased]`.

## The FoxIO material

`technical_details/JA4SSH.png` states the interval verbatim:
`(runs every 200 SSH packets by default)`.

The same image lists four separate fields: `SSH packets sent from client`, `SSH
packets sent from server`, `Bare ACKs sent from client`, and `Bare ACKs sent from
server`. The image does not state whether a bare ACK advances the window. The
vectors settle it. `ssh-scp-1050.pcap` holds four windows, `c52s148`, `c13s187`,
`c0s200` and `c0s200`. Each counts 200 SSH packets, and the bare ACK counts of
the four differ. A bare ACK therefore does not advance the window.

`ssh.pcapng` holds one expected fingerprint, `c36s36_c76s124_c0s0`. The two
counts sum to 200.

Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/technical_details
(retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/test/testdata/ssh.pcapng.json
(retrieved 2026-08-06)

## Acceptance criteria

| Criterion | Evidence |
|---|---|
| A JA4SSH fingerprinter built with default arguments emits nothing at 10 packets. | `test_the_default_window_emits_no_fingerprint_at_ten_packets` |
| A JA4SSH fingerprinter built with default arguments emits one fingerprint at 200 SSH packets. | `test_the_default_window_emits_one_fingerprint_at_two_hundred_packets` |
| `ssh.pcapng` produces exactly one JA4SSH fingerprint, and it equals `c36s36_c76s124_c0s0`. | `test_the_ssh_vector_produces_one_fingerprint`, and the conformance case `ssh.pcapng-stream0:57377-JA4SSH.1` now passes |
| A caller who passes `packet_count=10` gets a window of 10. | `test_the_caller_sets_the_window_size` |

The tests came first. Every one of them failed against the old code, except the
`packet_count=10` case, which `min(10, 10)` already satisfied.

## The register

`tests/foxio_deviations.json` is regenerated with
`tests/generate_foxio_baseline.py`. It holds 240 entries, and it held 252.

Twelve of the 24 entries that named #28 are gone:

```
gre-sample.pcap/JA4SSH            ssh-scp-1050.pcap/0:49237/JA4SSH.2
ssh-r.pcap/2:46396/JA4SSH.2       ssh-scp-1050.pcap/JA4SSH
ssh-r.pcap/2:46396/JA4SSH.3       ssh.pcapng/0:57377/JA4SSH.1
ssh-r.pcap/2:46396/JA4SSH.4       ssh.pcapng/JA4SSH
ssh2-malformed.pcap/JA4SSH        ssh2-moloch-crash.pcap/JA4SSH
sshv1.pcap/JA4SSH                 v6.pcap/JA4SSH
```

Twelve survive, and **#92 owns all twelve**. No survivor names the window size.
Every one sits on a capture that holds more than one window: `ssh-r.pcap` streams
0, 1 and 2, `ssh-scp-1050.pcap` stream 0, and `ssh2.pcapng` stream 14. A capture
of one window conforms now, and a capture of several does not.

`tests/generate_foxio_baseline.py` names the owner of each method, so the
re-attribution is one line of that program: `OWNING_ISSUES["JA4SSH"]` reads 92.
The register is regenerated from it, the twelve cause lines are unchanged, and
`#28` owns no entry.

The twelve hold three causes:

1. **The reference emits the remainder of a stream, and ja4plus does not.** Five
   cases: `ssh-r.pcap/0:64980/JA4SSH.2`, `ssh-r.pcap/1:46394/JA4SSH.1`,
   `ssh-r.pcap/2:46396/JA4SSH.5`, `ssh2.pcapng/14:57377/JA4SSH.2`, and the two
   occurrence-key entries `ssh-r.pcap/JA4SSH` and `ssh2.pcapng/JA4SSH`. On
   `ssh-r.pcap` stream 1 the reference holds `c64s64_c6s5_c4s5`, which counts 11
   SSH packets. A fix needs an end-of-capture step, which the conformance harness
   does not call today.
2. **ja4plus counts one client bare ACK too few.** Three cases:
   `ssh-r.pcap/0:64980/JA4SSH.1` (`c74s10` against `c73s10`),
   `ssh-scp-1050.pcap/0:49237/JA4SSH.1` (`c41s4` against `c40s4`), and
   `ssh2.pcapng/14:57377/JA4SSH.1` (`c74s5` against `c73s5`). ja4plus creates the
   connection on the first SSH data packet, so it drops the bare ACKs that
   precede that packet.
3. **The reference holds a packet-length mode for a direction that sent no SSH
   packet in the window.** Two cases: `ssh-scp-1050.pcap/0:49237/JA4SSH.3` and
   `.JA4SSH.4`, where the reference holds `c112s1460` and ja4plus produces
   `c0s1460`. `ssh-r.pcap/2:46396/JA4SSH.1` holds a third mode difference,
   `c64s64` against `c76s76`.

No entry of another method changed. `tests/foxio_vector_manifest.json` is
unchanged.

## Parity

The Go port carries the same defect at `ja4ssh.go:176`. This pull request does
not touch that repository. `docs/specs/spec.md` records the divergence.

## Verification

```
pytest tests/ -m "not spec_validation"   624 passed, 12 skipped, 86 subtests
pytest tests/ -m spec_validation         454 passed, 145 skipped, 240 xfailed, 0 failed
ruff check ja4plus/ tests/               All checks passed!
ruff format --check ja4plus/ tests/      76 files already formatted
mypy ja4plus/                            Success: no issues found in 25 source files
coverage                                 TOTAL 71%
```

The unit suite held 617 passed before this change, and the seven new tests bring
it to 624. No existing test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

