### PR TITLE
Read a loopback capture the same way on every host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A loopback capture that carries IPv6 now reads the same way on every host**
+  (#94). A capture whose link type is `DLT_NULL` starts each frame with the
+  address family value of the host that captured it. That value is 24 on NetBSD
+  and OpenBSD, 28 on FreeBSD, and 30 on Darwin. scapy binds one value,
+  `socket.AF_INET6`, which is 10 on Linux, and no capture holds 10. `ipv6.pcapng`,
+  `tls-alpn-h2.pcap` and `http-empty-useragent.pcap` therefore produced
+  fingerprints on macOS and none on Linux. `ja4plus` binds all three BSD values
+  when a caller imports it, and the conformance suite now reports the same counts
+  on both hosts.
+
 ### Changed
 
 - **BREAKING — JA4SSH emits one fingerprint for every 200 SSH packets** (#28).

--- a/docs/specs/features/01-spec-conformance.md
+++ b/docs/specs/features/01-spec-conformance.md
@@ -3,7 +3,7 @@ id: spec-conformance
 feature: Spec conformance
 epic: "Epic 1: Spec conformance"
 status: issued
-issues: [12, 27, 28, 29, 30, 31, 78, 80]
+issues: [12, 27, 28, 29, 30, 31, 78, 80, 94]
 mockups: []
 ---
 
@@ -60,6 +60,12 @@ ambiguous part of the specification.
 FR-spec-conformance-12 — `tests/test_parity.py` no longer asserts that a name
 exists.
 
+FR-spec-conformance-13 — The conformance suite reports the same counts on every
+host.
+
+FR-spec-conformance-14 — `ja4plus` reads the IPv6 layer of a loopback capture on
+every host.
+
 ## User flows
 
 **A maintainer fixes a failing method.**
@@ -106,6 +112,14 @@ This feature set has no screen. Its output is the test report.
   `JA4` and `JA4_r`.
 - No fingerprinter changes in a way that a vector does not require. A change that
   no vector covers belongs to Epic 2.
+- A vector produces one result on every host. A capture whose link type is
+  `DLT_NULL` starts each frame with the address family value of the host that
+  captured it, and that value is 24 on NetBSD and OpenBSD, 28 on FreeBSD, and 30
+  on Darwin. `ja4plus` binds all three values to the IPv6 layer, because scapy
+  binds only the value of the reading host.
+- A register entry names a real deviation from FoxIO. A failure that one host
+  produces and another host does not is a defect in this project, and it never
+  earns a register entry.
 
 ## Data touched
 
@@ -118,6 +132,10 @@ This feature set has no screen. Its output is the test report.
   method and by occurrence, so one test case compares one value.
 - Changed file `tests/test_parity.py`.
 - Changed file `docs/implementation_notes.md`.
+- New file `ja4plus/utils/loopback.py`. It binds the BSD address family values of
+  a loopback frame to the IPv6 layer.
+- New file `tests/test_loopback_link_type.py`.
+- Changed file `ja4plus/__init__.py`.
 
 ## Interfaces
 
@@ -147,6 +165,21 @@ Verified against:
 https://github.com/FoxIO-LLC/ja4/blob/main/python/test/testdata/ssh.pcapng.json
 (retrieved 2026-08-06).
 
+libpcap defines the address family value of a `DLT_NULL` frame. The value of
+`AF_INET6` is 24 on NetBSD, OpenBSD and BSD/OS, 28 on FreeBSD, and 30 on Darwin.
+libpcap reads all three values from a savefile, and it reads one value from a live
+capture.
+
+Verified against:
+https://github.com/the-tcpdump-group/libpcap/blob/f98637ad7f086a34c4027339c9639ae1ef842df3/gencode.c#L3333-L3354
+(retrieved 2026-08-06).
+
+scapy names 24, 28 and 30 as IPv6 in `LOOPBACK_TYPES`, and binds `socket.AF_INET6`
+alone. That value is 10 on Linux.
+
+Verified against: `scapy/layers/inet6.py:4226-4228` and `scapy/layers/l2.py:720-724`
+(scapy 2.7.0).
+
 ## Edge cases & failures
 
 | Case | What happens |
@@ -158,6 +191,8 @@ https://github.com/FoxIO-LLC/ja4/blob/main/python/test/testdata/ssh.pcapng.json
 | A TTL implies a negative hop count. | The hop count is clamped to zero and the factor is 1.5. |
 | A vector holds a method key this project does not implement, such as `JA4TScan`. | The suite ignores the key. |
 | The reference emits two fingerprints and this project emits one. | The suite fails and names the missing occurrence. |
+| A capture holds the `DLT_NULL` link type and the address family value 24, 28 or 30. | The reader dissects the frame as IPv6 on every host. |
+| A caller builds a loopback frame. | The address family value is the scapy default. This project binds the dissection path alone. |
 
 ## Acceptance criteria
 
@@ -176,6 +211,12 @@ https://github.com/FoxIO-LLC/ja4/blob/main/python/test/testdata/ssh.pcapng.json
 - [ ] `calculate_distance(latency, propagation_factor=1.6)` uses 1.6.
 - [ ] `docs/implementation_notes.md` records one entry for each ambiguous reading.
 - [ ] No test in `tests/test_parity.py` asserts only that an attribute exists.
+- [ ] `pytest tests/ -m spec_validation` reports the same counts on Linux and on
+      macOS.
+- [ ] A loopback frame that holds the address family value 24, 28 or 30 dissects
+      as IPv6.
+- [ ] `ipv6.pcapng` produces the JA4 value `t12d4605h2_85626a9a5f7f_aaf95bb78ec9`
+      on Linux and on macOS.
 
 ## Out of scope
 

--- a/ja4plus/__init__.py
+++ b/ja4plus/__init__.py
@@ -30,6 +30,13 @@ from ja4plus.fingerprinters.ja4ts import generate_ja4ts
 from ja4plus.fingerprinters.ja4d import generate_ja4d
 from ja4plus.fingerprinters.ja4d6 import generate_ja4d6
 
+from ja4plus.utils.loopback import bind_loopback_ipv6
+
+# scapy binds one loopback address family value, the value of the reading host. Without
+# this call a loopback capture that carries IPv6 produces fingerprints on Darwin and
+# none on Linux. Issue #94 records the measurement.
+bind_loopback_ipv6()
+
 
 def compute_ja4x_from_der(cert_der_bytes):
     """Compute the JA4X fingerprint for a DER-encoded X.509 certificate.

--- a/ja4plus/utils/loopback.py
+++ b/ja4plus/utils/loopback.py
@@ -1,0 +1,49 @@
+"""Bind every BSD address family value of a loopback frame to the IPv6 layer.
+
+A capture whose link type is `DLT_NULL` starts each frame with a four-byte address
+family value. libpcap writes the value of the host that captured the frame. The value
+of `AF_INET6` is 24 on NetBSD and OpenBSD, 28 on FreeBSD, and 30 on Darwin.
+
+scapy binds one of those values, `socket.AF_INET6`. That value is 30 on Darwin and 10
+on Linux, and no capture holds 10. A loopback capture that carries IPv6 therefore
+dissects on Darwin and returns raw bytes on Linux, and the same capture then produces a
+different set of fingerprints on each host.
+
+Verified against:
+https://github.com/the-tcpdump-group/libpcap/blob/f98637ad7f086a34c4027339c9639ae1ef842df3/gencode.c#L3333-L3354
+(retrieved 2026-08-06).
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# The address family value each BSD family writes into a `DLT_NULL` frame. scapy names
+# all three as IPv6 in `LOOPBACK_TYPES`, and binds only the value of the reading host.
+BSD_AF_INET6_VALUES = (0x18, 0x1C, 0x1E)
+
+# A second bind appends a second entry to the scapy dissection table. The entry is
+# harmless and it is also waste, so the module binds once.
+_bound = False
+
+
+def bind_loopback_ipv6():
+    """Bind the BSD address family values of a loopback frame to the IPv6 layer.
+
+    The bind reaches the dissection path alone. A caller that builds a loopback frame
+    keeps the scapy default, so this call changes no packet this library writes.
+
+    Returns:
+        None.
+    """
+    from scapy.layers.inet6 import IPv6
+    from scapy.layers.l2 import Loopback
+    from scapy.packet import bind_bottom_up
+
+    global _bound
+    if _bound:
+        return
+    for family_value in BSD_AF_INET6_VALUES:
+        bind_bottom_up(Loopback, IPv6, type=family_value)
+    _bound = True
+    logger.debug("bound the BSD AF_INET6 values %s to IPv6", BSD_AF_INET6_VALUES)

--- a/tests/test_loopback_link_type.py
+++ b/tests/test_loopback_link_type.py
@@ -1,0 +1,65 @@
+"""Tests that a loopback capture dissects as IPv6 on every host.
+
+A capture whose link type is `DLT_NULL` starts each frame with a four-byte address
+family value. libpcap writes the value of the host that captured the frame. The value
+of `AF_INET6` is 24 on NetBSD and OpenBSD, 28 on FreeBSD, and 30 on Darwin.
+
+scapy binds one of those values, `socket.AF_INET6`. That value is 30 on Darwin and 10
+on Linux. No capture holds 10, so a loopback capture that carries IPv6 dissects on
+Darwin and returns raw bytes on Linux. These tests hold the reading host out of the
+result.
+"""
+
+import json
+import pathlib
+
+import pytest
+from scapy.layers.inet6 import IPv6
+from scapy.layers.l2 import Loopback
+from scapy.packet import Raw
+
+# The `ja4plus` package binds the loopback address family values when a caller imports
+# it. The import states that a user of the library needs no further call.
+import ja4plus  # noqa: F401
+
+VECTOR_DIRECTORY = pathlib.Path(__file__).parent / "foxio_vectors"
+
+# The address family value each BSD family writes into a `DLT_NULL` frame. scapy names
+# all three as IPv6 in `LOOPBACK_TYPES`.
+BSD_AF_INET6_VALUES = (0x18, 0x1C, 0x1E)
+
+
+@pytest.mark.parametrize("family_value", BSD_AF_INET6_VALUES)
+def test_dissects_every_bsd_address_family_value_as_ipv6(family_value):
+    """The IPv6 layer of a loopback frame reaches a reader on every host."""
+    from scapy.layers.inet import TCP
+
+    frame = bytes(
+        Loopback(type=family_value) / IPv6(src="::1", dst="::2") / TCP(sport=1, dport=443)
+    )
+
+    packet = Loopback(frame)
+
+    assert IPv6 in packet, "a loopback frame with family {} holds no IPv6 layer".format(
+        hex(family_value)
+    )
+    assert packet[IPv6].dst == "::2"
+    assert Raw not in packet
+
+
+def test_the_ipv6_vector_produces_the_reference_ja4_fingerprint():
+    """The `ipv6.pcapng` vector produces the JA4 value the reference names."""
+    from scapy.all import rdpcap
+
+    from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+
+    capture = VECTOR_DIRECTORY / "ipv6.pcapng"
+    expected = json.loads((VECTOR_DIRECTORY / "ipv6.pcapng.json").read_text())[0]["JA4.1"]
+
+    fingerprinter = JA4Fingerprinter()
+    for packet in rdpcap(str(capture)):
+        fingerprinter.process_packet(packet)
+
+    produced = [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
+
+    assert produced == [expected]


### PR DESCRIPTION
## What

`ja4plus` binds the three BSD address family values of a loopback frame to the IPv6
layer. A loopback capture that carries IPv6 now produces the same fingerprints on
Linux and on macOS.

Refs #94. Part of #12.

## Why

Pull request #93 was green on macOS and red on `ubuntu-latest` with 17 failures, all
on an IPv6 stream.

The cause is the `DLT_NULL` link type, not the harness and not a fingerprinter. A
capture whose link type is `DLT_NULL` starts each frame with a four-byte address
family value, and libpcap writes the value of the host that captured the frame. The
value of `AF_INET6` is 24 on NetBSD and OpenBSD, 28 on FreeBSD, and 30 on Darwin.

scapy names all three values as IPv6 in `LOOPBACK_TYPES`, and then binds one value,
`socket.AF_INET6`. That value is 30 on Darwin and 10 on Linux. No capture holds 10,
so **no `DLT_NULL` IPv6 capture dissects on Linux at all**.

Three vectors hold `DLT_NULL` with the value 30: `ipv6.pcapng`, `tls-alpn-h2.pcap`
and `http-empty-useragent.pcap`. On Linux each frame stopped at `Loopback / Raw`, so
every fingerprinter received a packet with no IPv6 layer and no TCP layer, and
produced nothing.

## Evidence

The suite ran in `python:3.13-slim` on the merge base, and it reproduced the
continuous-integration result exactly:

```
17 failed, 437 passed, 145 skipped, 636 deselected, 240 xfailed
```

`index_produced("tests/foxio_vectors/ipv6.pcapng")` returned every method on macOS
and an empty map on Linux. The Linux dissection of the first frame:

```
packets: 9
0 Loopback / Raw
has IPv6: 0 has TCP: 0
JA4 fps: []
```

The first byte of that frame is `\x1e`, which is 30.

**macOS is the correct environment.** The reference values in
`tests/foxio_vectors/ipv6.pcapng.json` do not depend on a host, and macOS produces
them. Linux produced nothing, which is neither the reference value nor a deviation
from FoxIO. **No case earned a register entry**; `tests/foxio_deviations.json` is
unchanged and the registered count stays 240.

## How tested

Test-first. `tests/test_loopback_link_type.py` holds two tests:

- `test_dissects_every_bsd_address_family_value_as_ipv6` builds a loopback frame for
  each of 24, 28 and 30, and asserts the IPv6 layer. Before the fix it failed for 24
  and 28 on macOS, and for all three on Linux. This test reproduces the platform
  difference on any host.
- `test_the_ipv6_vector_produces_the_reference_ja4_fingerprint` reads `ipv6.pcapng`
  and asserts the JA4 value the reference names. Before the fix it failed on Linux
  and passed on macOS.

Full local suite, macOS on Python 3.14:

```
pytest tests/ -m spec_validation     454 passed, 145 skipped, 640 deselected, 240 xfailed
pytest tests/ -m "not spec_validation"  628 passed, 12 skipped, 86 subtests passed
coverage                             71% (floor 70)
ruff check                           All checks passed!
ruff format --check                  78 files already formatted
mypy ja4plus/                        Success: no issues found in 26 source files
```

Full local suite, Linux `python:3.13-slim` on the same commit:

```
pytest tests/ -m spec_validation     454 passed, 145 skipped, 640 deselected, 240 xfailed
pytest tests/ -m "not spec_validation"  628 passed, 12 skipped, 86 subtests passed
```

The two hosts report the same counts.

## Notes

`bind_bottom_up` reaches the dissection path alone, so a caller that builds a
loopback frame keeps the scapy default. This project writes no packet.

Verified against: https://github.com/the-tcpdump-group/libpcap/blob/f98637ad7f086a34c4027339c9639ae1ef842df3/gencode.c#L3333-L3354 (libpcap, retrieved 2026-08-06)
Verified against: `scapy/layers/inet6.py:4226-4228` and `scapy/layers/l2.py:720-724` (scapy 2.7.0)