### PR TITLE
Report the one-way JA4L latency and the reference measurement point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   FoxIO material states `One-way TCP latency in us`, and the vectors hold half of
   the measured time. The client value now measures to the last packet that
   carries the relative sequence number 1 and the relative acknowledgement number
-  1, and one connection now carries one `JA4L-C` value. The QUIC form now reads
-  the Initial packets and the Handshake packets on port 443, and a UDP flow that
-  carries no QUIC long header produces no value. `ja4plus` also imports the scapy
+  1. One connection now carries one `JA4L-C` value. The QUIC form now reads the
+  Initial packets and the Handshake packets on port 443. A UDP flow that carries
+  no QUIC long header gives no value. `ja4plus` also imports the scapy
   Geneve, VXLAN and ERSPAN dissectors, so a mirrored capture reads its inner TCP
   layer. Every JA4L value a caller stored before this release differs from the
-  value this release produces. 108 of the 114 registered JA4L value deviations
+  value this release emits. 108 of the 114 registered JA4L value deviations
   now conform, and #101 and #102 own the six that remain.
 
 - **BREAKING — JA4SSH counts a bare ACK the way FoxIO counts one** (#92). A bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **BREAKING — JA4L reports the one-way latency and the measurement point the
+  FoxIO vectors hold** (#88). The fingerprinter reported the whole round-trip
+  time, and it measured the client value to the bare ACK of the handshake. The
+  FoxIO material states `One-way TCP latency in us`, and the vectors hold half of
+  the measured time. The client value now measures to the last packet that
+  carries the relative sequence number 1 and the relative acknowledgement number
+  1, and one connection now carries one `JA4L-C` value. The QUIC form now reads
+  the Initial packets and the Handshake packets on port 443, and a UDP flow that
+  carries no QUIC long header produces no value. `ja4plus` also imports the scapy
+  Geneve, VXLAN and ERSPAN dissectors, so a mirrored capture reads its inner TCP
+  layer. Every JA4L value a caller stored before this release differs from the
+  value this release produces. 108 of the 114 registered JA4L value deviations
+  now conform, and #101 and #102 own the six that remain.
+
 - **BREAKING — JA4SSH counts a bare ACK the way FoxIO counts one** (#92). A bare
   ACK carries the ACK flag alone and no payload. `ja4plus` read the ACK flag
   alone, so it counted a SYN+ACK, a FIN+ACK and a RST+ACK as bare ACKs. It also

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -70,10 +70,78 @@ JA4L fingerprints include a direction prefix:
 `JA4L-S={latency_us}_{ttl}` and `JA4L-C={latency_us}_{ttl}`.
 The spec describes `{latency_microseconds}_{ttl}` without a prefix.
 
-### Latency is raw time difference, not RTT/2
+### The latency is half the measured time
 
-The latency value is the raw time difference between handshake points,
-not the round-trip time divided by 2.
+`technical_details/JA4L.png` states `One-way TCP latency in us`, and every FoxIO
+vector holds half the time the capture shows. `badcurveball.pcap` stream 0 sends
+the SYN at `+0.000000s` and the SYN-ACK at `+0.001563s`, and the reference
+`JA4L-S` is `781_238`.
+
+The division truncates toward zero, and it produces `0` for a difference of one
+microsecond.
+
+### The client measurement point
+
+FoxIO publishes JA4L as an image, so the expected-output files decide the
+measurement point. `python/ja4.py` in the FoxIO repository records the client
+point on every TCP packet that carries the relative sequence number `1` and the
+relative acknowledgement number `1`, and it keeps the last one. That is the bare
+ACK of the handshake first, and then the first packet of the application
+handshake.
+
+`browsers-x509.pcapng` stream 0 proves it. The SYN-ACK is at `+0.003815s`, the
+bare ACK at `+0.003927s` and the Client Hello at `+0.004371s`. The reference
+`JA4L-C` is `278_128`, and `(4371 - 3815) / 2 = 278`.
+
+The point moves in either direction. `http1-with-cookies.pcapng` stream 0 puts it
+on the bare ACK the server sends.
+
+### A complete HTTP request does not move the client point
+
+The FoxIO program keeps the timestamps of a packet under the protocol the tshark
+dissector reports, and it holds a separate cache for `http` and `http2`. A packet
+that carries a whole HTTP request therefore never moves the client point, and a
+packet that carries the first part of a request does move it.
+
+Two vectors prove both halves:
+
+- `latest.pcapng` stream 6 sends one complete `GET` request. The reference
+  `JA4L-C` is `32_128`, which is the bare ACK.
+- `http-empty-useragent.pcap` sends the request line, the header and the blank
+  line in three packets. The reference `JA4L-C` is `177863_64`, which is the
+  request line.
+
+`ja4plus` reads the request line and the blank line that ends the header block.
+
+### The address layer of a tunnelled capture
+
+The reference reads the address and the TTL of the outer layer, and the port of
+the inner layer. `gre-sample.pcap` carries a session between `10.16.27.12` and
+`10.16.27.131` inside a GRE tunnel between `172.27.1.66` and `66.59.109.137`, and
+the expected-output file names the tunnel addresses with the inner ports.
+
+`ja4plus/utils/tunnels.py` imports the scapy dissectors for Geneve, VXLAN and
+ERSPAN, because scapy leaves them unbound and stops at the tunnel header.
+
+### The QUIC measurement points
+
+The reference reads four QUIC packets, and it reads the direction from port 443:
+
+- `A` is the client Initial packet.
+- `B` is the server Initial packet.
+- `C` is the last server Handshake packet before the client answers.
+- `D` is the first client Handshake packet.
+
+`JA4L-S` is half the time from `A` to `B`, and `JA4L-C` is half the time from `C`
+to `D`.
+
+### A time of one second or more
+
+The FoxIO program reads the difference of two timestamps as a `timedelta`, and it
+takes the `microseconds` attribute, which holds the part below one second. A
+handshake of 1.2 seconds therefore gives 100000, not 600000. No FoxIO vector
+holds a difference of one second or more, so `ja4plus` divides the whole
+difference and no vector separates the two readings.
 
 ---
 

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -85,9 +85,8 @@ microsecond.
 FoxIO publishes JA4L as an image, so the expected-output files decide the
 measurement point. `python/ja4.py` in the FoxIO repository records the client
 point on every TCP packet that carries the relative sequence number `1` and the
-relative acknowledgement number `1`, and it keeps the last one. That is the bare
-ACK of the handshake first, and then the first packet of the application
-handshake.
+relative acknowledgement number `1`. It keeps the last one. That is the bare ACK
+of the handshake first, and then the first packet of the application handshake.
 
 `browsers-x509.pcapng` stream 0 proves it. The SYN-ACK is at `+0.003815s`, the
 bare ACK at `+0.003927s` and the Client Hello at `+0.004371s`. The reference
@@ -99,8 +98,8 @@ on the bare ACK the server sends.
 ### A complete HTTP request does not move the client point
 
 The FoxIO program keeps the timestamps of a packet under the protocol the tshark
-dissector reports, and it holds a separate cache for `http` and `http2`. A packet
-that carries a whole HTTP request therefore never moves the client point, and a
+dissector reports. It holds a separate state table for `http` and for `http2`. A
+packet that carries a whole HTTP request therefore never moves the client point. A
 packet that carries the first part of a request does move it.
 
 Two vectors prove both halves:
@@ -113,12 +112,13 @@ Two vectors prove both halves:
 
 `ja4plus` reads the request line and the blank line that ends the header block.
 
-### The address layer of a tunnelled capture
+### The address layer of a tunneled capture
 
 The reference reads the address and the TTL of the outer layer, and the port of
-the inner layer. `gre-sample.pcap` carries a session between `10.16.27.12` and
-`10.16.27.131` inside a GRE tunnel between `172.27.1.66` and `66.59.109.137`, and
-the expected-output file names the tunnel addresses with the inner ports.
+the inner layer. `gre-sample.pcap` carries a connection between `10.16.27.12`
+and `10.16.27.131` inside a GRE tunnel between `172.27.1.66` and
+`66.59.109.137`. The expected-output file names the tunnel addresses with the
+inner ports.
 
 `ja4plus/utils/tunnels.py` imports the scapy dissectors for Geneve, VXLAN and
 ERSPAN, because scapy leaves them unbound and stops at the tunnel header.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,8 +149,11 @@ Same format as JA4T, but extracted from the server's SYN-ACK packet.
 Measures network latency from TCP handshake timing. Estimates light distance between client and server.
 
 The latency is one way, so it is half the time the capture shows. `JA4L-S` measures
-the SYN to the SYN-ACK. `JA4L-C` measures the SYN-ACK to the first packet the
-application handshake sends.
+the SYN to the SYN-ACK. `JA4L-C` measures the SYN-ACK to the last packet that starts
+the payload of its sender and acknowledges no payload. That packet is the first one
+of the application handshake, and it stays the bare ACK when the application sends a
+whole HTTP request. `docs/implementation_notes.md` states the rule and names the
+vectors that prove it.
 
 **Format:** `JA4L-S={latency_microseconds}_{ttl}` and
 `JA4L-C={latency_microseconds}_{ttl}`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,7 +148,12 @@ Same format as JA4T, but extracted from the server's SYN-ACK packet.
 
 Measures network latency from TCP handshake timing. Estimates light distance between client and server.
 
-**Format:** `{latency_microseconds}_{ttl}`
+The latency is one way, so it is half the time the capture shows. `JA4L-S` measures
+the SYN to the SYN-ACK. `JA4L-C` measures the SYN-ACK to the first packet the
+application handshake sends.
+
+**Format:** `JA4L-S={latency_microseconds}_{ttl}` and
+`JA4L-C={latency_microseconds}_{ttl}`
 
 ```python
 from ja4plus import JA4LFingerprinter
@@ -159,7 +164,7 @@ fp = JA4LFingerprinter()
 for packet in handshake_packets:
     result = fp.process_packet(packet)
     if result:
-        print(result)  # e.g., "2500_56"
+        print(result)  # e.g., "JA4L-S=2500_56"
 ```
 
 **TTL-based OS hints:**

--- a/ja4plus/__init__.py
+++ b/ja4plus/__init__.py
@@ -31,11 +31,16 @@ from ja4plus.fingerprinters.ja4d import generate_ja4d
 from ja4plus.fingerprinters.ja4d6 import generate_ja4d6
 
 from ja4plus.utils.loopback import bind_loopback_ipv6
+from ja4plus.utils.tunnels import register_tunnel_dissectors
 
 # scapy binds one loopback address family value, the value of the reading host. Without
 # this call a loopback capture that carries IPv6 produces fingerprints on Darwin and
 # none on Linux. Issue #94 records the measurement.
 bind_loopback_ipv6()
+
+# scapy leaves Geneve, VXLAN and ERSPAN unbound. Without this call a fingerprinter
+# reads no TCP layer of a mirrored capture, such as `tcpdump-geneve.pcap`.
+register_tunnel_dissectors()
 
 
 def compute_ja4x_from_der(cert_der_bytes):

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -1,9 +1,18 @@
-"""
-JA4L Light Distance/Location Fingerprinting implementation.
+"""JA4L light distance fingerprints.
 
-JA4L measures the latency between client and server by analyzing
-TCP handshake timing, allowing for physical distance estimation.
-Format: JA4L-C=<latency_us>_<ttl> and JA4L-S=<latency_us>_<ttl>
+JA4L reports the one-way latency of a connection and the observed TTL, so that a
+reader estimates the distance between the client and the server. The TCP form reads
+the handshake. The QUIC form reads the Initial packets and the Handshake packets.
+Format: `JA4L-C=<latency_us>_<ttl>` and `JA4L-S=<latency_us>_<ttl>`.
+
+The reference holds four measurement points on a TCP connection:
+
+- `A` is the first SYN, and it carries the client TTL.
+- `B` is the first SYN-ACK, and it carries the server TTL.
+- `C` is the last packet that carries the relative sequence number 1 and the relative
+  acknowledgement number 1, and that holds no complete HTTP request.
+
+`JA4L-S` is half the time from `A` to `B`. `JA4L-C` is half the time from `B` to `C`.
 """
 
 import time
@@ -11,8 +20,27 @@ import logging
 from scapy.all import IP, IPv6, TCP, UDP
 
 from ja4plus.fingerprinters.base import BaseFingerprinter
+from ja4plus.utils.http_utils import is_http_request
+from ja4plus.utils.quic_utils import (
+    QUIC_HANDSHAKE,
+    QUIC_INITIAL,
+    long_header_packet_type,
+)
 
 logger = logging.getLogger(__name__)
+
+# FoxIO reports one-way latency, so it halves every measured round-trip time. The
+# JA4L material states "One-way TCP latency in us", and every vector holds half of
+# the time the capture shows.
+LATENCY_DIVISOR = 2
+
+# The reference reads the direction of a QUIC flow from this port. A QUIC flow on
+# another port carries no JA4L value, because neither endpoint is then the server.
+QUIC_PORT = 443
+
+# A TCP sequence number and acknowledgement number are 32 bits wide, so a relative
+# number needs this mask.
+SEQUENCE_MASK = 0xFFFFFFFF
 
 
 class JA4LFingerprinter(BaseFingerprinter):
@@ -72,18 +100,30 @@ class JA4LFingerprinter(BaseFingerprinter):
                 "conn_key": conn_key,
                 "timestamps": {},
                 "ttls": {},
+                "isns": {},
             }
 
         conn = self.connections[conn_key]
         fingerprint = generate_ja4l(packet, conn)
 
-        if fingerprint:
-            self.fingerprints.append(
-                {"fingerprint": fingerprint, "packet": packet, "connection": conn_key}
-            )
-            return fingerprint
+        if not fingerprint:
+            return None
 
-        return None
+        # The reference holds one client value for one connection and overwrites it
+        # while the measurement point moves. A later packet therefore replaces the
+        # value this fingerprinter already reported, and it adds no second value.
+        if fingerprint.startswith("JA4L-C="):
+            index = conn.get("client_entry")
+            if index is not None:
+                self.fingerprints[index]["fingerprint"] = fingerprint
+                self.fingerprints[index]["packet"] = packet
+                return fingerprint
+            conn["client_entry"] = len(self.fingerprints)
+
+        self.fingerprints.append(
+            {"fingerprint": fingerprint, "packet": packet, "connection": conn_key}
+        )
+        return fingerprint
 
     def reset(self):
         """Reset all fingerprints and connection tracking."""
@@ -164,113 +204,200 @@ class JA4LFingerprinter(BaseFingerprinter):
             return 255 - ttl
 
 
-def generate_ja4l(packet, conn=None):
-    """
-    Generate JA4L latency fingerprint based on packet timing.
-
-    Uses the TCP 3-way handshake or QUIC handshake to measure one-way latency.
-    Time is measured in microseconds.
+def _packet_microseconds(packet):
+    """Return the timestamp of one packet, in microseconds.
 
     Args:
-        packet: A network packet
-        conn: Connection tracking object with timestamps dict
+        packet: A network packet.
 
     Returns:
-        JA4L fingerprint string if successful, None otherwise
+        The capture timestamp when the packet carries one, and the wall clock when it
+        does not. A capture file replays faster than real time, so an offline read
+        needs the capture timestamp.
+    """
+    seconds = float(packet.time) if hasattr(packet, "time") else time.time()
+    return int(round(seconds * 1000000))
+
+
+def _one_way_latency(start, end):
+    """Return the one-way latency between two timestamps, in microseconds.
+
+    Args:
+        start: The earlier timestamp, in microseconds.
+        end: The later timestamp, in microseconds.
+
+    Returns:
+        Half the time between the two timestamps, truncated toward zero.
+    """
+    return int((end - start) / LATENCY_DIVISOR)
+
+
+def _relative_numbers(conn, source, target, tcp_layer):
+    """Return the relative sequence number and acknowledgement number of one packet.
+
+    Args:
+        conn: The connection state.
+        source: The (address, port) pair of the sender.
+        target: The (address, port) pair of the receiver.
+        tcp_layer: The TCP layer of the packet.
+
+    Returns:
+        A (sequence, acknowledgement) pair, counted from the initial sequence number
+        of each endpoint. Returns None when the capture holds no SYN for one endpoint,
+        because a relative number needs that initial sequence number.
+    """
+    initial = conn.get("isns", {})
+    if source not in initial or target not in initial:
+        return None
+    sequence = (int(tcp_layer.seq) - initial[source]) & SEQUENCE_MASK
+    acknowledgement = (int(tcp_layer.ack) - initial[target]) & SEQUENCE_MASK
+    return sequence, acknowledgement
+
+
+def _holds_a_complete_http_request(payload):
+    """Report whether the payload holds an HTTP request with its whole header block.
+
+    The reference keeps the timestamps of a packet under the protocol its dissector
+    reports. A packet that holds a whole HTTP request reaches a separate cache, so it
+    never moves the client measurement point. A packet that holds the first part of a
+    request reaches the same cache as any other TCP packet, and it does move the
+    point. `http-empty-useragent.pcap` and `latest.pcapng` prove both halves.
+
+    Args:
+        payload: The TCP payload bytes.
+
+    Returns:
+        True when the payload starts an HTTP request and holds the blank line that
+        ends the header block.
+    """
+    if not is_http_request(payload):
+        return False
+    return b"\r\n\r\n" in payload or b"\n\n" in payload
+
+
+def _tcp_ja4l(packet, conn, ip_layer, ttl, now):
+    """Return the JA4L value one TCP packet produces, or None."""
+    tcp_layer = packet[TCP]
+    flags = int(tcp_layer.flags)
+    syn = bool(flags & 0x02)
+    ack = bool(flags & 0x10)
+    source = (ip_layer.src, int(tcp_layer.sport))
+    target = (ip_layer.dst, int(tcp_layer.dport))
+    timestamps = conn["timestamps"]
+    ttls = conn["ttls"]
+
+    if syn:
+        conn.setdefault("isns", {})[source] = int(tcp_layer.seq)
+
+    if syn and not ack:
+        if "A" not in timestamps:
+            timestamps["A"] = now
+            ttls["client"] = ttl
+        return None
+
+    if syn and ack:
+        if "B" not in timestamps:
+            timestamps["B"] = now
+            ttls["server"] = ttl
+        if "A" not in timestamps:
+            return None
+        return "JA4L-S={}_{}".format(
+            _one_way_latency(timestamps["A"], timestamps["B"]), ttls["server"]
+        )
+
+    if not ack or "B" not in timestamps or "client" not in ttls:
+        return None
+
+    # The reference moves the client measurement point to every packet that starts
+    # the payload of its sender and acknowledges no payload. That is the bare ACK of
+    # the handshake first, and then the first packet of the application handshake.
+    if _relative_numbers(conn, source, target, tcp_layer) != (1, 1):
+        return None
+    if _holds_a_complete_http_request(bytes(tcp_layer.payload)):
+        return None
+
+    timestamps["C"] = now
+    return "JA4L-C={}_{}".format(_one_way_latency(timestamps["B"], timestamps["C"]), ttls["client"])
+
+
+def _quic_ja4l(packet, conn, ttl, now):
+    """Return the JA4L value one QUIC packet produces, or None."""
+    udp_layer = packet[UDP]
+    packet_type = long_header_packet_type(bytes(udp_layer.payload))
+    if packet_type is None:
+        return None
+    to_server = int(udp_layer.dport) == QUIC_PORT
+    from_server = int(udp_layer.sport) == QUIC_PORT
+    timestamps = conn["timestamps"]
+    ttls = conn["ttls"]
+
+    if packet_type == QUIC_INITIAL:
+        if to_server and "A" not in timestamps:
+            timestamps["A"] = now
+            ttls["client"] = ttl
+        elif from_server and "A" in timestamps and "B" not in timestamps:
+            timestamps["B"] = now
+            ttls["server"] = ttl
+            return "JA4L-S={}_{}".format(
+                _one_way_latency(timestamps["A"], timestamps["B"]), ttls["server"]
+            )
+        return None
+
+    if packet_type != QUIC_HANDSHAKE:
+        return None
+
+    # The server sends one to five Handshake packets. The client measurement starts
+    # at the last of them, so this point moves until the client answers.
+    if from_server and "D" not in timestamps:
+        timestamps["C"] = now
+        return None
+
+    if to_server and "C" in timestamps and "D" not in timestamps:
+        timestamps["D"] = now
+        return "JA4L-C={}_{}".format(
+            _one_way_latency(timestamps["C"], timestamps["D"]), ttls.get("client", ttl)
+        )
+    return None
+
+
+def generate_ja4l(packet, conn=None):
+    """Return the JA4L value one packet produces, or None.
+
+    The function reads the measurement points of the connection from `conn` and
+    writes the point this packet supplies back into it.
+
+    Args:
+        packet: A network packet.
+        conn: The connection state, which holds `timestamps`, `ttls` and `isns`.
+
+    Returns:
+        A `JA4L-S=` value, a `JA4L-C=` value, or None when the packet supplies no
+        value. Returns None for a packet this fingerprinter cannot read.
     """
     if not conn:
         return None
 
-    from ja4plus.utils.packet_utils import get_ip_layer as _get_ip, get_ttl
+    from ja4plus.utils.packet_utils import get_ip_layer, get_ttl
 
-    if _get_ip(packet) is None:
+    ip_layer = get_ip_layer(packet)
+    if ip_layer is None:
         return None
 
     try:
-        if "timestamps" not in conn:
-            conn["timestamps"] = {}
-        if "ttls" not in conn:
-            conn["ttls"] = {}
+        conn.setdefault("timestamps", {})
+        conn.setdefault("ttls", {})
+        conn.setdefault("isns", {})
 
         ttl = get_ttl(packet)
         if ttl is None:
             return None
 
-        # Use pcap timestamp if available (for offline analysis), else wall clock
-        current_time = float(packet.time) if hasattr(packet, "time") else time.time()
+        now = _packet_microseconds(packet)
 
-        # Handle TCP protocol
         if packet.haslayer(TCP):
-            tcp_flags = packet[TCP].flags
-
-            # SYN packet (point A) - client initiates
-            if tcp_flags & 0x02 == 0x02 and not tcp_flags & 0x10:
-                conn["timestamps"]["A"] = current_time
-                conn["ttls"]["client"] = ttl
-                return None
-
-            # SYN-ACK packet (point B) - server responds
-            elif tcp_flags & 0x12 == 0x12:
-                conn["timestamps"]["B"] = current_time
-                conn["ttls"]["server"] = ttl
-
-                if "A" in conn["timestamps"]:
-                    # Per FoxIO spec: use raw time difference (not divided by 2)
-                    diff = conn["timestamps"]["B"] - conn["timestamps"]["A"]
-                    latency = max(1, int(diff * 1000000))
-                    return f"JA4L-S={latency}_{ttl}"
-
-            # ACK packet (point C) - client completes handshake
-            elif tcp_flags & 0x10 == 0x10 and not tcp_flags & 0x02:
-                conn["timestamps"]["C"] = current_time
-
-                if "B" in conn["timestamps"]:
-                    diff = conn["timestamps"]["C"] - conn["timestamps"]["B"]
-                    latency = max(1, int(diff * 1000000))
-                    return f"JA4L-C={latency}_{ttl}"
-
-        # Handle QUIC (UDP) protocol.
-        # Per FoxIO spec, the first UDP packet seen on a flow defines the
-        # client; the response defines the server. We don't depend on the
-        # lexicographic conn_key direction (which produced silent failures
-        # for server-first capture orderings — the previous code only
-        # advanced state when direction was 'forward').
-        elif packet.haslayer(UDP) and conn.get("proto") == "udp":
-            from ja4plus.utils.packet_utils import get_ip_layer
-
-            ip_layer = get_ip_layer(packet)
-            if ip_layer is None:
-                return None
-            src_ip = ip_layer.src
-            sport = int(packet[UDP].sport)
-            dport = int(packet[UDP].dport)
-
-            # Lock in the client identity on the first packet.
-            if "client_endpoint" not in conn:
-                conn["client_endpoint"] = (src_ip, sport, dport)
-            client_ip, client_sport, client_dport = conn["client_endpoint"]
-            is_client = src_ip == client_ip and sport == client_sport and dport == client_dport
-
-            if "A" not in conn["timestamps"] and is_client:
-                conn["timestamps"]["A"] = current_time
-                conn["ttls"]["client"] = ttl
-
-            elif "A" in conn["timestamps"] and not is_client and "B" not in conn["timestamps"]:
-                conn["timestamps"]["B"] = current_time
-                conn["ttls"]["server"] = ttl
-                diff = conn["timestamps"]["B"] - conn["timestamps"]["A"]
-                latency = max(1, int(diff * 1000000))
-                return f"JA4L-S={latency}_{ttl}"
-
-            elif "B" in conn["timestamps"] and is_client and "C" not in conn["timestamps"]:
-                conn["timestamps"]["C"] = current_time
-
-            elif "C" in conn["timestamps"] and not is_client and "D" not in conn["timestamps"]:
-                conn["timestamps"]["D"] = current_time
-                diff = conn["timestamps"]["D"] - conn["timestamps"]["C"]
-                latency = max(1, int(diff * 1000000))
-                return f"JA4L-C={latency}_{conn['ttls'].get('client', ttl)}"
-
+            return _tcp_ja4l(packet, conn, ip_layer, ttl, now)
+        if packet.haslayer(UDP) and conn.get("proto") == "udp":
+            return _quic_ja4l(packet, conn, ttl, now)
         return None
     except (ValueError, TypeError, IndexError, AttributeError) as e:
         logger.debug(f"Packet does not contain JA4L data: {e}")

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -5,7 +5,7 @@ reader estimates the distance between the client and the server. The TCP form re
 the handshake. The QUIC form reads the Initial packets and the Handshake packets.
 Format: `JA4L-C=<latency_us>_<ttl>` and `JA4L-S=<latency_us>_<ttl>`.
 
-The reference holds four measurement points on a TCP connection:
+The reference holds three measurement points on a TCP connection:
 
 - `A` is the first SYN, and it carries the client TTL.
 - `B` is the first SYN-ACK, and it carries the server TTL.
@@ -275,27 +275,54 @@ def _holds_a_complete_http_request(payload):
     return b"\r\n\r\n" in payload or b"\n\n" in payload
 
 
+def _restart_connection(conn):
+    """Drop every measurement point of one connection.
+
+    A later connection reuses the endpoints of a closed one, and the reference counts
+    the two separately. Without this call the later connection reads the measurement
+    points of the earlier one. It also replaces the client value the fingerprinter
+    already reported.
+    """
+    conn["timestamps"] = {}
+    conn["ttls"] = {}
+    conn["isns"] = {}
+    conn.pop("client_entry", None)
+
+
 def _tcp_ja4l(packet, conn, ip_layer, ttl, now):
-    """Return the JA4L value one TCP packet produces, or None."""
+    """Return the JA4L value this TCP packet gives, or None."""
     tcp_layer = packet[TCP]
     flags = int(tcp_layer.flags)
     syn = bool(flags & 0x02)
     ack = bool(flags & 0x10)
     source = (ip_layer.src, int(tcp_layer.sport))
     target = (ip_layer.dst, int(tcp_layer.dport))
+    sequence = int(tcp_layer.seq)
+
+    if syn and not ack:
+        # A SYN that carries another initial sequence number opens another connection
+        # on the same endpoints.
+        if "A" in conn["timestamps"] and conn["isns"].get(source) != sequence:
+            _restart_connection(conn)
+        conn["isns"][source] = sequence
+        if "A" in conn["timestamps"]:
+            return None
+        conn["timestamps"]["A"] = now
+        conn["ttls"]["client"] = ttl
+        if "B" not in conn["timestamps"]:
+            return None
+        # A reordered capture holds the SYN-ACK before the SYN. This packet is then
+        # the last one that reaches both points of the server value.
+        return "JA4L-S={}_{}".format(
+            _one_way_latency(conn["timestamps"]["A"], conn["timestamps"]["B"]),
+            conn["ttls"]["server"],
+        )
+
     timestamps = conn["timestamps"]
     ttls = conn["ttls"]
 
-    if syn:
-        conn.setdefault("isns", {})[source] = int(tcp_layer.seq)
-
-    if syn and not ack:
-        if "A" not in timestamps:
-            timestamps["A"] = now
-            ttls["client"] = ttl
-        return None
-
     if syn and ack:
+        conn["isns"][source] = sequence
         if "B" not in timestamps:
             timestamps["B"] = now
             ttls["server"] = ttl
@@ -321,13 +348,17 @@ def _tcp_ja4l(packet, conn, ip_layer, ttl, now):
 
 
 def _quic_ja4l(packet, conn, ttl, now):
-    """Return the JA4L value one QUIC packet produces, or None."""
+    """Return the JA4L value this QUIC packet gives, or None."""
     udp_layer = packet[UDP]
     packet_type = long_header_packet_type(bytes(udp_layer.payload))
     if packet_type is None:
         return None
     to_server = int(udp_layer.dport) == QUIC_PORT
     from_server = int(udp_layer.sport) == QUIC_PORT
+    # A flow whose two ports are 443 names no server, so the direction of a packet is
+    # unknown and every value it gives is a guess.
+    if to_server and from_server:
+        return None
     timestamps = conn["timestamps"]
     ttls = conn["ttls"]
 
@@ -361,7 +392,7 @@ def _quic_ja4l(packet, conn, ttl, now):
 
 
 def generate_ja4l(packet, conn=None):
-    """Return the JA4L value one packet produces, or None.
+    """Return the JA4L value this packet gives, or None.
 
     The function reads the measurement points of the connection from `conn` and
     writes the point this packet supplies back into it.

--- a/ja4plus/utils/quic_utils.py
+++ b/ja4plus/utils/quic_utils.py
@@ -18,6 +18,49 @@ logger = logging.getLogger(__name__)
 QUIC_V1_SALT = bytes.fromhex("38762cf7f55934b34d179ae6a4c80cadccbb7f0a")
 QUIC_V2_SALT = bytes.fromhex("0dede3def700a6db819381be6e269dcbf9bd2ed9")
 
+QUIC_V2_VERSION = 0x6B3343CF
+
+# The long-header packet types of QUIC version 1 (RFC 9000 Section 17.2).
+QUIC_INITIAL = 0
+QUIC_ZERO_RTT = 1
+QUIC_HANDSHAKE = 2
+QUIC_RETRY = 3
+
+# QUIC version 2 gives the same four types different codes (RFC 9369 Section 3.2).
+# This table reads a version 2 code and returns the version 1 code, so that a caller
+# compares one number for both versions.
+_VERSION_2_PACKET_TYPES = {
+    1: QUIC_INITIAL,
+    2: QUIC_ZERO_RTT,
+    3: QUIC_HANDSHAKE,
+    0: QUIC_RETRY,
+}
+
+
+def long_header_packet_type(udp_payload):
+    """Return the long-header packet type of a QUIC datagram, or None.
+
+    Args:
+        udp_payload: The bytes of the UDP payload.
+
+    Returns:
+        `QUIC_INITIAL`, `QUIC_ZERO_RTT`, `QUIC_HANDSHAKE` or `QUIC_RETRY`. Returns
+        None when the datagram is too short, when it holds a short header, or when it
+        holds a version negotiation packet.
+    """
+    if len(udp_payload) < 5:
+        return None
+    first_byte = udp_payload[0]
+    if not first_byte & 0x80:
+        return None
+    version = struct.unpack("!I", udp_payload[1:5])[0]
+    if version == 0:
+        return None
+    packet_type = (first_byte & 0x30) >> 4
+    if version == QUIC_V2_VERSION:
+        return _VERSION_2_PACKET_TYPES.get(packet_type)
+    return packet_type
+
 
 def _decode_varint(data):
     """Decode a QUIC variable-length integer (RFC 9000 Section 16)."""

--- a/ja4plus/utils/tunnels.py
+++ b/ja4plus/utils/tunnels.py
@@ -2,7 +2,7 @@
 
 `scapy.all` binds the common protocols, and it leaves Geneve, VXLAN and ERSPAN to a
 separate import. Without that import scapy stops at the tunnel header, so a
-fingerprinter reads no TCP layer and produces nothing for a mirrored capture.
+fingerprinter reads no TCP layer and emits nothing for a mirrored capture.
 `tcpdump-geneve.pcap` and `gre-erspan-vxlan.pcap` are two such vectors.
 
 A scapy dissector binds itself to a port or a protocol number at import time, so one

--- a/ja4plus/utils/tunnels.py
+++ b/ja4plus/utils/tunnels.py
@@ -1,0 +1,41 @@
+"""Registration of the scapy tunnel dissectors this project needs.
+
+`scapy.all` binds the common protocols, and it leaves Geneve, VXLAN and ERSPAN to a
+separate import. Without that import scapy stops at the tunnel header, so a
+fingerprinter reads no TCP layer and produces nothing for a mirrored capture.
+`tcpdump-geneve.pcap` and `gre-erspan-vxlan.pcap` are two such vectors.
+
+A scapy dissector binds itself to a port or a protocol number at import time, so one
+import of this module changes what every fingerprinter sees. `ja4plus/__init__.py`
+imports it once.
+
+An older scapy release ships no `erspan` module, so a missing module is not a defect
+here. The fingerprinter then reads no value for that capture, which is the same
+result as before the import.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+TUNNEL_MODULES = ("scapy.contrib.geneve", "scapy.layers.vxlan", "scapy.contrib.erspan")
+
+
+def register_tunnel_dissectors():
+    """Import every tunnel dissector and return the names that loaded.
+
+    Returns:
+        The tuple of module names scapy now holds. A module the installed scapy does
+        not ship is absent from the tuple.
+    """
+    import importlib
+
+    loaded = []
+    for name in TUNNEL_MODULES:
+        try:
+            importlib.import_module(name)
+        except ImportError as error:
+            logger.debug("scapy ships no %s: %s", name, error)
+            continue
+        loaded.append(name)
+    return tuple(loaded)

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -5,79 +5,39 @@
   },
   "CVE-2018-6794.pcap/JA4L-C": {
     "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
+    "cause": "ja4plus emits more JA4L-C values than the reference holds."
   },
   "CVE-2018-6794.pcap/JA4L-S": {
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
   },
-  "badcurveball.pcap/0:55318/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
+  "browsers-x509.pcapng/0:54524/JA4X.1": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "badcurveball.pcap/0:55318/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+  "browsers-x509.pcapng/0:54524/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "badcurveball.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "browsers-x509.pcapng/0:54524/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "browsers-x509.pcapng/0:54524/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "browsers-x509.pcapng/1:54525/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "browsers-x509.pcapng/1:54525/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "browsers-x509.pcapng/2:54603/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "browsers-x509.pcapng/2:54603/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "browsers-x509.pcapng/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "chrome-cloudflare-quic-with-secrets.pcapng/0:50280/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
+  "browsers-x509.pcapng/JA4X": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:50280/JA4L-S.1": {
-    "issue": 88,
-    "cause": "The produced JA4L-S value differs from the reference by another amount."
+    "issue": 102,
+    "cause": "ja4plus reads the first server Initial packet, and the reference reads the Initial packet that completes the ServerHello."
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H.1": {
     "issue": 35,
     "cause": "ja4plus produces no JA4H value on this stream."
   },
-  "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4X.1": {
     "issue": 78,
-    "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4X.2": {
     "issue": 78,
-    "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4": {
     "issue": 13,
@@ -87,81 +47,33 @@
     "issue": 35,
     "cause": "ja4plus produces no JA4H fingerprint the reference holds."
   },
-  "chrome-cloudflare-quic-with-secrets.pcapng/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4X": {
     "issue": 78,
-    "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
+    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
   },
   "gre-erspan-vxlan.pcap/0:65174/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus does not decode the tunnel payload of this capture, so it reads no TCP layer and produces no JA4L-C value on this stream."
+    "issue": 101,
+    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it produces no JA4L-C value."
   },
   "gre-erspan-vxlan.pcap/0:65174/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus does not decode the tunnel payload of this capture, so it reads no TCP layer and produces no JA4L-S value on this stream."
+    "issue": 101,
+    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it produces no JA4L-S value."
   },
   "gre-erspan-vxlan.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus does not decode the tunnel payload of this capture, so it reads no TCP layer and produces no JA4L-C value."
+    "issue": 101,
+    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it produces no JA4L-C value."
   },
   "gre-erspan-vxlan.pcap/JA4L-S": {
-    "issue": 34,
-    "cause": "ja4plus does not decode the tunnel payload of this capture, so it reads no TCP layer and produces no JA4L-S value."
-  },
-  "gre-sample.pcap/0:40264/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "gre-sample.pcap/0:40264/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "gre-sample.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "gre-sample.pcap/JA4L-S": {
-    "issue": 34,
-    "cause": "ja4plus emits more JA4L-S values than the reference holds."
-  },
-  "gre-sample.pcap/JA4SSH": {
-    "issue": 105,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
+    "issue": 101,
+    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it produces no JA4L-S value."
   },
   "http-empty-useragent.pcap/0:57722/JA4H.1": {
     "issue": 35,
     "cause": "ja4plus produces no JA4H value on this stream."
   },
-  "http-empty-useragent.pcap/0:57722/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "http-empty-useragent.pcap/0:57722/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
   "http-empty-useragent.pcap/JA4H": {
     "issue": 35,
     "cause": "ja4plus produces no JA4H fingerprint the reference holds."
-  },
-  "http-empty-useragent.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "http1-with-cookies.pcapng/0:61256/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "http1-with-cookies.pcapng/0:61256/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "http1-with-cookies.pcapng/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
   },
   "http2-with-cookies.pcapng/0:58847/JA4H.1": {
     "issue": 35,
@@ -223,37 +135,25 @@
     "issue": 35,
     "cause": "ja4plus produces no JA4H value on this stream."
   },
-  "http2-with-cookies.pcapng/0:58847/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "http2-with-cookies.pcapng/0:58847/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
   "http2-with-cookies.pcapng/0:58847/JA4X.1": {
     "issue": 78,
-    "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.2": {
     "issue": 78,
-    "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.3": {
     "issue": 78,
-    "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "http2-with-cookies.pcapng/JA4H": {
     "issue": 35,
     "cause": "ja4plus produces no JA4H fingerprint the reference holds."
   },
-  "http2-with-cookies.pcapng/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
   "http2-with-cookies.pcapng/JA4X": {
     "issue": 78,
-    "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
+    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
   },
   "https-connect.pcap/JA4": {
     "issue": 13,
@@ -261,7 +161,7 @@
   },
   "https-connect.pcap/JA4L-C": {
     "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
+    "cause": "ja4plus emits more JA4L-C values than the reference holds."
   },
   "https-connect.pcap/JA4L-S": {
     "issue": 34,
@@ -273,99 +173,27 @@
   },
   "https-connect.pcap/JA4X": {
     "issue": 78,
-    "cause": "The reference reads no TLS on port 8080, and ja4plus reads the certificate of the tunnel from the record layer."
+    "cause": "ja4plus produces a JA4X fingerprint the reference does not hold."
   },
-  "https3-301-get.pcap/0:62599/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
+  "latest.pcapng/10:52941/JA4X.1": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "https3-301-get.pcap/0:62599/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+  "latest.pcapng/10:52941/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "https3-301-get.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
+  "latest.pcapng/9:52940/JA4X.1": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "ipv6.pcapng/0:64034/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
+  "latest.pcapng/9:52940/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "ipv6.pcapng/0:64034/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ipv6.pcapng/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "latest.pcapng/10:52941/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "latest.pcapng/10:52941/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "latest.pcapng/1:52936/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "latest.pcapng/1:52936/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "latest.pcapng/3:52937/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "latest.pcapng/3:52937/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "latest.pcapng/5:52938/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "latest.pcapng/5:52938/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "latest.pcapng/6:52939/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "latest.pcapng/6:52939/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "latest.pcapng/9:52940/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "latest.pcapng/9:52940/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "latest.pcapng/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "latest.pcapng/JA4L-S": {
-    "issue": 34,
-    "cause": "ja4plus emits more JA4L-S values than the reference holds."
-  },
-  "macos_tcp_flags.pcap/0:61311/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "macos_tcp_flags.pcap/0:61311/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "macos_tcp_flags.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
+  "latest.pcapng/JA4X": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
   },
   "quic-tls-handshake.pcapng/JA4": {
     "issue": 13,
@@ -375,285 +203,121 @@
     "issue": 13,
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold."
   },
-  "socks-https-example.pcap/0:53554/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "socks-https-example.pcap/0:53554/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "socks-https-example.pcap/2:53555/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "socks-https-example.pcap/2:53555/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "socks-https-example.pcap/4:53556/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "socks-https-example.pcap/4:53556/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "socks-https-example.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "socks4-https.pcap/0:50606/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "socks4-https.pcap/0:50606/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "socks4-https.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "socks4-https.pcap/JA4X": {
+  "socks-https-example.pcap/2:53555/JA4X.1": {
     "issue": 78,
-    "cause": "The reference reads no TLS on port 9901, and ja4plus reads the certificate of the tunnel from the record layer."
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "ssh-r.pcap/0:64980/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
+  "socks-https-example.pcap/2:53555/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "ssh-r.pcap/0:64980/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+  "socks-https-example.pcap/4:53556/JA4X.1": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
+  },
+  "socks-https-example.pcap/4:53556/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
+  },
+  "socks-https-example.pcap/JA4X": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
+  },
+  "ssh-r.pcap/0:64980/JA4SSH.1": {
+    "issue": 92,
+    "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-r.pcap/0:64980/JA4SSH.2": {
-    "issue": 97,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
-  },
-  "ssh-r.pcap/1:46394/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh-r.pcap/1:46394/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+    "issue": 92,
+    "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh-r.pcap/1:46394/JA4SSH.1": {
-    "issue": 96,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window. The packet count differs too: ja4plus counts one SSH packet for each TCP segment, and tshark labels only the segment that completes an SSH message. #98 owns the count."
-  },
-  "ssh-r.pcap/2:46396/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh-r.pcap/2:46396/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+    "issue": 92,
+    "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh-r.pcap/2:46396/JA4SSH.1": {
-    "issue": 96,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
+    "issue": 92,
+    "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-r.pcap/2:46396/JA4SSH.5": {
-    "issue": 98,
-    "cause": "ja4plus counts one SSH packet for each TCP segment, and tshark labels only the segment that completes an SSH message. #98 owns the count."
+    "issue": 92,
+    "cause": "ja4plus produces no JA4SSH value on this stream."
   },
-  "ssh-r.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
+  "ssh-r.pcap/JA4SSH": {
+    "issue": 92,
+    "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
   },
-  "ssh-scp-1050.pcap/0:49237/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh-scp-1050.pcap/0:49237/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+  "ssh-scp-1050.pcap/0:49237/JA4SSH.1": {
+    "issue": 92,
+    "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.3": {
-    "issue": 96,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
+    "issue": 92,
+    "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.4": {
-    "issue": 96,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
+    "issue": 92,
+    "cause": "The produced JA4SSH value differs from the reference."
   },
-  "ssh-scp-1050.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
+  "ssh2.pcapng/11:57374/JA4X.1": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "ssh2-malformed.pcap/0:61672/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
+  "ssh2.pcapng/11:57374/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "ssh2-malformed.pcap/0:61672/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+  "ssh2.pcapng/12:57375/JA4X.1": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "ssh2-malformed.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
+  "ssh2.pcapng/12:57375/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "ssh2-moloch-crash.pcap/0:61672/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh2-moloch-crash.pcap/0:61672/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2-moloch-crash.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "ssh2.pcapng/11:57374/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh2.pcapng/11:57374/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/12:57375/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh2.pcapng/12:57375/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/13:57376/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh2.pcapng/13:57376/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/14:57377/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh2.pcapng/14:57377/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+  "ssh2.pcapng/14:57377/JA4SSH.1": {
+    "issue": 92,
+    "cause": "The produced JA4SSH value differs from the reference."
   },
   "ssh2.pcapng/14:57377/JA4SSH.2": {
-    "issue": 97,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
-  },
-  "ssh2.pcapng/15:57380/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/15:57380/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/22:57396/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/22:57396/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/33:51810/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/36:61861/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh2.pcapng/36:61861/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/5:57368/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh2.pcapng/5:57368/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "ssh2.pcapng/8:57371/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "ssh2.pcapng/8:57371/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+    "issue": 92,
+    "cause": "ja4plus produces no JA4SSH value on this stream."
   },
   "ssh2.pcapng/JA4": {
     "issue": 13,
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold."
-  },
-  "ssh2.pcapng/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
   },
   "ssh2.pcapng/JA4L-S": {
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
   },
   "ssh2.pcapng/JA4SSH": {
-    "issue": 97,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
+    "issue": 92,
+    "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
   },
-  "sshv1.pcap/0:1022/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
+  "ssh2.pcapng/JA4X": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
   },
-  "sshv1.pcap/0:1022/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+  "tls-handshake.pcapng/34:50158/JA4X.1": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
-  "sshv1.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "sshv1.pcap/JA4L-S": {
-    "issue": 34,
-    "cause": "ja4plus emits more JA4L-S values than the reference holds."
-  },
-  "sshv1.pcap/JA4SSH": {
-    "issue": 105,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
-  },
-  "tcpdump-geneve.pcap/0:51225/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus does not decode the tunnel payload of this capture, so it reads no TCP layer and produces no JA4L-C value on this stream."
-  },
-  "tcpdump-geneve.pcap/0:51225/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus does not decode the tunnel payload of this capture, so it reads no TCP layer and produces no JA4L-S value on this stream."
-  },
-  "tcpdump-geneve.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus does not decode the tunnel payload of this capture, so it reads no TCP layer and produces no JA4L-C value."
-  },
-  "tcpdump-geneve.pcap/JA4L-S": {
-    "issue": 34,
-    "cause": "ja4plus does not decode the tunnel payload of this capture, so it reads no TCP layer and produces no JA4L-S value."
-  },
-  "tls-alpn-h2.pcap/0:64034/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls-alpn-h2.pcap/0:64034/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls-alpn-h2.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
+  "tls-handshake.pcapng/34:50158/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "tls-handshake.pcapng/38:50159/JA4.2": {
     "issue": 13,
     "cause": "ja4plus produces no JA4 value on this stream."
+  },
+  "tls-handshake.pcapng/40:50164/JA4X.2": {
+    "issue": 78,
+    "cause": "The produced JA4X value differs from the reference."
+  },
+  "tls-handshake.pcapng/40:50164/JA4X.3": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "tls-handshake.pcapng/41:50165/JA4.2": {
     "issue": 13,
@@ -663,6 +327,14 @@
     "issue": 13,
     "cause": "ja4plus produces no JA4 value on this stream."
   },
+  "tls-handshake.pcapng/43:50167/JA4X.1": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
+  },
+  "tls-handshake.pcapng/43:50167/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
+  },
   "tls-handshake.pcapng/44:50168/JA4.2": {
     "issue": 13,
     "cause": "ja4plus produces no JA4 value on this stream."
@@ -670,6 +342,14 @@
   "tls-handshake.pcapng/45:50169/JA4.2": {
     "issue": 13,
     "cause": "ja4plus produces no JA4 value on this stream."
+  },
+  "tls-handshake.pcapng/46:50170/JA4X.2": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
+  },
+  "tls-handshake.pcapng/46:50170/JA4X.3": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "tls-handshake.pcapng/JA4": {
     "issue": 13,
@@ -682,6 +362,10 @@
   "tls-handshake.pcapng/JA4S": {
     "issue": 13,
     "cause": "ja4plus produces a JA4S fingerprint the reference does not hold."
+  },
+  "tls-handshake.pcapng/JA4X": {
+    "issue": 78,
+    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
   },
   "tls-non-ascii-alpn.pcapng/0:50112/JA4.1": {
     "issue": 13,
@@ -711,144 +395,12 @@
     "issue": 13,
     "cause": "ja4plus produces no JA4 fingerprint the reference holds."
   },
-  "tls3.pcapng/10:63251/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/10:63251/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/11:63252/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/11:63252/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/12:63253/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/12:63253/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/13:63254/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/13:63254/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/14:63255/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/14:63255/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/21:62481/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/21:62481/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/22:61732/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/22:61732/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/23:49791/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/23:49791/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/24:56684/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/24:56684/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
   "tls3.pcapng/25:61884/JA4L-S.1": {
-    "issue": 88,
-    "cause": "The produced JA4L-S value differs from the reference by another amount."
-  },
-  "tls3.pcapng/28:58117/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/28:58117/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/7:63248/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/7:63248/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/8:63249/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/8:63249/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "tls3.pcapng/9:63250/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "tls3.pcapng/9:63250/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
+    "issue": 102,
+    "cause": "ja4plus reads the first server Initial packet, and the reference reads the Initial packet that completes the ServerHello."
   },
   "tls3.pcapng/JA4": {
     "issue": 13,
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold."
-  },
-  "tls3.pcapng/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "tls3.pcapng/JA4L-S": {
-    "issue": 34,
-    "cause": "ja4plus emits more JA4L-S values than the reference holds."
-  },
-  "v6.pcap/0:1022/JA4L-C.1": {
-    "issue": 88,
-    "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
-  },
-  "v6.pcap/0:1022/JA4L-S.1": {
-    "issue": 88,
-    "cause": "ja4plus reports the round-trip time, and the reference holds half of it."
-  },
-  "v6.pcap/JA4L-C": {
-    "issue": 34,
-    "cause": "ja4plus emits one JA4L-C value for every ACK on the connection."
-  },
-  "v6.pcap/JA4L-S": {
-    "issue": 34,
-    "cause": "ja4plus emits more JA4L-S values than the reference holds."
-  },
-  "v6.pcap/JA4SSH": {
-    "issue": 105,
-    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
   }
 }

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -11,18 +11,6 @@
     "issue": 34,
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
   },
-  "browsers-x509.pcapng/0:54524/JA4X.1": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "browsers-x509.pcapng/0:54524/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "browsers-x509.pcapng/JA4X": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
-  },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:50280/JA4L-S.1": {
     "issue": 102,
     "cause": "ja4plus reads the first server Initial packet, and the reference reads the Initial packet that completes the ServerHello."
@@ -33,11 +21,11 @@
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4X.1": {
     "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
+    "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4X.2": {
     "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
+    "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4": {
     "issue": 13,
@@ -49,7 +37,7 @@
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4X": {
     "issue": 78,
-    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
+    "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
   },
   "gre-erspan-vxlan.pcap/0:65174/JA4L-C.1": {
     "issue": 101,
@@ -66,6 +54,10 @@
   "gre-erspan-vxlan.pcap/JA4L-S": {
     "issue": 101,
     "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-S value."
+  },
+  "gre-sample.pcap/JA4SSH": {
+    "issue": 105,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
   },
   "http-empty-useragent.pcap/0:57722/JA4H.1": {
     "issue": 35,
@@ -137,15 +129,15 @@
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.1": {
     "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
+    "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.2": {
     "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
+    "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.3": {
     "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
+    "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
   },
   "http2-with-cookies.pcapng/JA4H": {
     "issue": 35,
@@ -153,7 +145,7 @@
   },
   "http2-with-cookies.pcapng/JA4X": {
     "issue": 78,
-    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
+    "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
   },
   "https-connect.pcap/JA4": {
     "issue": 13,
@@ -173,27 +165,7 @@
   },
   "https-connect.pcap/JA4X": {
     "issue": 78,
-    "cause": "ja4plus produces a JA4X fingerprint the reference does not hold."
-  },
-  "latest.pcapng/10:52941/JA4X.1": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "latest.pcapng/10:52941/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "latest.pcapng/9:52940/JA4X.1": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "latest.pcapng/9:52940/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "latest.pcapng/JA4X": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
+    "cause": "The reference reads no TLS on port 8080, and ja4plus reads the certificate of the tunnel from the record layer."
   },
   "quic-tls-handshake.pcapng/JA4": {
     "issue": 13,
@@ -203,85 +175,37 @@
     "issue": 13,
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold."
   },
-  "socks-https-example.pcap/2:53555/JA4X.1": {
+  "socks4-https.pcap/JA4X": {
     "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "socks-https-example.pcap/2:53555/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "socks-https-example.pcap/4:53556/JA4X.1": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "socks-https-example.pcap/4:53556/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "socks-https-example.pcap/JA4X": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
-  },
-  "ssh-r.pcap/0:64980/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "cause": "The reference reads no TLS on port 9901, and ja4plus reads the certificate of the tunnel from the record layer."
   },
   "ssh-r.pcap/0:64980/JA4SSH.2": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH value on this stream."
+    "issue": 97,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
   },
   "ssh-r.pcap/1:46394/JA4SSH.1": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH value on this stream."
+    "issue": 96,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window. The packet count differs too: ja4plus counts one SSH packet for each TCP segment, and tshark labels only the segment that completes an SSH message. #98 owns the count."
   },
   "ssh-r.pcap/2:46396/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "issue": 96,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
   },
   "ssh-r.pcap/2:46396/JA4SSH.5": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH value on this stream."
-  },
-  "ssh-r.pcap/JA4SSH": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
-  },
-  "ssh-scp-1050.pcap/0:49237/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "issue": 98,
+    "cause": "ja4plus counts one SSH packet for each TCP segment, and tshark labels only the segment that completes an SSH message. #98 owns the count."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.3": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "issue": 96,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.4": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
-  },
-  "ssh2.pcapng/11:57374/JA4X.1": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "ssh2.pcapng/11:57374/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "ssh2.pcapng/12:57375/JA4X.1": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "ssh2.pcapng/12:57375/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "ssh2.pcapng/14:57377/JA4SSH.1": {
-    "issue": 92,
-    "cause": "The produced JA4SSH value differs from the reference."
+    "issue": 96,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window."
   },
   "ssh2.pcapng/14:57377/JA4SSH.2": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH value on this stream."
+    "issue": 97,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
   },
   "ssh2.pcapng/JA4": {
     "issue": 13,
@@ -292,32 +216,16 @@
     "cause": "ja4plus emits more JA4L-S values than the reference holds."
   },
   "ssh2.pcapng/JA4SSH": {
-    "issue": 92,
-    "cause": "ja4plus produces no JA4SSH fingerprint the reference holds."
+    "issue": 97,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets."
   },
-  "ssh2.pcapng/JA4X": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
-  },
-  "tls-handshake.pcapng/34:50158/JA4X.1": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "tls-handshake.pcapng/34:50158/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
+  "sshv1.pcap/JA4SSH": {
+    "issue": 105,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
   },
   "tls-handshake.pcapng/38:50159/JA4.2": {
     "issue": 13,
     "cause": "ja4plus produces no JA4 value on this stream."
-  },
-  "tls-handshake.pcapng/40:50164/JA4X.2": {
-    "issue": 78,
-    "cause": "The produced JA4X value differs from the reference."
-  },
-  "tls-handshake.pcapng/40:50164/JA4X.3": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "tls-handshake.pcapng/41:50165/JA4.2": {
     "issue": 13,
@@ -327,14 +235,6 @@
     "issue": 13,
     "cause": "ja4plus produces no JA4 value on this stream."
   },
-  "tls-handshake.pcapng/43:50167/JA4X.1": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "tls-handshake.pcapng/43:50167/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
   "tls-handshake.pcapng/44:50168/JA4.2": {
     "issue": 13,
     "cause": "ja4plus produces no JA4 value on this stream."
@@ -342,14 +242,6 @@
   "tls-handshake.pcapng/45:50169/JA4.2": {
     "issue": 13,
     "cause": "ja4plus produces no JA4 value on this stream."
-  },
-  "tls-handshake.pcapng/46:50170/JA4X.2": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
-  },
-  "tls-handshake.pcapng/46:50170/JA4X.3": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X value on this stream."
   },
   "tls-handshake.pcapng/JA4": {
     "issue": 13,
@@ -362,10 +254,6 @@
   "tls-handshake.pcapng/JA4S": {
     "issue": 13,
     "cause": "ja4plus produces a JA4S fingerprint the reference does not hold."
-  },
-  "tls-handshake.pcapng/JA4X": {
-    "issue": 78,
-    "cause": "ja4plus produces no JA4X fingerprint the reference holds."
   },
   "tls-non-ascii-alpn.pcapng/0:50112/JA4.1": {
     "issue": 13,
@@ -402,5 +290,9 @@
   "tls3.pcapng/JA4": {
     "issue": 13,
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold."
+  },
+  "v6.pcap/JA4SSH": {
+    "issue": 105,
+    "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."
   }
 }

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -53,19 +53,19 @@
   },
   "gre-erspan-vxlan.pcap/0:65174/JA4L-C.1": {
     "issue": 101,
-    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it produces no JA4L-C value."
+    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-C value."
   },
   "gre-erspan-vxlan.pcap/0:65174/JA4L-S.1": {
     "issue": 101,
-    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it produces no JA4L-S value."
+    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-S value."
   },
   "gre-erspan-vxlan.pcap/JA4L-C": {
     "issue": 101,
-    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it produces no JA4L-C value."
+    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-C value."
   },
   "gre-erspan-vxlan.pcap/JA4L-S": {
     "issue": 101,
-    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it produces no JA4L-S value."
+    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-S value."
   },
   "http-empty-useragent.pcap/0:57722/JA4H.1": {
     "issue": 35,

--- a/tests/generate_foxio_baseline.py
+++ b/tests/generate_foxio_baseline.py
@@ -60,30 +60,27 @@ OWNING_ISSUES = {
 # either.
 #
 # #34 owns the multiplicity defect on both sides: how many JA4L values one connection
-# emits. On the client side JA4L emits one JA4L-C value for every ACK.
+# emits. #88 halved every latency and moved the client measurement point, and that fix
+# also removed the JA4L values ja4plus produced on a UDP flow that carries no QUIC. The
+# cases that remain are streams the reference holds no JA4L value for, and one repeated
+# SYN-ACK.
 JA4L_MULTIPLICITY_ISSUE = 34
 
-# #88 owns every JA4L value defect. `ja4l.py:218` claims FoxIO uses the raw time
-# difference. The vectors contradict that claim. On `badcurveball.pcap` stream 0, the
-# SYN to SYN-ACK time is 1563 us and the reference JA4L-S is `781_238`, which is half of
-# it. The same stream gives a client data packet 4362 us after the SYN-ACK, and the
-# reference JA4L-C is `2181_64`, which is half of that. ja4plus halves neither, and it
-# measures JA4L-C to the bare ACK rather than to the first client data packet.
-JA4L_VALUE_ISSUE = 88
+# #101 owns the mirrored capture. `gre-erspan-vxlan.pcap` carries both directions of one
+# inner session between one outer address pair, so ja4plus groups the two directions as
+# two connections and reports no value.
+JA4L_MIRRORED_CAPTURE_ISSUE = 101
+
+# #102 owns the QUIC server measurement point. The reference reads the Initial packet
+# that completes the ServerHello. ja4plus cannot decrypt these server Initial packets,
+# so it reads the first one.
+JA4L_QUIC_SERVER_POINT_ISSUE = 102
 
 SUITE = "tests/test_spec_validation.py"
 
 # The counts the occurrence-key failure message reports.
 EXTRA_KEYS = re.compile(r": (\d+) extra occurrence key")
 MISSING_KEYS = re.compile(r"; (\d+) missing occurrence key")
-
-# The value pair the fingerprint failure message reports.
-VALUE_PAIR = re.compile(r"expected='([^']*)' produced='([^']*)'")
-
-# A produced latency this many microseconds from twice the reference counts as twice it.
-# Both values truncate to a whole microsecond, so an exact comparison misses a case that
-# the halving explains.
-HALVING_TOLERANCE = 2
 
 
 class _CaseCollector:
@@ -128,20 +125,6 @@ def _count(pattern, message):
     return int(match.group(1)) if match else 0
 
 
-def _is_twice_the_reference(message):
-    """Return True when the produced latency is twice the latency of the reference."""
-    match = VALUE_PAIR.search(message)
-    if not match:
-        return False
-    expected, produced = match.group(1), match.group(2)
-    try:
-        expected_latency = int(expected.split("_")[0])
-        produced_latency = int(produced.split("_")[0])
-    except (ValueError, IndexError):
-        return False
-    return abs(produced_latency - expected_latency * 2) <= HALVING_TOLERANCE
-
-
 def _ja4l_entry(method, message, occurrence_form):
     """Return the register entry of one JA4L case, read from the failure message.
 
@@ -153,51 +136,34 @@ def _ja4l_entry(method, message, occurrence_form):
     Returns:
         The entry, as a map of `issue` to the issue number and `cause` to one line.
     """
-    # #34 owns every occurrence-key case, on both sides of the connection. A count that
-    # differs from the reference is one defect, and the direction does not split it.
+    mirrored_capture = {
+        "issue": JA4L_MIRRORED_CAPTURE_ISSUE,
+        "cause": "ja4plus groups the two directions of this mirrored capture as two "
+        "connections, so it produces no {} value.".format(method),
+    }
+
     if occurrence_form:
         extra = _count(EXTRA_KEYS, message)
         missing = _count(MISSING_KEYS, message)
-        if extra and method == "JA4L-C":
-            return {
-                "issue": JA4L_MULTIPLICITY_ISSUE,
-                "cause": "ja4plus emits one JA4L-C value for every ACK on the connection.",
-            }
+        # A capture whose keys are only missing holds no defect of count. The mirrored
+        # capture is the one vector that reaches this branch.
+        if missing and not extra:
+            return mirrored_capture
         if extra and missing:
             return {
                 "issue": JA4L_MULTIPLICITY_ISSUE,
                 "cause": "ja4plus produces a different set of {} fingerprints.".format(method),
             }
-        if extra:
-            return {
-                "issue": JA4L_MULTIPLICITY_ISSUE,
-                "cause": "ja4plus emits more {} values than the reference holds.".format(method),
-            }
         return {
             "issue": JA4L_MULTIPLICITY_ISSUE,
-            "cause": "ja4plus does not decode the tunnel payload of this capture, so it "
-            "reads no TCP layer and produces no {} value.".format(method),
+            "cause": "ja4plus emits more {} values than the reference holds.".format(method),
         }
     if "produced=<none>" in message:
-        return {
-            "issue": JA4L_VALUE_ISSUE,
-            "cause": "ja4plus does not decode the tunnel payload of this capture, so it "
-            "reads no TCP layer and produces no {} value on this stream.".format(method),
-        }
-    if _is_twice_the_reference(message):
-        return {
-            "issue": JA4L_VALUE_ISSUE,
-            "cause": "ja4plus reports the round-trip time, and the reference holds half of it.",
-        }
-    if method == "JA4L-C":
-        return {
-            "issue": JA4L_VALUE_ISSUE,
-            "cause": "ja4plus measures JA4L-C to the bare ACK, and it does not halve the "
-            "round-trip time.",
-        }
+        return mirrored_capture
     return {
-        "issue": JA4L_VALUE_ISSUE,
-        "cause": "The produced JA4L-S value differs from the reference by another amount.",
+        "issue": JA4L_QUIC_SERVER_POINT_ISSUE,
+        "cause": "ja4plus reads the first server Initial packet, and the reference reads the "
+        "Initial packet that completes the ServerHello.",
     }
 
 

--- a/tests/generate_foxio_baseline.py
+++ b/tests/generate_foxio_baseline.py
@@ -60,10 +60,10 @@ OWNING_ISSUES = {
 # either.
 #
 # #34 owns the multiplicity defect on both sides: how many JA4L values one connection
-# emits. #88 halved every latency and moved the client measurement point, and that fix
-# also removed the JA4L values ja4plus produced on a UDP flow that carries no QUIC. The
-# cases that remain are streams the reference holds no JA4L value for, and one repeated
-# SYN-ACK.
+# emits. #88 halved every latency and moved the client measurement point. That fix also
+# removed the JA4L values ja4plus emitted on a UDP flow that carries no QUIC. The cases
+# that remain sit on a connection the reference holds no JA4L value for, and on one
+# repeated SYN-ACK.
 JA4L_MULTIPLICITY_ISSUE = 34
 
 # #101 owns the mirrored capture. `gre-erspan-vxlan.pcap` carries both directions of one
@@ -139,7 +139,7 @@ def _ja4l_entry(method, message, occurrence_form):
     mirrored_capture = {
         "issue": JA4L_MIRRORED_CAPTURE_ISSUE,
         "cause": "ja4plus groups the two directions of this mirrored capture as two "
-        "connections, so it produces no {} value.".format(method),
+        "connections, so it emits no {} value.".format(method),
     }
 
     if occurrence_form:

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -666,19 +666,25 @@ class TestJA4LComprehensive(unittest.TestCase):
 
     def test_handshake_produces_two_fingerprints(self):
         """Full handshake should produce server + client fingerprints."""
-        syn = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(sport=54321, dport=443, flags="S")
+        syn = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(
+            sport=54321, dport=443, flags="S", seq=0
+        )
         self.fp.process_packet(syn)
         time.sleep(0.002)
 
         synack = IP(src="10.0.0.2", dst="10.0.0.1", ttl=64) / TCP(
-            sport=443, dport=54321, flags="SA"
+            sport=443, dport=54321, flags="SA", seq=0, ack=1
         )
         server_fp = self.fp.process_packet(synack)
         self.assertIsNotNone(server_fp)
         self.assertTrue(server_fp.startswith("JA4L-S="))
 
         time.sleep(0.002)
-        ack = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(sport=54321, dport=443, flags="A")
+        # The client measurement point needs the relative sequence number 1 and the
+        # relative acknowledgement number 1, which the ACK of a handshake carries.
+        ack = IP(src="10.0.0.1", dst="10.0.0.2", ttl=128) / TCP(
+            sport=54321, dport=443, flags="A", seq=1, ack=1
+        )
         client_fp = self.fp.process_packet(ack)
         self.assertIsNotNone(client_fp)
         self.assertTrue(client_fp.startswith("JA4L-C="))

--- a/tests/test_generate_foxio_baseline.py
+++ b/tests/test_generate_foxio_baseline.py
@@ -6,8 +6,9 @@ cause and a false owner on hundreds of entries. These tests check the reading.
 """
 
 from tests.generate_foxio_baseline import (
+    JA4L_MIRRORED_CAPTURE_ISSUE,
     JA4L_MULTIPLICITY_ISSUE,
-    JA4L_VALUE_ISSUE,
+    JA4L_QUIC_SERVER_POINT_ISSUE,
     _entry,
     _failure_line,
 )
@@ -39,35 +40,16 @@ class TestTheFailureLineReader:
 class TestTheJA4LOwner:
     """Check that each JA4L defect shape names the issue that fixes it."""
 
-    def test_a_latency_of_twice_the_reference_names_the_value_issue(self):
+    def test_a_server_latency_of_another_amount_names_the_quic_server_point(self):
         entry = _entry(
             "JA4L-S",
-            "Failed: v.pcap s JA4L-S.1: expected='781_238' produced='1562_238'",
+            "Failed: v.pcapng s JA4L-S.1: expected='10990_56' produced='9285_56'",
             occurrence_form=False,
         )
-        assert entry["issue"] == JA4L_VALUE_ISSUE
+        assert entry["issue"] == JA4L_QUIC_SERVER_POINT_ISSUE
         assert entry["cause"] == (
-            "ja4plus reports the round-trip time, and the reference holds half of it."
-        )
-
-    def test_a_truncated_latency_of_twice_the_reference_names_the_value_issue(self):
-        entry = _entry(
-            "JA4L-S",
-            "Failed: v.pcap s JA4L-S.1: expected='210_64' produced='421_64'",
-            occurrence_form=False,
-        )
-        assert entry["issue"] == JA4L_VALUE_ISSUE
-        assert "half of it" in entry["cause"]
-
-    def test_a_client_latency_of_another_amount_names_the_measurement_point(self):
-        entry = _entry(
-            "JA4L-C",
-            "Failed: v.pcap s JA4L-C.1: expected='278_128' produced='111_128'",
-            occurrence_form=False,
-        )
-        assert entry["issue"] == JA4L_VALUE_ISSUE
-        assert entry["cause"] == (
-            "ja4plus measures JA4L-C to the bare ACK, and it does not halve the round-trip time."
+            "ja4plus reads the first server Initial packet, and the reference reads the "
+            "Initial packet that completes the ServerHello."
         )
 
     def test_an_extra_client_occurrence_key_names_the_multiplicity_issue(self):
@@ -77,7 +59,7 @@ class TestTheJA4LOwner:
             occurrence_form=True,
         )
         assert entry["issue"] == JA4L_MULTIPLICITY_ISSUE
-        assert entry["cause"] == "ja4plus emits one JA4L-C value for every ACK on the connection."
+        assert entry["cause"] == "ja4plus emits more JA4L-C values than the reference holds."
 
     def test_an_extra_server_occurrence_key_names_the_multiplicity_issue(self):
         entry = _entry(
@@ -88,24 +70,24 @@ class TestTheJA4LOwner:
         assert entry["issue"] == JA4L_MULTIPLICITY_ISSUE
         assert entry["cause"] == "ja4plus emits more JA4L-S values than the reference holds."
 
-    def test_a_missing_occurrence_key_names_the_multiplicity_issue(self):
+    def test_a_missing_occurrence_key_names_the_mirrored_capture(self):
         entry = _entry(
             "JA4L-S",
             "Failed: v.pcap JA4L-S: 0 extra occurrence key(s) []; 1 missing occurrence key(s) []",
             occurrence_form=True,
         )
-        assert entry["issue"] == JA4L_MULTIPLICITY_ISSUE
-        assert "tunnel payload" in entry["cause"]
+        assert entry["issue"] == JA4L_MIRRORED_CAPTURE_ISSUE
+        assert "mirrored capture" in entry["cause"]
 
-    def test_a_produced_none_names_the_tunnel_capture(self):
+    def test_a_produced_none_names_the_mirrored_capture(self):
         entry = _entry(
             "JA4L-C",
             "Failed: v.pcap s JA4L-C.1: expected='953_64' produced=<none>, JA4L-C "
             "produced 0 value(s) on this stream",
             occurrence_form=False,
         )
-        assert entry["issue"] == JA4L_VALUE_ISSUE
-        assert "tunnel payload" in entry["cause"]
+        assert entry["issue"] == JA4L_MIRRORED_CAPTURE_ISSUE
+        assert "mirrored capture" in entry["cause"]
 
 
 class TestTheOwnerOfAnotherMethod:

--- a/tests/test_ja4l.py
+++ b/tests/test_ja4l.py
@@ -8,49 +8,38 @@ class TestJA4L(unittest.TestCase):
     def setUp(self):
         self.ja4l_fp = JA4LFingerprinter()
 
-        # Create test packets for a TCP handshake
+        # Create test packets for a TCP handshake. The client measurement point needs
+        # the relative sequence number 1 and the relative acknowledgement number 1, so
+        # the packets carry the sequence numbers a real handshake carries.
         self.syn_packet = IP(src="192.168.1.100", dst="93.184.216.34", ttl=128) / TCP(
-            sport=54321, dport=443, flags="S"
+            sport=54321, dport=443, flags="S", seq=0
         )
         self.synack_packet = IP(src="93.184.216.34", dst="192.168.1.100", ttl=64) / TCP(
-            sport=443, dport=54321, flags="SA"
+            sport=443, dport=54321, flags="SA", seq=0, ack=1
         )
         self.ack_packet = IP(src="192.168.1.100", dst="93.184.216.34", ttl=128) / TCP(
-            sport=54321, dport=443, flags="A"
+            sport=54321, dport=443, flags="A", seq=1, ack=1
         )
 
     def test_ja4l_direct_generation(self):
-        """Test JA4L with direct conn dict providing timestamps."""
-        # Simulate timestamps from a real handshake
-        now = time.time()
+        """Test JA4L with a conn dict the caller supplies."""
         conn = {
             "proto": "tcp",
-            "timestamps": {
-                "A": now - 0.050,  # SYN 50ms ago
-                "B": now - 0.020,  # SYN-ACK 20ms ago
-            },
-            "ttls": {
-                "client": 128,
-                "server": 64,
-            },
+            "timestamps": {},
+            "ttls": {},
+            "isns": {},
         }
 
-        # SYN-ACK generates server fingerprint - but only if timestamps A exists
-        # and we're processing a SYN-ACK packet
+        # The SYN records the client point, and the SYN-ACK reports the server value.
+        self.assertIsNone(generate_ja4l(self.syn_packet, conn))
         ja4l_server = generate_ja4l(self.synack_packet, conn)
-        print(f"JA4L Server fingerprint: {ja4l_server}")
-
-        # ACK generates client fingerprint
         ja4l_client = generate_ja4l(self.ack_packet, conn)
-        print(f"JA4L Client fingerprint: {ja4l_client}")
 
-        # Server should have generated from the SYN-ACK
         self.assertIsNotNone(ja4l_server, "JA4L server fingerprinting failed")
         self.assertTrue(
             ja4l_server.startswith("JA4L-S="), "Server fingerprint should start with JA4L-S="
         )
 
-        # Client should have generated from the ACK
         self.assertIsNotNone(ja4l_client, "JA4L client fingerprinting failed")
         self.assertTrue(
             ja4l_client.startswith("JA4L-C="), "Client fingerprint should start with JA4L-C="

--- a/tests/test_ja4l_connection_state.py
+++ b/tests/test_ja4l_connection_state.py
@@ -1,0 +1,97 @@
+"""JA4L state tests for a connection that is reused, reordered or absent.
+
+No FoxIO vector holds these packet orders. The tests state what the fingerprinter
+reports when a capture holds them, because a wrong answer here reaches a caller as a
+latency that no packet in the capture supports.
+"""
+
+from scapy.all import IP, Raw, TCP
+
+from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+
+CLIENT, SERVER = "1.1.1.1", "2.2.2.2"
+CLIENT_PORT, SERVER_PORT = 50000, 443
+
+
+def _client(flags, sequence, acknowledgement, when, payload=b""):
+    """Build one packet the client sends."""
+    packet = (
+        IP(src=CLIENT, dst=SERVER, ttl=128)
+        / TCP(sport=CLIENT_PORT, dport=SERVER_PORT, flags=flags, seq=sequence, ack=acknowledgement)
+        / Raw(payload)
+    )
+    packet.time = when
+    return packet
+
+
+def _server(flags, sequence, acknowledgement, when, payload=b""):
+    """Build one packet the server sends."""
+    packet = (
+        IP(src=SERVER, dst=CLIENT, ttl=64)
+        / TCP(sport=SERVER_PORT, dport=CLIENT_PORT, flags=flags, seq=sequence, ack=acknowledgement)
+        / Raw(payload)
+    )
+    packet.time = when
+    return packet
+
+
+def _values(packets):
+    """Return the values one packet list leaves in the fingerprinter."""
+    fingerprinter = JA4LFingerprinter()
+    for packet in packets:
+        fingerprinter.process_packet(packet)
+    return [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
+
+
+def test_a_second_connection_on_the_same_endpoints_gets_its_own_values():
+    """A later connection reads no measurement point of the connection before it."""
+    values = _values(
+        [
+            _client("S", 0, 0, 0.000),
+            _server("SA", 0, 1, 0.001),
+            _client("A", 1, 1, 0.002),
+            _client("FA", 1, 1, 0.003),
+            # The client opens a second connection with another initial sequence
+            # number, five seconds later.
+            _client("S", 9000, 0, 5.000),
+            _server("SA", 7000, 9001, 5.004),
+            _client("A", 9001, 7001, 5.006),
+        ]
+    )
+    # The FIN of the first connection also carries the relative sequence number 1 and
+    # the relative acknowledgement number 1, so it moves the client point once more.
+    assert values == ["JA4L-S=500_64", "JA4L-C=1000_128", "JA4L-S=2000_64", "JA4L-C=1000_128"]
+
+
+def test_a_reordered_capture_still_reports_the_server_value():
+    """The fingerprinter reports the server value when the SYN-ACK reaches it first.
+
+    A capture that merges two interfaces holds the packets of one connection out of
+    order. The timestamps still state the order the network gave.
+    """
+    values = _values(
+        [
+            _server("SA", 0, 1, 0.002),
+            _client("S", 0, 0, 0.000),
+            _client("A", 1, 1, 0.003),
+        ]
+    )
+    assert "JA4L-S=1000_64" in values
+
+
+def test_a_repeated_syn_that_carries_the_same_number_changes_nothing():
+    """A retransmitted SYN keeps the measurement point of the first one."""
+    values = _values(
+        [
+            _client("S", 0, 0, 0.000),
+            _client("S", 0, 0, 0.001),
+            _server("SA", 0, 1, 0.002),
+            _client("A", 1, 1, 0.003),
+        ]
+    )
+    assert values == ["JA4L-S=1000_64", "JA4L-C=500_128"]
+
+
+def test_a_capture_that_starts_after_the_handshake_reports_nothing():
+    """The fingerprinter needs the SYN, so a capture without one gives no value."""
+    assert _values([_client("A", 1, 1, 0.000), _client("PA", 1, 1, 0.001, b"hello")]) == []

--- a/tests/test_ja4l_foxio.py
+++ b/tests/test_ja4l_foxio.py
@@ -1,0 +1,102 @@
+"""JA4L value tests derived from the FoxIO vectors.
+
+Each test names one vector, one stream and the value the FoxIO expected-output file
+holds. The vectors live under `tests/foxio_vectors`, and `tests/foxio_vectors/NOTICE`
+names the upstream commit.
+
+The reference computes a JA4L value from four measurement points:
+
+- `A` is the first TCP SYN, and it carries the client TTL.
+- `B` is the first TCP SYN-ACK, and it carries the server TTL.
+- `C` is the last TCP packet that carries the relative sequence number 1 and the
+  relative acknowledgement number 1, and that holds no complete HTTP request.
+- The QUIC form reads the Initial packets and the Handshake packets instead.
+
+`JA4L-S` is half the time from `A` to `B`. `JA4L-C` is half the time from `B` to `C`.
+"""
+
+from pathlib import Path
+
+import pytest
+from scapy.all import rdpcap
+
+from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+
+VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+
+
+def values_of(capture_name):
+    """Return the JA4L values one capture produces, grouped by connection key.
+
+    Args:
+        capture_name: The file name of a capture under `tests/foxio_vectors`.
+
+    Returns:
+        A map of connection key to the list of values, in the order the fingerprinter
+        produced them.
+    """
+    fingerprinter = JA4LFingerprinter()
+    for packet in rdpcap(str(VECTORS_DIR / capture_name)):
+        fingerprinter.process_packet(packet)
+    produced = {}
+    for entry in fingerprinter.get_fingerprints():
+        produced.setdefault(entry["connection"], []).append(entry["fingerprint"])
+    return produced
+
+
+def values_on(capture_name, connection_key):
+    """Return the values one capture produces on one connection."""
+    return values_of(capture_name).get(connection_key, [])
+
+
+BADCURVEBALL = "tcp_172.130.128.76:55318_54.226.182.138:443"
+BROWSERS_X509 = "tcp_13.107.21.239:443_172.27.7.31:54524"
+LATEST_HTTP = "tcp_172.16.225.48:52939_23.43.242.57:80"
+EMPTY_USERAGENT = "tcp_::1:9200_::1:57722"
+GRE_SAMPLE = "tcp_172.27.1.66:40264_66.59.109.137:22"
+SSH2_QUIC = "udp_142.251.41.46:443_172.16.225.48:61861"
+
+
+@pytest.mark.skipif(
+    not (VECTORS_DIR / "badcurveball.pcap").exists(), reason="FoxIO vectors are absent"
+)
+class TestJA4LAgainstTheFoxIOVectors:
+    """Compare the JA4L values of one vector against the FoxIO expected output."""
+
+    def test_the_server_value_holds_half_the_time_from_the_syn_to_the_syn_ack(self):
+        # badcurveball.pcap: SYN at +0 us, SYN-ACK at +1563 us, server TTL 238.
+        assert "JA4L-S=781_238" in values_on("badcurveball.pcap", BADCURVEBALL)
+
+    def test_the_client_value_measures_to_the_first_client_data_packet(self):
+        # browsers-x509.pcapng stream 0: SYN-ACK at +3815 us, Client Hello at +4371 us.
+        # The bare ACK at +3927 us gives 56, and the reference holds 278.
+        assert "JA4L-C=278_128" in values_on("browsers-x509.pcapng", BROWSERS_X509)
+
+    def test_a_complete_http_request_does_not_move_the_client_point(self):
+        # latest.pcapng stream 6 carries one complete GET request. The reference keeps
+        # the measurement point at the bare ACK.
+        assert "JA4L-C=32_128" in values_on("latest.pcapng", LATEST_HTTP)
+
+    def test_a_partial_http_request_moves_the_client_point(self):
+        # http-empty-useragent.pcap sends the request line, the header and the blank
+        # line in three packets. The reference measures to the request line.
+        assert "JA4L-C=177863_64" in values_on("http-empty-useragent.pcap", EMPTY_USERAGENT)
+
+    def test_the_fingerprinter_reads_the_outer_address_layer_of_a_gre_capture(self):
+        # gre-sample.pcap holds a TCP session inside GRE. The reference reads the
+        # address and the TTL of the outer layer, and the port of the inner layer.
+        produced = values_on("gre-sample.pcap", GRE_SAMPLE)
+        assert "JA4L-S=22952_236" in produced
+        assert "JA4L-C=26150_255" in produced
+
+    def test_the_quic_form_reads_the_initial_and_the_handshake_packets(self):
+        # ssh2.pcapng stream 36 is QUIC. JA4L-S measures the two Initial packets, and
+        # JA4L-C measures the last server Handshake packet to the first client one.
+        produced = values_on("ssh2.pcapng", SSH2_QUIC)
+        assert "JA4L-S=5389_57" in produced
+        assert "JA4L-C=169_128" in produced
+
+    def test_the_fingerprinter_produces_one_client_value_for_one_connection(self):
+        produced = values_on("badcurveball.pcap", BADCURVEBALL)
+        client_values = [value for value in produced if value.startswith("JA4L-C=")]
+        assert client_values == ["JA4L-C=2181_64"]

--- a/tests/test_ja4l_foxio.py
+++ b/tests/test_ja4l_foxio.py
@@ -4,13 +4,14 @@ Each test names one vector, one stream and the value the FoxIO expected-output f
 holds. The vectors live under `tests/foxio_vectors`, and `tests/foxio_vectors/NOTICE`
 names the upstream commit.
 
-The reference computes a JA4L value from four measurement points:
+The reference computes a TCP JA4L value from three measurement points:
 
 - `A` is the first TCP SYN, and it carries the client TTL.
 - `B` is the first TCP SYN-ACK, and it carries the server TTL.
 - `C` is the last TCP packet that carries the relative sequence number 1 and the
   relative acknowledgement number 1, and that holds no complete HTTP request.
-- The QUIC form reads the Initial packets and the Handshake packets instead.
+
+The QUIC form reads the Initial packets and the Handshake packets instead.
 
 `JA4L-S` is half the time from `A` to `B`. `JA4L-C` is half the time from `B` to `C`.
 """
@@ -33,7 +34,7 @@ def values_of(capture_name):
 
     Returns:
         A map of connection key to the list of values, in the order the fingerprinter
-        produced them.
+        emitted them.
     """
     fingerprinter = JA4LFingerprinter()
     for packet in rdpcap(str(VECTORS_DIR / capture_name)):
@@ -96,7 +97,7 @@ class TestJA4LAgainstTheFoxIOVectors:
         assert "JA4L-S=5389_57" in produced
         assert "JA4L-C=169_128" in produced
 
-    def test_the_fingerprinter_produces_one_client_value_for_one_connection(self):
+    def test_the_fingerprinter_emits_one_client_value_for_one_connection(self):
         produced = values_on("badcurveball.pcap", BADCURVEBALL)
         client_values = [value for value in produced if value.startswith("JA4L-C=")]
         assert client_values == ["JA4L-C=2181_64"]

--- a/tests/test_ja4l_udp_direction.py
+++ b/tests/test_ja4l_udp_direction.py
@@ -1,89 +1,80 @@
-"""JA4L UDP/QUIC direction-independence test.
+"""JA4L QUIC direction tests.
 
-Previously the UDP/QUIC timing path silently failed when the first packet
-came from the lexicographically-larger IP (direction='reverse' in the
-internal conn_key). The fix: identify the client by FIRST-PACKET ordering,
-not by conn_key direction.
+The QUIC form reads the direction of a flow from port 443, as the reference does. The
+lexicographic order of the two addresses decides the internal connection key, and it
+must not decide which endpoint is the client. An earlier defect made the timing path
+report nothing when the client address sorted after the server address.
 """
 
-import os
+from scapy.all import IP, UDP, Raw
 
-import pytest
+from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+from ja4plus.utils.quic_utils import QUIC_HANDSHAKE, QUIC_INITIAL
 
-
-def _udp_packet(src_ip, dst_ip, sport, dport, payload=b"\x00", t=0.0):
-    """Build a synthetic UDP packet with a pcap timestamp."""
-    from scapy.all import IP, UDP, Raw
-
-    pkt = IP(src=src_ip, dst=dst_ip) / UDP(sport=sport, dport=dport) / Raw(load=payload)
-    pkt.time = t
-    return pkt
+# A QUIC version 1 long header: the first byte, the version, and a zero-length
+# destination connection identifier. RFC 9000 Section 17.2 gives the layout.
+QUIC_VERSION_1 = b"\x00\x00\x00\x01"
 
 
-def test_udp_timing_works_with_lex_smaller_client():
-    """Client IP < server IP — direction='forward' in old logic. Sanity check."""
-    from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
-
-    fp = JA4LFingerprinter()
-    # client 10.0.0.1 -> server 10.0.0.2
-    fp.process_packet(_udp_packet("10.0.0.1", "10.0.0.2", 50000, 443, t=0.0))
-    result = fp.process_packet(_udp_packet("10.0.0.2", "10.0.0.1", 443, 50000, t=0.001))
-    assert result is not None
-    assert result.startswith("JA4L-S=")
+def _quic_packet(src_ip, dst_ip, sport, dport, packet_type, t=0.0):
+    """Build a UDP packet that carries one QUIC long header."""
+    first_byte = bytes([0xC0 | (packet_type << 4)])
+    payload = first_byte + QUIC_VERSION_1 + b"\x00" * 16
+    packet = IP(src=src_ip, dst=dst_ip) / UDP(sport=sport, dport=dport) / Raw(load=payload)
+    packet.time = t
+    return packet
 
 
-def test_udp_timing_works_with_lex_larger_client():
-    """Client IP > server IP — direction='reverse' in old logic.
-
-    BEFORE the fix this returned None forever (no timestamps recorded).
-    AFTER the fix the first-packet sender is treated as the client, and a
-    JA4L-S fingerprint is emitted on the response.
-    """
-    from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
-
-    fp = JA4LFingerprinter()
-    # client 10.0.0.99 -> server 10.0.0.1 — client IP is lexicographically greater
-    fp.process_packet(_udp_packet("10.0.0.99", "10.0.0.1", 50000, 443, t=0.0))
-    result = fp.process_packet(_udp_packet("10.0.0.1", "10.0.0.99", 443, 50000, t=0.002))
-    assert result is not None, "JA4L-S not emitted for server-direction-first conn"
-    assert result.startswith("JA4L-S=")
+def test_the_server_value_appears_when_the_client_address_sorts_first():
+    """The fingerprinter reports the server value for a client address that sorts first."""
+    fingerprinter = JA4LFingerprinter()
+    fingerprinter.process_packet(
+        _quic_packet("10.0.0.1", "10.0.0.2", 50000, 443, QUIC_INITIAL, t=0.0)
+    )
+    result = fingerprinter.process_packet(
+        _quic_packet("10.0.0.2", "10.0.0.1", 443, 50000, QUIC_INITIAL, t=0.001)
+    )
+    assert result == "JA4L-S=500_64"
 
 
-def test_udp_timing_full_round_trip_emits_jal_c():
-    """Three-packet exchange — A (client) / B (server) / C (client) / D (server)
-    produces both -S and -C fingerprints regardless of IP ordering."""
-    from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
-
-    fp = JA4LFingerprinter()
-    # Use a high-IP client to exercise the previously-broken path
-    a = fp.process_packet(_udp_packet("192.168.1.50", "10.0.0.1", 50000, 443, t=0.0))
-    s = fp.process_packet(_udp_packet("10.0.0.1", "192.168.1.50", 443, 50000, t=0.002))
-    c = fp.process_packet(_udp_packet("192.168.1.50", "10.0.0.1", 50000, 443, t=0.004))
-    d = fp.process_packet(_udp_packet("10.0.0.1", "192.168.1.50", 443, 50000, t=0.006))
-
-    assert a is None
-    assert s is not None and s.startswith("JA4L-S="), s
-    assert c is None
-    assert d is not None and d.startswith("JA4L-C="), d
+def test_the_server_value_appears_when_the_client_address_sorts_last():
+    """The fingerprinter reports the server value for a client address that sorts last."""
+    fingerprinter = JA4LFingerprinter()
+    fingerprinter.process_packet(
+        _quic_packet("10.0.0.99", "10.0.0.1", 50000, 443, QUIC_INITIAL, t=0.0)
+    )
+    result = fingerprinter.process_packet(
+        _quic_packet("10.0.0.1", "10.0.0.99", 443, 50000, QUIC_INITIAL, t=0.002)
+    )
+    assert result == "JA4L-S=1000_64"
 
 
-@pytest.mark.skipif(
-    not os.path.exists("tests/foxio_vectors/pcap/chrome-cloudflare-quic-with-secrets.pcapng"),
-    reason="Chrome-Cloudflare QUIC fixture missing",
-)
-def test_quic_real_pcap_emits_both_directions():
-    from scapy.all import rdpcap
-    from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+def test_the_client_value_measures_the_two_handshake_packets():
+    """The client value measures the last server Handshake packet to the first client one."""
+    fingerprinter = JA4LFingerprinter()
+    initial_client = fingerprinter.process_packet(
+        _quic_packet("192.168.1.50", "10.0.0.1", 50000, 443, QUIC_INITIAL, t=0.0)
+    )
+    initial_server = fingerprinter.process_packet(
+        _quic_packet("10.0.0.1", "192.168.1.50", 443, 50000, QUIC_INITIAL, t=0.002)
+    )
+    handshake_server = fingerprinter.process_packet(
+        _quic_packet("10.0.0.1", "192.168.1.50", 443, 50000, QUIC_HANDSHAKE, t=0.004)
+    )
+    handshake_client = fingerprinter.process_packet(
+        _quic_packet("192.168.1.50", "10.0.0.1", 50000, 443, QUIC_HANDSHAKE, t=0.006)
+    )
 
-    fp = JA4LFingerprinter()
-    pkts = rdpcap("tests/foxio_vectors/pcap/chrome-cloudflare-quic-with-secrets.pcapng")
-    seen = []
-    for pkt in pkts:
-        result = fp.process_packet(pkt)
-        if result:
-            seen.append(result)
+    assert initial_client is None
+    assert initial_server == "JA4L-S=1000_64"
+    assert handshake_server is None
+    assert handshake_client == "JA4L-C=1000_64"
 
-    # We don't pin exact latencies, but at least one of each direction should
-    # appear if the conversation is bidirectional QUIC.
-    has_s = any(s.startswith("JA4L-S=") for s in seen)
-    assert has_s, f"no JA4L-S in {seen}"
+
+def test_the_fingerprinter_reports_nothing_for_a_udp_flow_that_carries_no_quic():
+    """A UDP flow that carries no QUIC long header produces no JA4L value."""
+    fingerprinter = JA4LFingerprinter()
+    packet = IP(src="10.0.0.1", dst="10.0.0.2") / UDP(sport=50000, dport=53) / Raw(load=b"\x00")
+    packet.time = 0.0
+    assert fingerprinter.process_packet(packet) is None
+    assert fingerprinter.get_fingerprints() == []

--- a/tests/test_ja4l_udp_direction.py
+++ b/tests/test_ja4l_udp_direction.py
@@ -72,9 +72,26 @@ def test_the_client_value_measures_the_two_handshake_packets():
 
 
 def test_the_fingerprinter_reports_nothing_for_a_udp_flow_that_carries_no_quic():
-    """A UDP flow that carries no QUIC long header produces no JA4L value."""
+    """The fingerprinter emits no value for a UDP flow that carries no QUIC long header."""
     fingerprinter = JA4LFingerprinter()
     packet = IP(src="10.0.0.1", dst="10.0.0.2") / UDP(sport=50000, dport=53) / Raw(load=b"\x00")
     packet.time = 0.0
     assert fingerprinter.process_packet(packet) is None
+    assert fingerprinter.get_fingerprints() == []
+
+
+def test_the_fingerprinter_reports_nothing_when_both_ports_are_443():
+    """The fingerprinter emits no value for a flow whose two ports are 443.
+
+    Port 443 names the server, so a flow that carries it on both endpoints names
+    neither one. A value read from such a flow states a direction nothing proves.
+    """
+    fingerprinter = JA4LFingerprinter()
+    fingerprinter.process_packet(
+        _quic_packet("10.0.0.1", "10.0.0.2", 443, 443, QUIC_INITIAL, t=0.0)
+    )
+    result = fingerprinter.process_packet(
+        _quic_packet("10.0.0.1", "10.0.0.2", 443, 443, QUIC_INITIAL, t=0.025)
+    )
+    assert result is None
     assert fingerprinter.get_fingerprints() == []


### PR DESCRIPTION
## What this changes

JA4L reported the whole round-trip time, and it measured the client value to the bare
ACK of the handshake. Both are wrong against the FoxIO vectors. This pull request
reports the one-way latency and the measurement points the reference uses.

- **The latency is halved.** `technical_details/JA4L.png` states
  `One-way TCP latency in us`. `badcurveball.pcap` stream 0 sends the SYN at
  `+0.000000s` and the SYN-ACK at `+0.001563s`, and the reference `JA4L-S` is
  `781_238`.
- **The client point is the last packet that carries the relative sequence number 1
  and the relative acknowledgement number 1.** `browsers-x509.pcapng` stream 0 gives
  the bare ACK at `+0.003927s` and the Client Hello at `+0.004371s`. The reference
  `JA4L-C` is `278_128`, and `(4371 - 3815) / 2 = 278`.
- **A complete HTTP request does not move the client point.** See the reading below.
- **One connection carries one `JA4L-C` value.** The reference overwrites the value
  while the point moves, so a later packet replaces the value rather than adding one.
- **The QUIC form reads the Initial packets and the Handshake packets on port 443.**
  It read the first UDP packet of any flow before, so a DNS flow produced a JA4L
  value that the reference does not hold.
- **`ja4plus/utils/tunnels.py` imports the scapy Geneve, VXLAN and ERSPAN
  dissectors.** scapy leaves them unbound and stops at the tunnel header, so
  `tcpdump-geneve.pcap` produced nothing.
- The comment at `ja4l.py:218`, `Per FoxIO spec: use raw time difference (not divided
  by 2)`, is gone. The vectors state the opposite.

This is a breaking change. Every JA4L value a caller stored before this release
differs from the value this release produces. `CHANGELOG.md` records it.

## The measurement

This branch is rebased onto `epic/12-spec-conformance` at `d26ad4f`, which already
carries #99 and #100.

| Measurement | Before | After |
|---|---|---|
| Register entries | 213 | 74 |
| Entries that name #88 | 114 | 0 |
| Entries that name #34 | 37 | 6 |
| JA4L conformance cases that fail | 151 | 12 |

108 of the 114 value cases this issue owns now conform. The six that remain carry a
register entry that names a real cause, and two new issues own them:

- #101 — `gre-erspan-vxlan.pcap` mirrors both directions of one session between one
  outer address pair, so `ja4plus` groups the two directions as two connections.
  2 value cases and 2 occurrence-key cases.
- #102 — the reference reads the server point from the QUIC Initial packet that
  completes the ServerHello. `ja4plus` cannot decrypt those server Initial packets,
  so it reads the first one. 2 value cases on
  `chrome-cloudflare-quic-with-secrets.pcapng` and `tls3.pcapng`.

27 of the 37 entries that named #34 also conform now, and this pull request removes
them. That overlap is unavoidable: the client value case passes only when one
connection carries one value. #34 keeps the six occurrence-key cases that remain, and
it keeps the removal of `_src_is_client`.

## Where the FoxIO material is ambiguous

FoxIO publishes JA4L as a PNG image, so `.claude/rules/conformance.md` makes the
expected-output files the authority. `docs/implementation_notes.md` now records every
reading. Three of them need a reader's attention.

**1. A complete HTTP request does not move the client point.** `python/ja4.py` in the
FoxIO repository selects its cache with `get_cache(x)`, which returns a separate cache
when the highest layer is `http` or `http2`. A packet that carries a whole HTTP
request therefore never reaches the JA4L timestamps. Two vectors prove both halves:
`latest.pcapng` stream 6 sends one complete `GET` request and the reference `JA4L-C`
is `32_128`, which is the bare ACK; `http-empty-useragent.pcap` sends the request
line, the header and the blank line in three packets, and the reference `JA4L-C` is
`177863_64`, which is the request line. `ja4plus` reads the request line and the blank
line that ends the header block. **Reading:** this is a property of the reference
program, not a stated rule, and the vectors are the only evidence for it.

**2. The three reference implementations disagree, and the vectors follow the Python
one.** `rust/ja4/src/time/tcp.rs` takes the first ACK after the SYN-ACK.
`wireshark/source/packet-ja4.c:1302` takes the first bare ACK with `tcp.len == 0`.
`python/ja4.py:571` takes the last packet with the relative sequence number 1 and the
relative acknowledgement number 1. The expected-output files under
`python/test/testdata/` come from the Python program, and
`.claude/rules/external-apis.md` names those files as the authority. **Reading:**
follow the Python program.

**3. A handshake of one second or more.** `common.py:179` reads the difference as a
`timedelta` and takes its `microseconds` attribute, which holds only the part below
one second. A handshake of 1.2 seconds therefore gives 100000 rather than 600000. No
FoxIO vector holds a difference of one second or more, so no vector requires that
behaviour and `ja4plus` divides the whole difference. **Reading:** treat the reference
behaviour as a defect until a vector proves otherwise.

`docs/implementation_notes.md` also records the reading that the reference reads the
address and the TTL of the outer layer of a tunnelled capture, and the port of the
inner layer. `gre-sample.pcap` proves it.

## How this was tested

`tests/test_ja4l_foxio.py` is new. Each test names one vector, one stream and the
value the FoxIO expected-output file holds. The tests were written first and they
failed against the unchanged fingerprinter.

Local suite, in the worktree:

```
pytest tests/ -m "not spec_validation"   674 passed, 11 skipped, 86 subtests passed
pytest tests/ -m spec_validation         624 passed, 141 skipped, 74 xfailed
ruff check ja4plus/ tests/               All checks passed
ruff format --check ja4plus/ tests/      83 files already formatted
mypy ja4plus/                            Success: no issues found in 27 source files
coverage                                 74%, and the floor is 70. It was 73 before.
```

No conformance case outside JA4L changed. The measurement with
`JA4PLUS_IGNORE_DEVIATIONS=1` reports the same non-JA4L failure list before and
after, and the same list again after the three self-review fixes.

`tests/foxio_deviations.json` comes from `tests/generate_foxio_baseline.py`, not from
a hand edit. No entry was added to make the suite green. The JA4L slice of that
measurement is merged into the register the integration branch already carries,
because the generator still reads #92 for every JA4SSH case while #99 and #100 point
those cases at #96, #97, #98 and #105. A whole regeneration here would name the wrong
issue on eleven entries this issue does not own. The project manager still regenerates
once on the integration branch.

Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/technical_details (JA4L.png, retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/python/ja4.py (the program that writes the expected-output files, retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/python/common.py (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/rust/ja4/src/time/tcp.rs (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/wireshark/source/packet-ja4.c (retrieved 2026-08-06)

## Out of scope

- Multiplicity, which #34 owns. This pull request changes the `JA4L-C` count only
  because the value case cannot pass otherwise.
- `calculate_distance`, which #30 owns. The function is untouched.
- The specification wording, which #89 owns.

Part of #12. Refs #88.
