### PR TITLE
Emit every JA4SSH window on a long connection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,7 @@
       "Bash(mkdocs build:*)",
       "Bash(mkdocs serve:*)",
       "Bash(python tests/download_test_vectors.py:*)",
+      "Bash(tshark:*)",
       "Bash(git:*)",
       "Bash(gh:*)"
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `ssh-scp-1050.pcap` and `ssh2.pcapng` now equal the reference on their first
   window. `ssh.pcapng` holds no bare ACK, and it stays at `c36s36_c76s124_c0s0`.
 
+- **JA4SSH emits the window a connection holds open when it closes** (#92). A
+  connection that carries fewer than 200 SSH packets produced no fingerprint at
+  all, and a connection that closed part way through a window lost those packets.
+  `ja4plus` now emits that window on a packet that carries the FIN flag and the ACK
+  flag, which is the rule `python/ja4.py` states above `finalize_ja4ssh`. An empty
+  window emits nothing. `ssh-r.pcap` now produces the occurrence keys the reference
+  holds on all three of its streams.
+
+### Divergence from the FoxIO reference
+
+- **JA4SSH declines three results of the reference** (#96, #97, #105). Each one
+  describes the capture and not the connection, so it cannot be compared against
+  the output of another tool. The reference reads its mode field from the packet
+  lengths of every connection in the capture, because `dict(ja4sh_stats)` shares
+  one payload list (#96). It writes an extra occurrence from a window of zero SSH
+  packets whenever a bare ACK follows a window boundary (#97). It emits no trailing
+  window for the connection it holds at stream index 0, because `finalize_ja4ssh`
+  guards with `if stream:` (#105). `ja4plus` reads the window alone, emits a value
+  only for a window that holds SSH packets, and emits the trailing window for every
+  connection that closes. `docs/implementation_notes.md` holds the measurement.
+
 - **A loopback capture that carries IPv6 now reads the same way on every host**
   (#94). A capture whose link type is `DLT_NULL` starts each frame with the
   address family value of the host that captured it. That value is 24 on NetBSD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **BREAKING — JA4SSH counts a bare ACK the way FoxIO counts one** (#92). A bare
+  ACK carries the ACK flag alone and no payload. `ja4plus` read the ACK flag
+  alone, so it counted a SYN+ACK, a FIN+ACK and a RST+ACK as bare ACKs. It also
+  created its state table entry on the first SSH packet, so it dropped the ACK
+  that completes the TCP handshake. The two ACK counts of a JA4SSH fingerprint
+  therefore change on any connection that carries a bare ACK. `ssh-r.pcap`,
+  `ssh-scp-1050.pcap` and `ssh2.pcapng` now equal the reference on their first
+  window. `ssh.pcapng` holds no bare ACK, and it stays at `c36s36_c76s124_c0s0`.
+
 - **A loopback capture that carries IPv6 now reads the same way on every host**
   (#94). A capture whose link type is `DLT_NULL` starts each frame with the
   address family value of the host that captured it. That value is 24 on NetBSD

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -100,12 +100,66 @@ Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/technical_details
 it. A capture of 10 SSH packets produced a fingerprint that no reference
 implementation matches.
 
+### The bare ACK
+
+A bare ACK is one packet that carries the ACK flag alone and no payload. FoxIO
+counts one only when the TCP flags equal `0x0010`, so a SYN+ACK, a FIN+ACK and a
+RST+ACK never reach the bare-ACK counter.
+
+The ACK that completes the TCP handshake is a bare ACK, and it arrives before the
+first SSH packet of the connection. FoxIO counts it, because `python/ja4.py` holds
+a state table entry for every packet whose source port or destination port is 22.
+Four vectors confirm the reading. `ssh-r.pcap`, `ssh-scp-1050.pcap` and
+`ssh2.pcapng` each hold one bare client ACK before the first SSH packet, and each
+reference value reports one more client ACK than a state table built on SSH data
+alone. `ssh.pcapng` holds no bare ACK, and its value is unchanged.
+
+Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4ssh.py
+(retrieved 2026-08-06).
+
+**BUG (fixed by #92):** Before #92 the fingerprinter created a state table entry
+on the first SSH packet, so it dropped the ACK of the TCP handshake. It also read
+the ACK flag alone, so it counted a SYN+ACK, a FIN+ACK and a RST+ACK as bare ACKs.
+
 ### The remainder of a stream
 
-The reference emits the packets that remain when a stream ends. On `ssh-r.pcap`
-stream 1 the reference holds `c64s64_c6s5_c4s5`, which counts 11 SSH packets.
-ja4plus emits no such fingerprint, because it holds no end-of-capture step. The
-deviation register records the cases.
+The reference emits the packets that remain on some connections and not on others,
+and the vectors do not settle the condition. On `ssh-r.pcap` stream 1 the reference
+holds `c64s64_c6s5_c4s5`, which counts 11 SSH packets. `gre-sample.pcap`,
+`sshv1.pcap` and `v6.pcap` each hold one SSH connection of the same shape, with a
+banner, data packets and a FIN packet, and the reference holds no JA4SSH value for
+any of them.
+
+`python/ja4.py` runs `finalize_ja4ssh` on a packet that carries the FIN flag and
+the ACK flag, and that function acts only when `entry['protos']` ends with `:ssh`.
+Every FIN+ACK packet of these captures carries no payload, so the condition depends
+on a `tshark` protocol label that a capture file alone does not give. ja4plus emits
+no value for a window a connection holds open, because a rule that emits one gives
+`gre-sample.pcap`, `sshv1.pcap` and `v6.pcap` a value the reference does not hold.
+#92 owns the question.
+
+### Two defects of the reference
+
+The reference produces two JA4SSH results that a simulation of `python/ja4ssh.py`
+reproduces, and that describe no property of the connection.
+
+`dict(ja4sh_stats)` copies the dictionary and not the two lists inside it, so every
+window on every connection shares one `client_payloads` list and one
+`server_payloads` list. The mode field therefore reads the packet lengths of every
+connection the tool has seen. `ssh-r.pcap` stream 2 window 1 reports `c64s64`, and
+the packets of that window read `c76s76`. #96 owns the decision.
+
+`(entry['count'] % ssh_sample_count) == 0` stays true for every bare ACK that
+follows a window boundary, so each of those packets writes the next occurrence key
+from a window that holds no SSH packet. `ssh-r.pcap` stream 0 holds `JA4SSH.2`
+equal to `c64s64_c0s0_c0s1`. #97 owns the decision.
+
+### The TCP segment
+
+ja4plus counts one SSH packet for every TCP segment that carries a payload, and
+the reference counts the packets `tshark` labels `ssh`. `tshark` labels the segment
+that completes an SSH message and not the earlier segment, so the two disagree by
+one packet for each message that spans two segments. #98 owns the defect.
 
 ### Direction detection on non-standard ports
 

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -121,38 +121,50 @@ Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4ssh.py
 on the first SSH packet, so it dropped the ACK of the TCP handshake. It also read
 the ACK flag alone, so it counted a SYN+ACK, a FIN+ACK and a RST+ACK as bare ACKs.
 
-### The remainder of a stream
+### The window a connection holds open
 
-The reference emits the packets that remain on some connections and not on others,
-and the vectors do not settle the condition. On `ssh-r.pcap` stream 1 the reference
-holds `c64s64_c6s5_c4s5`, which counts 11 SSH packets. `gre-sample.pcap`,
-`sshv1.pcap` and `v6.pcap` each hold one SSH connection of the same shape, with a
-banner, data packets and a FIN packet, and the reference holds no JA4SSH value for
-any of them.
+A connection that closes emits the window it holds open. `python/ja4.py` states the
+rule above `finalize_ja4ssh`: `If the SSH connection is not terminated or the last
+sample is less than 200 the finalize function just cleans up and prints the last
+JA4SSH hash`. That function runs on a packet that carries the FIN flag and the ACK
+flag. An empty window emits nothing, so the second FIN packet of a close finds the
+window the first FIN packet emptied and adds no value.
 
-`python/ja4.py` runs `finalize_ja4ssh` on a packet that carries the FIN flag and
-the ACK flag, and that function acts only when `entry['protos']` ends with `:ssh`.
-Every FIN+ACK packet of these captures carries no payload, so the condition depends
-on a `tshark` protocol label that a capture file alone does not give. ja4plus emits
-no value for a window a connection holds open, because a rule that emits one gives
-`gre-sample.pcap`, `sshv1.pcap` and `v6.pcap` a value the reference does not hold.
-#92 owns the question.
+`ssh-r.pcap` confirms the reading. Stream 1 holds 11 SSH packets and one
+occurrence, `c64s64_c6s5_c4s5`. Stream 2 holds 931 SSH packets, four full windows,
+and a fifth occurrence of 131 packets. `ssh-scp-1050.pcap` and `ssh2.pcapng` carry
+no FIN packet, and each keeps its full windows alone.
 
-### Two defects of the reference
+Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4.py
+(retrieved 2026-08-06).
 
-The reference produces two JA4SSH results that a simulation of `python/ja4ssh.py`
-reproduces, and that describe no property of the connection.
+### Three defects of the reference
 
-`dict(ja4sh_stats)` copies the dictionary and not the two lists inside it, so every
-window on every connection shares one `client_payloads` list and one
-`server_payloads` list. The mode field therefore reads the packet lengths of every
-connection the tool has seen. `ssh-r.pcap` stream 2 window 1 reports `c64s64`, and
-the packets of that window read `c76s76`. #96 owns the decision.
+`ja4plus` declines to reproduce three results of the reference. Each one describes
+the capture and not the connection, so a user cannot compare it against the output
+of another tool. The measurement ran `python/ja4.py` at the pinned commit against
+`tshark` 4.6.7.
 
-`(entry['count'] % ssh_sample_count) == 0` stays true for every bare ACK that
-follows a window boundary, so each of those packets writes the next occurrence key
-from a window that holds no SSH packet. `ssh-r.pcap` stream 0 holds `JA4SSH.2`
-equal to `c64s64_c0s0_c0s1`. #97 owns the decision.
+**The mode field reads the whole capture.** `dict(ja4sh_stats)` copies the
+dictionary and not the two lists inside it, so every window on every connection
+shares one `client_payloads` list and one `server_payloads` list. `ssh-r.pcap`
+stream 2 window 1 reports `c64s64`, and the packets of that window read `c76s76`.
+`ja4plus` reads the lengths of the window. #96 records the decision.
+
+**A bare ACK writes another occurrence.** `(entry['count'] % ssh_sample_count) == 0`
+stays true for every bare ACK that follows a window boundary, so each of those
+packets writes the next occurrence key from a window that holds no SSH packet.
+`ssh-r.pcap` stream 0 holds `JA4SSH.2` equal to `c64s64_c0s0_c0s1`. `ja4plus` emits
+a value only for a window that holds SSH packets. #97 records the decision.
+
+**The stream index 0 is false.** `finalize_ja4ssh` guards with `if stream:`, so the
+reference emits no trailing window for the connection it holds at index 0.
+`gre-sample.pcap`, `sshv1.pcap` and `v6.pcap` each hold their SSH connection at that
+index, and the reference holds no JA4SSH value for any of them. The same run, with
+that guard read as `if stream is not None:` and nothing else changed, emits
+`c24s23_c4s4_c5s4` for `gre-sample.pcap` and `c20s12_c18s23_c10s1` for `sshv1.pcap`.
+`ja4plus` emits the window for every connection that closes. #105 records the
+decision.
 
 ### The TCP segment
 

--- a/docs/specs/spec.md
+++ b/docs/specs/spec.md
@@ -183,6 +183,7 @@ change, and files nothing there.
 | Mapping file refresh | `db update` and `db info` already exist. | The same two subcommands. | — | Already at parity. Keep a test that proves it. |
 | Shard key format | `tcp:ip:port->ip:port`. | The same format. | — | Already at parity. Keep a test that proves it. |
 | JA4SSH window | Emits at `packet_count`, which defaults to 200. | Emits at `min(packetCount, 10)`. | 1 | Fixed here by #28. The port carries the defect at `ja4ssh.go:176`. |
+| JA4SSH results the reference produces and this project declines | Reads the mode field from the window alone, emits a value only for a window that holds SSH packets, and emits the trailing window for every connection that closes. | Not measured. | 1 | Three defects of the FoxIO reference produce output that describes the capture and not the connection, so rule 1 does not settle them and a person decided each one. #96, #97 and #105 hold the decision and the measurement. The port must adopt all three, or the two implementations disagree on JA4SSH. |
 | Parity test | 6 tests that assert names exist. | Not applicable. | 3 | Replace with the shared vector suite. Epic 1. |
 
 Verified against: https://github.com/Crank-Git/ja4plus-go (`types.go`,

--- a/ja4plus/fingerprinters/ja4ssh.py
+++ b/ja4plus/fingerprinters/ja4ssh.py
@@ -21,6 +21,14 @@ logger = logging.getLogger(__name__)
 # produces a fingerprint that no reference implementation matches.
 DEFAULT_PACKET_COUNT = 200
 
+# The port FoxIO reads a bare ACK on. `python/ja4.py` tracks a connection for JA4SSH
+# only when one endpoint uses this port.
+SSH_PORT = 22
+
+# A bare ACK carries the ACK flag alone. FoxIO counts one only when the TCP flags equal
+# `0x0010`, so a SYN+ACK, a FIN+ACK and a RST+ACK never reach the bare-ACK counter.
+ACK_FLAG = 0x10
+
 
 class JA4SSHFingerprinter(BaseFingerprinter):
     """
@@ -73,7 +81,7 @@ class JA4SSHFingerprinter(BaseFingerprinter):
         dst_port = tcp.dport
 
         # Determine client/server based on SSH port (22) if available, otherwise use connection direction
-        ssh_port = 22
+        ssh_port = SSH_PORT
         if dst_port == ssh_port:
             client_ip, server_ip = src_ip, dst_ip
             client_port, server_port = src_port, dst_port
@@ -98,8 +106,19 @@ class JA4SSHFingerprinter(BaseFingerprinter):
         # Connection key for tracking
         conn_key = f"{client_ip}:{client_port}-{server_ip}:{server_port}"
 
+        # A bare ACK carries the ACK flag alone and no payload. FoxIO counts one only
+        # when the TCP flags equal 0x0010, which excludes a SYN+ACK, a FIN+ACK and a
+        # RST+ACK.
+        is_bare_ack = int(tcp.flags) == ACK_FLAG and not packet.haslayer(Raw)
+
+        # The ACK of the TCP handshake is a bare ACK, and it arrives before the first
+        # SSH packet. FoxIO counts it, so the state table needs the connection before
+        # any SSH data reaches it. `ssh-r.pcap`, `ssh-scp-1050.pcap` and `ssh2.pcapng`
+        # each report one more client ACK than a state table built on SSH data alone.
+        opens_on_ssh_port = is_bare_ack and ssh_port in (src_port, dst_port)
+
         # Skip packets that aren't SSH data AND don't belong to a known SSH connection
-        if not has_ssh_data and conn_key not in self.connections:
+        if not has_ssh_data and not opens_on_ssh_port and conn_key not in self.connections:
             return None
 
         # Initialize connection if needed
@@ -149,58 +168,44 @@ class JA4SSHFingerprinter(BaseFingerprinter):
                 else:
                     conn["ssh_packets"]["server"].append(packet_size)
 
-        # Track ACK packets (no data) - but only for connections that have shown SSH activity
-        elif tcp.flags & 0x10 == 0x10 and not packet.haslayer(Raw):  # ACK flag set, no payload
-            # Only track ACKs if we've seen SSH data in this connection
-            if (
-                conn["client_id"]
-                or conn["server_id"]
-                or len(conn["ssh_packets"]["client"]) > 0
-                or len(conn["ssh_packets"]["server"]) > 0
-            ):
-                if is_client_to_server:
-                    conn["bare_acks"]["client"] += 1
-                else:
-                    conn["bare_acks"]["server"] += 1
+        elif is_bare_ack:
+            if is_client_to_server:
+                conn["bare_acks"]["client"] += 1
+            else:
+                conn["bare_acks"]["server"] += 1
 
         # The window counts the SSH packets of both directions. The FoxIO image lists
         # the SSH packet counts and the bare ACK counts as separate fields, so a bare
         # ACK does not advance the window.
         total_packets = len(conn["ssh_packets"]["client"]) + len(conn["ssh_packets"]["server"])
 
-        if total_packets >= self.packet_count:
-            # Calculate most common packet sizes
-            client_sizes = conn["ssh_packets"]["client"]
-            server_sizes = conn["ssh_packets"]["server"]
+        if total_packets < self.packet_count:
+            return None
 
-            client_mode = self._mode(client_sizes) if client_sizes else 0
-            server_mode = self._mode(server_sizes) if server_sizes else 0
+        return self._close_window(conn_key)
 
-            # Count SSH packets per direction (raw counts per FoxIO spec)
-            client_ssh_count = len(client_sizes)
-            server_ssh_count = len(server_sizes)
+    def _close_window(self, conn_key):
+        """Emit the open window of one connection, and start a new window.
 
-            # Count ACK packets per direction (raw counts per FoxIO spec)
-            client_ack_count = conn["bare_acks"]["client"]
-            server_ack_count = conn["bare_acks"]["server"]
+        Args:
+            conn_key: The connection key of the window.
 
-            # Generate the JA4SSH fingerprint using raw counts (not percentages)
-            fingerprint = f"c{client_mode}s{server_mode}_c{client_ssh_count}s{server_ssh_count}_c{client_ack_count}s{server_ack_count}"
+        Returns:
+            The JA4SSH fingerprint.
+        """
+        conn = self.connections[conn_key]
+        fingerprint = self._generate_ja4ssh(conn_key)
 
-            # Store the fingerprint
-            self.fingerprints.append(
-                {"fingerprint": fingerprint, "connection": conn_key, "timestamp": time.time()}
-            )
+        self.fingerprints.append(
+            {"fingerprint": fingerprint, "connection": conn_key, "timestamp": time.time()}
+        )
 
-            # Reset counters for next window
-            conn["ssh_packets"]["client"] = []
-            conn["ssh_packets"]["server"] = []
-            conn["bare_acks"]["client"] = 0
-            conn["bare_acks"]["server"] = 0
+        conn["ssh_packets"]["client"] = []
+        conn["ssh_packets"]["server"] = []
+        conn["bare_acks"]["client"] = 0
+        conn["bare_acks"]["server"] = 0
 
-            return fingerprint
-
-        return None
+        return fingerprint
 
     def _generate_ja4ssh(self, conn_key):
         """Generate JA4SSH fingerprint for a connection."""

--- a/ja4plus/fingerprinters/ja4ssh.py
+++ b/ja4plus/fingerprinters/ja4ssh.py
@@ -29,6 +29,11 @@ SSH_PORT = 22
 # `0x0010`, so a SYN+ACK, a FIN+ACK and a RST+ACK never reach the bare-ACK counter.
 ACK_FLAG = 0x10
 
+# A connection closes with a packet that carries the FIN flag and the ACK flag. FoxIO
+# runs `finalize_ja4ssh` on such a packet, which emits the window the connection holds
+# open.
+FIN_FLAG = 0x01
+
 
 class JA4SSHFingerprinter(BaseFingerprinter):
     """
@@ -179,10 +184,17 @@ class JA4SSHFingerprinter(BaseFingerprinter):
         # ACK does not advance the window.
         total_packets = len(conn["ssh_packets"]["client"]) + len(conn["ssh_packets"]["server"])
 
-        if total_packets < self.packet_count:
-            return None
+        if total_packets >= self.packet_count:
+            return self._close_window(conn_key)
 
-        return self._close_window(conn_key)
+        # A connection that closes emits the window it holds open. FoxIO states the
+        # rule above `finalize_ja4ssh`: `If the SSH connection is not terminated or the
+        # last sample is less than 200 the finalize function just cleans up and prints
+        # the last JA4SSH hash`.
+        if int(tcp.flags) & FIN_FLAG and int(tcp.flags) & ACK_FLAG:
+            return self._close_window(conn_key)
+
+        return None
 
     def _close_window(self, conn_key):
         """Emit the open window of one connection, and start a new window.
@@ -191,9 +203,14 @@ class JA4SSHFingerprinter(BaseFingerprinter):
             conn_key: The connection key of the window.
 
         Returns:
-            The JA4SSH fingerprint.
+            The JA4SSH fingerprint, or None when the window holds no SSH packet. An
+            empty window emits nothing, because the second FIN packet of a close finds
+            the window the first FIN packet emptied.
         """
         conn = self.connections[conn_key]
+        if not conn["ssh_packets"]["client"] and not conn["ssh_packets"]["server"]:
+            return None
+
         fingerprint = self._generate_ja4ssh(conn_key)
 
         self.fingerprints.append(

--- a/ja4plus/fingerprinters/ja4ssh.py
+++ b/ja4plus/fingerprinters/ja4ssh.py
@@ -203,9 +203,11 @@ class JA4SSHFingerprinter(BaseFingerprinter):
             conn_key: The connection key of the window.
 
         Returns:
-            The JA4SSH fingerprint, or None when the window holds no SSH packet. An
-            empty window emits nothing, because the second FIN packet of a close finds
-            the window the first FIN packet emptied.
+            The JA4SSH fingerprint, or None when the window holds no SSH packet. A
+            fingerprint of an empty window describes no traffic. Two connection states
+            reach this guard: the second FIN packet of a close finds the window the
+            first FIN packet emptied, and a connection that closes right after a full
+            window holds no SSH packet either.
         """
         conn = self.connections[conn_key]
         if not conn["ssh_packets"]["client"] and not conn["ssh_packets"]["server"]:

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -471,13 +471,9 @@
     "issue": 88,
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
-  "ssh-r.pcap/0:64980/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
   "ssh-r.pcap/0:64980/JA4SSH.2": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH value on this stream."
+    "issue": 97,
+    "cause": "FoxIO writes this occurrence from a bare ACK that follows the window boundary, and ja4plus emits one value for each full window."
   },
   "ssh-r.pcap/1:46394/JA4L-C.1": {
     "issue": 88,
@@ -489,7 +485,7 @@
   },
   "ssh-r.pcap/1:46394/JA4SSH.1": {
     "issue": 92,
-    "cause": "ja4plus produces no JA4SSH value on this stream."
+    "cause": "The connection fills no window, and ja4plus emits no value for the window it holds open."
   },
   "ssh-r.pcap/2:46396/JA4L-C.1": {
     "issue": 88,
@@ -500,12 +496,12 @@
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
   "ssh-r.pcap/2:46396/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "issue": 96,
+    "cause": "The reference mode field reads the packet lengths of every connection, and ja4plus reads the lengths of the window."
   },
   "ssh-r.pcap/2:46396/JA4SSH.5": {
     "issue": 92,
-    "cause": "ja4plus produces no JA4SSH value on this stream."
+    "cause": "The connection closes with a window open, and ja4plus emits no value for that window."
   },
   "ssh-r.pcap/JA4L-C": {
     "issue": 34,
@@ -513,7 +509,7 @@
   },
   "ssh-r.pcap/JA4SSH": {
     "issue": 92,
-    "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
+    "cause": "ja4plus emits no value for a window that a connection holds open when it closes."
   },
   "ssh-scp-1050.pcap/0:49237/JA4L-C.1": {
     "issue": 88,
@@ -523,17 +519,13 @@
     "issue": 88,
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
-  "ssh-scp-1050.pcap/0:49237/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.3": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "issue": 96,
+    "cause": "The reference mode field reads the packet lengths of every connection, and ja4plus reads the lengths of the window."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.4": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "issue": 96,
+    "cause": "The reference mode field reads the packet lengths of every connection, and ja4plus reads the lengths of the window."
   },
   "ssh-scp-1050.pcap/JA4L-C": {
     "issue": 34,
@@ -611,13 +603,9 @@
     "issue": 88,
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
-  "ssh2.pcapng/14:57377/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
   "ssh2.pcapng/14:57377/JA4SSH.2": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH value on this stream."
+    "issue": 97,
+    "cause": "FoxIO writes this occurrence from a bare ACK that follows the window boundary, and ja4plus emits one value for each full window."
   },
   "ssh2.pcapng/15:57380/JA4L-C.1": {
     "issue": 88,
@@ -676,8 +664,8 @@
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
   },
   "ssh2.pcapng/JA4SSH": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
+    "issue": 97,
+    "cause": "FoxIO writes a second occurrence from a bare ACK that follows the window boundary, and ja4plus emits one value for each full window."
   },
   "ssh2.pcapng/JA4X": {
     "issue": 78,

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -139,6 +139,10 @@
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
   },
+  "gre-sample.pcap/JA4SSH": {
+    "issue": 105,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
+  },
   "http-empty-useragent.pcap/0:57722/JA4H.1": {
     "issue": 35,
     "cause": "ja4plus produces no JA4H value on this stream."
@@ -473,7 +477,7 @@
   },
   "ssh-r.pcap/0:64980/JA4SSH.2": {
     "issue": 97,
-    "cause": "FoxIO writes this occurrence from a bare ACK that follows the window boundary, and ja4plus emits one value for each full window."
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
   },
   "ssh-r.pcap/1:46394/JA4L-C.1": {
     "issue": 88,
@@ -484,8 +488,8 @@
     "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
   },
   "ssh-r.pcap/1:46394/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The connection fills no window, and ja4plus emits no value for the window it holds open."
+    "issue": 96,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window. The packet count differs too: ja4plus counts one SSH packet for each TCP segment, and tshark labels only the segment that completes an SSH message. #98 owns the count."
   },
   "ssh-r.pcap/2:46396/JA4L-C.1": {
     "issue": 88,
@@ -497,19 +501,15 @@
   },
   "ssh-r.pcap/2:46396/JA4SSH.1": {
     "issue": 96,
-    "cause": "The reference mode field reads the packet lengths of every connection, and ja4plus reads the lengths of the window."
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
   },
   "ssh-r.pcap/2:46396/JA4SSH.5": {
-    "issue": 92,
-    "cause": "The connection closes with a window open, and ja4plus emits no value for that window."
+    "issue": 98,
+    "cause": "ja4plus counts one SSH packet for each TCP segment, and tshark labels only the segment that completes an SSH message. #98 owns the count."
   },
   "ssh-r.pcap/JA4L-C": {
     "issue": 34,
     "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "ssh-r.pcap/JA4SSH": {
-    "issue": 92,
-    "cause": "ja4plus emits no value for a window that a connection holds open when it closes."
   },
   "ssh-scp-1050.pcap/0:49237/JA4L-C.1": {
     "issue": 88,
@@ -521,11 +521,11 @@
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.3": {
     "issue": 96,
-    "cause": "The reference mode field reads the packet lengths of every connection, and ja4plus reads the lengths of the window."
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.4": {
     "issue": 96,
-    "cause": "The reference mode field reads the packet lengths of every connection, and ja4plus reads the lengths of the window."
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
   },
   "ssh-scp-1050.pcap/JA4L-C": {
     "issue": 34,
@@ -605,7 +605,7 @@
   },
   "ssh2.pcapng/14:57377/JA4SSH.2": {
     "issue": 97,
-    "cause": "FoxIO writes this occurrence from a bare ACK that follows the window boundary, and ja4plus emits one value for each full window."
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
   },
   "ssh2.pcapng/15:57380/JA4L-C.1": {
     "issue": 88,
@@ -665,7 +665,7 @@
   },
   "ssh2.pcapng/JA4SSH": {
     "issue": 97,
-    "cause": "FoxIO writes a second occurrence from a bare ACK that follows the window boundary, and ja4plus emits one value for each full window."
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
   },
   "ssh2.pcapng/JA4X": {
     "issue": 78,
@@ -686,6 +686,10 @@
   "sshv1.pcap/JA4L-S": {
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
+  },
+  "sshv1.pcap/JA4SSH": {
+    "issue": 105,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
   },
   "tcpdump-geneve.pcap/0:51225/JA4L-C.1": {
     "issue": 88,
@@ -946,5 +950,9 @@
   "v6.pcap/JA4L-S": {
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
+  },
+  "v6.pcap/JA4SSH": {
+    "issue": 105,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
   }
 }

--- a/tests/test_ja4ssh_windows.py
+++ b/tests/test_ja4ssh_windows.py
@@ -166,6 +166,18 @@ def test_two_fin_packets_emit_one_fingerprint():
     assert len(fingerprinter.get_fingerprints()) == 1
 
 
+def test_a_reset_packet_leaves_the_window_open():
+    """FoxIO closes the window on the FIN flag and the ACK flag, and it reads no other
+    flag. A connection that a RST packet ends keeps its window open."""
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    for index in range(11):
+        fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0))
+    assert fingerprinter.process_packet(_tcp(True, "R")) is None
+    assert fingerprinter.process_packet(_tcp(True, "RA")) is None
+    assert fingerprinter.get_fingerprints() == []
+
+
 def test_a_fin_packet_on_an_unknown_connection_emits_nothing():
     fingerprinter = JA4SSHFingerprinter()
     assert fingerprinter.process_packet(_tcp(True, "FA")) is None

--- a/tests/test_ja4ssh_windows.py
+++ b/tests/test_ja4ssh_windows.py
@@ -10,10 +10,13 @@ closes.
    not bare ACKs.
 2. The ACK of the TCP handshake is a bare ACK, and it arrives before the first SSH
    packet of the connection. FoxIO counts it.
-3. A connection that closes emits no value for the window it holds open. #92 owns the
-   condition FoxIO applies, which the vectors do not settle.
+3. A connection that closes emits the window it holds open, and an empty window emits
+   nothing.
 
-The FoxIO reference states rule 1 and rule 2 in `python/ja4ssh.py`.
+The FoxIO reference states rule 1 and rule 2 in `python/ja4ssh.py`. It states rule 3
+above `finalize_ja4ssh` in `python/ja4.py`: `If the SSH connection is not terminated or
+the last sample is less than 200 the finalize function just cleans up and prints the
+last JA4SSH hash`.
 
 Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4ssh.py
 (retrieved 2026-08-06).
@@ -123,19 +126,64 @@ def test_a_bare_ack_alone_emits_no_fingerprint():
 # ---------------------------------------------------------------------------
 
 
-def test_a_connection_that_closes_emits_no_partial_window():
-    """FoxIO holds no JA4SSH value for `gre-sample.pcap`, `sshv1.pcap` and `v6.pcap`.
-    Each of those captures holds one SSH connection that carries a banner, data packets
-    and a FIN packet, and each fills no window. A rule that emits the open window on a
-    FIN packet gives all three a value the reference does not hold. #92 owns the
-    condition FoxIO applies."""
+def test_the_connection_close_emits_the_open_window():
     fingerprinter = JA4SSHFingerprinter()
     handshake(fingerprinter)
     for index in range(11):
         assert fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0)) is None
+    assert fingerprinter.process_packet(_tcp(True, "FA")) == "c36s36_c6s5_c1s0"
+    assert len(fingerprinter.get_fingerprints()) == 1
+
+
+def test_the_connection_close_emits_the_window_that_follows_a_full_window():
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    fill_window(fingerprinter)
+    for index in range(4):
+        fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0))
+    assert fingerprinter.process_packet(_tcp(True, "FA")) == "c36s36_c2s2_c0s0"
+    values = [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
+    assert values == ["c36s36_c100s100_c1s0", "c36s36_c2s2_c0s0"]
+
+
+def test_the_connection_close_emits_nothing_when_the_open_window_holds_no_ssh_packet():
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    fill_window(fingerprinter)
     assert fingerprinter.process_packet(_tcp(True, "FA")) is None
+    assert len(fingerprinter.get_fingerprints()) == 1
+
+
+def test_two_fin_packets_emit_one_fingerprint():
+    """Both endpoints close the connection. The second FIN packet finds an empty
+    window, and an empty window emits nothing."""
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    for index in range(11):
+        fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0))
+    assert fingerprinter.process_packet(_tcp(True, "FA")) == "c36s36_c6s5_c1s0"
     assert fingerprinter.process_packet(_tcp(False, "FA")) is None
+    assert len(fingerprinter.get_fingerprints()) == 1
+
+
+def test_a_fin_packet_on_an_unknown_connection_emits_nothing():
+    fingerprinter = JA4SSHFingerprinter()
+    assert fingerprinter.process_packet(_tcp(True, "FA")) is None
     assert fingerprinter.get_fingerprints() == []
+
+
+def test_a_connection_the_reference_indexes_as_stream_zero_emits_its_open_window():
+    """`finalize_ja4ssh` guards with `if stream:`, and the stream index 0 is false in
+    Python, so the reference emits no trailing window for the connection it indexes as
+    stream 0. `gre-sample.pcap`, `sshv1.pcap` and `v6.pcap` each hold their SSH
+    connection at that index. The stream index describes the position of a connection
+    in a capture and not the connection, so ja4plus emits the window. #105 records the
+    divergence."""
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    for index in range(8):
+        fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0))
+    assert fingerprinter.process_packet(_tcp(True, "FA")) == "c36s36_c4s4_c1s0"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ja4ssh_windows.py
+++ b/tests/test_ja4ssh_windows.py
@@ -1,0 +1,215 @@
+"""Tests for what JA4SSH does after the first window closes.
+
+#28 set the window to 200 SSH packets. A capture that holds one window conforms after
+that change, and a capture that holds several does not. This module covers the bare-ACK
+rule that a long connection needs, and the window a connection holds open when it
+closes.
+
+1. A bare ACK is one packet that carries the ACK flag alone and no payload. FoxIO counts
+   one only when the TCP flags equal `0x0010`, so a SYN+ACK, a FIN+ACK and a RST+ACK are
+   not bare ACKs.
+2. The ACK of the TCP handshake is a bare ACK, and it arrives before the first SSH
+   packet of the connection. FoxIO counts it.
+3. A connection that closes emits no value for the window it holds open. #92 owns the
+   condition FoxIO applies, which the vectors do not settle.
+
+The FoxIO reference states rule 1 and rule 2 in `python/ja4ssh.py`.
+
+Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4ssh.py
+(retrieved 2026-08-06).
+Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/test/testdata
+(retrieved 2026-08-06).
+"""
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+from scapy.all import IP, TCP, Raw
+
+from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
+
+CLIENT = "10.0.0.1"
+SERVER = "10.0.0.2"
+CLIENT_PORT = 50000
+SERVER_PORT = 22
+
+VECTORS = Path(__file__).parent / "foxio_vectors"
+
+
+def ssh_packet(to_server=True, size=36):
+    """Return one SSH data packet of the given payload size.
+
+    Args:
+        to_server: True for a client packet, False for a server packet.
+        size: The payload length in bytes. The minimum is 6.
+
+    Returns:
+        A scapy packet that `is_ssh_packet` accepts.
+    """
+    payload = struct.pack(">I", size - 4) + bytes([4, 94]) + b"A" * (size - 6)
+    return _tcp(to_server, "PA") / Raw(load=payload)
+
+
+def _tcp(to_server, flags):
+    """Return one TCP packet of the given direction and flags, with no payload."""
+    if to_server:
+        return IP(src=CLIENT, dst=SERVER) / TCP(sport=CLIENT_PORT, dport=SERVER_PORT, flags=flags)
+    return IP(src=SERVER, dst=CLIENT) / TCP(sport=SERVER_PORT, dport=CLIENT_PORT, flags=flags)
+
+
+def handshake(fingerprinter):
+    """Send the three packets of the TCP handshake to the fingerprinter."""
+    fingerprinter.process_packet(_tcp(True, "S"))
+    fingerprinter.process_packet(_tcp(False, "SA"))
+    fingerprinter.process_packet(_tcp(True, "A"))
+
+
+def fill_window(fingerprinter, count=200):
+    """Send `count` SSH packets, one direction after the other."""
+    result = None
+    for index in range(count):
+        result = fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# The bare ACK
+# ---------------------------------------------------------------------------
+
+
+def test_the_window_counts_the_ack_of_the_tcp_handshake():
+    """FoxIO counts every bare ACK on a port-22 connection, including the third
+    packet of the TCP handshake, which arrives before the first SSH packet."""
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    assert fill_window(fingerprinter) == "c36s36_c100s100_c1s0"
+
+
+def test_a_syn_ack_is_not_a_bare_ack():
+    fingerprinter = JA4SSHFingerprinter()
+    fingerprinter.process_packet(_tcp(True, "S"))
+    fingerprinter.process_packet(_tcp(False, "SA"))
+    assert fill_window(fingerprinter) == "c36s36_c100s100_c0s0"
+
+
+def test_a_fin_ack_is_not_a_bare_ack():
+    """The FIN+ACK arrives while the window is empty, so the close rule emits nothing
+    and the server ACK counter stays at zero."""
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    assert fingerprinter.process_packet(_tcp(False, "FA")) is None
+    assert fill_window(fingerprinter) == "c36s36_c100s100_c1s0"
+
+
+def test_a_reset_packet_is_not_a_bare_ack():
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    fingerprinter.process_packet(_tcp(False, "RA"))
+    assert fill_window(fingerprinter) == "c36s36_c100s100_c1s0"
+
+
+def test_a_bare_ack_alone_emits_no_fingerprint():
+    """A port scan that sends bare ACKs holds no SSH packet, and it emits nothing."""
+    fingerprinter = JA4SSHFingerprinter()
+    for _ in range(500):
+        assert fingerprinter.process_packet(_tcp(True, "A")) is None
+    assert fingerprinter.get_fingerprints() == []
+
+
+# ---------------------------------------------------------------------------
+# The close of the connection
+# ---------------------------------------------------------------------------
+
+
+def test_a_connection_that_closes_emits_no_partial_window():
+    """FoxIO holds no JA4SSH value for `gre-sample.pcap`, `sshv1.pcap` and `v6.pcap`.
+    Each of those captures holds one SSH connection that carries a banner, data packets
+    and a FIN packet, and each fills no window. A rule that emits the open window on a
+    FIN packet gives all three a value the reference does not hold. #92 owns the
+    condition FoxIO applies."""
+    fingerprinter = JA4SSHFingerprinter()
+    handshake(fingerprinter)
+    for index in range(11):
+        assert fingerprinter.process_packet(ssh_packet(to_server=index % 2 == 0)) is None
+    assert fingerprinter.process_packet(_tcp(True, "FA")) is None
+    assert fingerprinter.process_packet(_tcp(False, "FA")) is None
+    assert fingerprinter.get_fingerprints() == []
+
+
+# ---------------------------------------------------------------------------
+# The FoxIO vectors
+# ---------------------------------------------------------------------------
+
+
+def produced(name):
+    """Return the JA4SSH values of one capture, grouped by connection key."""
+    from scapy.all import rdpcap
+
+    fingerprinter = JA4SSHFingerprinter()
+    for packet in rdpcap(str(VECTORS / name)):
+        fingerprinter.process_packet(packet)
+    values = {}
+    for entry in fingerprinter.get_fingerprints():
+        values.setdefault(entry["connection"], []).append(entry["fingerprint"])
+    return values
+
+
+def expected(name):
+    """Return the JA4SSH occurrence keys of one expected-output file, by source port."""
+    with open(VECTORS / (name + ".json")) as handle:
+        records = json.load(handle)
+    values = {}
+    for record in records:
+        for key in sorted(record):
+            if key.startswith("JA4SSH."):
+                port = record["srcport"] if record["dstport"] == "22" else record["dstport"]
+                values.setdefault(port, []).append(record[key])
+    return values
+
+
+def vector(name):
+    """Skip the test when the capture or its expected-output file is absent."""
+    return pytest.mark.skipif(
+        not (VECTORS / name).exists() or not (VECTORS / (name + ".json")).exists(),
+        reason="the FoxIO vector {} is not available".format(name),
+    )
+
+
+@vector("ssh.pcapng")
+def test_the_one_window_vector_keeps_its_value():
+    """`ssh.pcapng` conforms after #28, and the bare-ACK rule must not disturb it."""
+    values = produced("ssh.pcapng")
+    assert list(values.values()) == [["c36s36_c76s124_c0s0"]]
+
+
+@vector("ssh-r.pcap")
+def test_the_reverse_ssh_vector_produces_the_reference_first_window():
+    values = produced("ssh-r.pcap")
+    first = values["192.168.1.169:64980-192.168.1.197:22"][0]
+    assert first == expected("ssh-r.pcap")["64980"][0]
+    assert first == "c64s64_c107s93_c74s10"
+
+
+@vector("ssh-scp-1050.pcap")
+def test_the_file_transfer_vector_produces_the_reference_ack_count():
+    values = produced("ssh-scp-1050.pcap")["192.168.1.169:49237-192.168.1.197:22"]
+    reference = expected("ssh-scp-1050.pcap")["49237"]
+    assert len(values) == len(reference) == 4
+    assert values[0] == reference[0] == "c112s1460_c52s148_c41s4"
+    assert values[1] == reference[1] == "c112s1460_c13s187_c35s0"
+
+
+@vector("ssh-scp-1050.pcap")
+def test_a_capture_that_holds_no_fin_packet_emits_no_extra_window():
+    """`ssh-scp-1050.pcap` never closes its connection, so it keeps four windows."""
+    values = produced("ssh-scp-1050.pcap")
+    assert [len(item) for item in values.values()] == [4]
+
+
+@vector("ssh2.pcapng")
+def test_the_long_capture_produces_the_reference_first_window():
+    values = produced("ssh2.pcapng")["172.16.225.48:57377-54.160.114.75:22"]
+    assert values[0] == expected("ssh2.pcapng")["57377"][0]
+    assert values[0] == "c36s36_c76s124_c74s5"


### PR DESCRIPTION
## What

`ja4plus` reads a bare ACK the way FoxIO reads one, and it emits the window a
connection holds open when it closes. `ssh-r.pcap` now produces the occurrence keys the
reference holds on all three of its streams.

Three changes to `ja4plus/fingerprinters/ja4ssh.py`:

1. A bare ACK carries the ACK flag alone. FoxIO counts one only when the TCP flags equal
   `0x0010`. `ja4plus` read the ACK flag alone, so it counted a SYN+ACK, a FIN+ACK and a
   RST+ACK as bare ACKs.
2. The ACK that completes the TCP handshake is a bare ACK, and it arrives before the
   first SSH packet. `ja4plus` created its state table entry on the first SSH packet, so
   it dropped that ACK.
3. A connection that closes emits the window it holds open. An empty window emits
   nothing, so the second FIN packet of a close adds no value.

## Why

#92 asked what JA4SSH does after the first window closes. The 12 surviving JA4SSH
register entries had six distinct causes. This pull request fixes the three that belong
to `ja4plus`, and it records the three that belong to the reference.

### The rule for the window a connection holds open

FoxIO states it above `finalize_ja4ssh`: `If the SSH connection is not terminated or the
last sample is less than 200 the finalize function just cleans up and prints the last
JA4SSH hash`. That function runs on a packet that carries the FIN flag and the ACK flag.

The reference appears to contradict its own rule, and `tshark` settles it. `ssh-r.pcap`
stream 1 gets a trailing occurrence, while `gre-sample.pcap`, `sshv1.pcap` and `v6.pcap`
hold no JA4SSH value at all for a connection of exactly the same shape.

The measurement ran the FoxIO python implementation at the pinned commit, against
`tshark` 4.6.7, with a print added to `finalize_ja4ssh`.

```
$ python ja4.py --ja4ssh -J tests/foxio_vectors/ssh-r.pcap
FINALIZE called stream=1 truthy=True  in_cache=True protos='eth:ethertype:ip:tcp:ssh'
FINALIZE called stream=2 truthy=True  in_cache=True protos='eth:ethertype:ip:tcp:ssh'
FINALIZE called stream=0 truthy=False in_cache=True protos='eth:ethertype:ip:tcp:ssh'

$ python ja4.py --ja4ssh -J tests/foxio_vectors/gre-sample.pcap
FINALIZE called stream=0 truthy=False in_cache=True protos='eth:ethertype:ip:gre:ip:tcp:ssh'

$ python ja4.py --ja4ssh -J tests/foxio_vectors/sshv1.pcap
FINALIZE called stream=0 truthy=False in_cache=True protos='eth:ethertype:ipv6:tcp:ssh'
```

`finalize_ja4ssh` opens with `if stream:`, and the stream index `0` is false in Python.
Every entry above is in the cache and carries a protocol chain that ends with `:ssh`, so
the guard is the only thing that stops the trailing window. `gre-sample.pcap`,
`sshv1.pcap` and `v6.pcap` each hold their SSH connection at index 0.

The same run, with that guard read as `if stream is not None:` and nothing else changed:

```
gre-sample.pcap  stream 0  JA4SSH.1  c24s23_c4s4_c5s4     (the reference holds none)
sshv1.pcap       stream 0  JA4SSH.1  c20s12_c18s23_c10s1  (the reference holds none)
ssh-r.pcap       stream 0  JA4SSH.2  c76s76_c33s48_c41s2  (the reference holds c64s64_c0s0_c0s1)
ssh-r.pcap       stream 1  JA4SSH.1  c64s64_c6s5_c4s5     (unchanged)
ssh-r.pcap       stream 2  JA4SSH.5  c76s76_c66s65_c9s51  (unchanged)
```

The rule holds. The exceptions are one integer-zero defect.

### The three results this project declines to reproduce

Each describes the capture and not the connection, so a user cannot compare it against
another tool's output. The user decided each one.

| Issue | The reference | `ja4plus` |
|---|---|---|
| #96 | `dict(ja4sh_stats)` shares one payload list, so the mode field reads the packet lengths of the whole capture. | Reads the lengths of the window. |
| #97 | A bare ACK after a window boundary writes another occurrence from a window of zero SSH packets. | Emits a value only for a window that holds SSH packets. |
| #105 | `finalize_ja4ssh` guards with `if stream:`, so no trailing window reaches the connection at stream index 0. | Emits the trailing window for every connection that closes. |

### The register

240 entries on the base, 239 now. Four leave and three join.

**Removed, because the case passes:**

```
ssh-r.pcap/0:64980/JA4SSH.1        c64s64_c107s93_c74s10
ssh-scp-1050.pcap/0:49237/JA4SSH.1 c112s1460_c52s148_c41s4
ssh2.pcapng/14:57377/JA4SSH.1      c36s36_c76s124_c74s5
ssh-r.pcap/JA4SSH                  the occurrence keys now equal the reference
```

**Added, recording the #105 divergence:** `gre-sample.pcap/JA4SSH`, `sshv1.pcap/JA4SSH`,
`v6.pcap/JA4SSH`. Each states that `ja4plus` emits one value the reference does not
hold, on a connection the reference indexes as stream 0. No entry was added to make a
red case green.

The six entries that name #96 and #97 now state that the cause is a reference defect
this project declines to reproduce, and that the decision is made.

`ssh-r.pcap/2:46396/JA4SSH.5` names #98, which owns the one remaining `ja4plus` defect:
`tshark` labels only the TCP segment that completes an SSH message, and `ja4plus` counts
both. That issue is out of this batch.

## How tested

```
pytest tests/ -m "not spec_validation"   644 passed, 12 skipped, 86 subtests passed
pytest tests/ -m spec_validation         458 passed, 142 skipped, 239 xfailed, 0 failed
ruff check ja4plus/ tests/               All checks passed
ruff format --check ja4plus/ tests/      79 files already formatted
mypy ja4plus/                            Success: no issues found in 26 source files
coverage                                 72%, up from 71% on the base
```

The base measured 628 unit tests, 454 conformance passed and 240 xfailed. No case that
passed before fails now. `ja4plus/fingerprinters/ja4ssh.py` coverage rose from 88% to
97%.

`tests/test_ja4ssh_windows.py` is new and holds 16 tests: five on the bare ACK, six on
the window a connection holds open, and five that read the FoxIO vectors.

Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4.py (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4ssh.py (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata (retrieved 2026-08-06)
Verified against: TShark (Wireshark) 4.6.7

Refs #92, #96, #97, #105