### PR TITLE
Read the JA4L propagation factor from the FoxIO hop-count table

### DIFF
--- a/docs/specs/spec.md
+++ b/docs/specs/spec.md
@@ -74,6 +74,8 @@ that user, because comparison is the only thing a fingerprint is for.
 | conform | verb | To produce the same output as the FoxIO reference. | comply, match spec |
 | port | noun | The Go implementation at `Crank-Git/ja4plus-go`. | Go version, sibling, twin |
 | parity | noun | The state where this project and the port expose the same interface and emit the same fingerprint. | alignment, sync, consistency |
+| hop count | noun | The count of routers a packet crossed, read as the initial TTL minus the observed TTL. | hop distance, TTL delta |
+| propagation factor | noun | The JA4L divisor that the FoxIO hop-count table gives for one hop count. | propagation delay, terrain factor |
 
 ## Goals
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -176,10 +176,25 @@ for packet in handshake_packets:
 - 64 = Linux / macOS / mobile
 
 **Distance estimation:**
+
+`calculate_distance` returns miles and `calculate_distance_km` returns kilometers. The
+formula is `latency_us * 0.128 / propagation_factor` for miles, and it uses `0.206` for
+kilometers.
+
+Pass the observed TTL, and the method reads the propagation factor from the FoxIO
+hop-count table. A hop count of 21 or fewer gives 1.5, then 1.6, 1.7, 1.8 and 1.9 for
+22, 23, 24 and 25 hops, and 26 hops or more give 2.0. A TTL above the initial TTL
+implies a negative hop count, which clamps to zero hops.
+
 ```python
-# JA4L latency can estimate physical distance
-# distance = latency_us * 0.128 / propagation_factor
-# propagation_factor: 1.5 (good terrain) to 2.0 (poor terrain)
+# The TTL 44 implies 20 hops, so the factor is 1.5.
+fp.calculate_distance(5191, ttl=44)
+
+# An explicit factor overrides the table.
+fp.calculate_distance(5191, propagation_factor=1.6)
+
+# A call without a TTL gives no hop count, so the factor stays 1.6.
+fp.calculate_distance(5191)
 ```
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -182,9 +182,18 @@ formula is `latency_us * 0.128 / propagation_factor` for miles, and it uses `0.2
 kilometers.
 
 Pass the observed TTL, and the method reads the propagation factor from the FoxIO
-hop-count table. A hop count of 21 or fewer gives 1.5, then 1.6, 1.7, 1.8 and 1.9 for
-22, 23, 24 and 25 hops, and 26 hops or more give 2.0. A TTL above the initial TTL
-implies a negative hop count, which clamps to zero hops.
+hop-count table:
+
+| Hop count | Propagation factor |
+|---|---|
+| 21 or fewer | 1.5 |
+| 22 | 1.6 |
+| 23 | 1.7 |
+| 24 | 1.8 |
+| 25 | 1.9 |
+| 26 or more | 2.0 |
+
+A TTL above the initial TTL implies a negative hop count, which clamps to zero hops.
 
 ```python
 # The TTL 44 implies 20 hops, so the factor is 1.5.

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -42,6 +42,26 @@ QUIC_PORT = 443
 # number needs this mask.
 SEQUENCE_MASK = 0xFFFFFFFF
 
+# FoxIO gives the propagation factor as a table keyed on the hop count. Each pair
+# holds the highest hop count of one row and the factor of that row. A longer path
+# crosses more terrain that the fiber does not follow, so the factor grows.
+PROPAGATION_FACTOR_TABLE = ((21, 1.5), (22, 1.6), (23, 1.7), (24, 1.8), (25, 1.9))
+
+# The last row of the FoxIO table covers a hop count of 26 or more.
+MAXIMUM_PROPAGATION_FACTOR = 2.0
+
+# A caller that passes no TTL gives no hop count, so the table answers nothing. The
+# worked example in the FoxIO material uses 1.6, and this project used 1.6 before it
+# read the table.
+DEFAULT_PROPAGATION_FACTOR = 1.6
+
+# FoxIO gives the speed of light in fiber as 0.128 miles or 0.206 km per microsecond.
+# Verified against
+# https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4L.png
+# (retrieved 2026-08-06). The image holds both the table above and these two values.
+MILES_PER_MICROSECOND = 0.128
+KILOMETERS_PER_MICROSECOND = 0.206
+
 
 class JA4LFingerprinter(BaseFingerprinter):
     """
@@ -138,36 +158,56 @@ class JA4LFingerprinter(BaseFingerprinter):
         self.connections.pop(fwd, None)
         self.connections.pop(rev, None)
 
-    def calculate_distance(self, latency_us, propagation_factor=1.6):
-        """
-        Calculate the physical distance based on JA4L latency.
+    def _propagation_factor(self, ttl, propagation_factor):
+        """Return the propagation factor one distance call uses.
 
         Args:
-            latency_us: One-way latency in microseconds
-            propagation_factor: Propagation delay factor (default: 1.6)
+            ttl: The observed TTL, or None when the caller knows none.
+            propagation_factor: The factor the caller passed, or None.
 
         Returns:
-            Distance in miles
+            The factor the caller passed, or the factor of the FoxIO table row for the
+            hop count the TTL implies, or `DEFAULT_PROPAGATION_FACTOR` when the caller
+            passes neither value. A TTL above the initial TTL implies a negative hop
+            count, which clamps to zero hops.
         """
-        # Speed of light per us in fiber (miles/us)
-        speed_of_light = 0.128
-        distance = (latency_us * speed_of_light) / propagation_factor
-        return distance
+        if propagation_factor is not None:
+            return propagation_factor
+        if ttl is None:
+            return DEFAULT_PROPAGATION_FACTOR
+        hop_count = max(self.estimate_hop_count(ttl), 0)
+        for highest, factor in PROPAGATION_FACTOR_TABLE:
+            if hop_count <= highest:
+                return factor
+        return MAXIMUM_PROPAGATION_FACTOR
 
-    def calculate_distance_km(self, latency_us, propagation_factor=1.6):
-        """
-        Calculate the physical distance in kilometers.
+    def calculate_distance(self, latency_us, ttl=None, propagation_factor=None):
+        """Return the distance the JA4L latency implies, in miles.
 
         Args:
-            latency_us: One-way latency in microseconds
-            propagation_factor: Propagation delay factor (default: 1.6)
+            latency_us: The one-way latency, in microseconds.
+            ttl: The observed TTL. The FoxIO table reads the hop count it implies.
+            propagation_factor: An explicit factor, which overrides the table.
 
         Returns:
-            Distance in kilometers
+            The distance in miles.
         """
-        speed_of_light_km = 0.206  # km/us in fiber
-        distance = (latency_us * speed_of_light_km) / propagation_factor
-        return distance
+        factor = self._propagation_factor(ttl, propagation_factor)
+        return (latency_us * MILES_PER_MICROSECOND) / factor
+
+    def calculate_distance_km(self, latency_us, ttl=None, propagation_factor=None):
+        """Return the distance the JA4L latency implies, in kilometers.
+
+        Args:
+            latency_us: The one-way latency, in microseconds.
+            ttl: The observed TTL. The FoxIO table reads the hop count it implies.
+            propagation_factor: An explicit factor, which overrides the table.
+
+        Returns:
+            The distance in kilometers.
+        """
+        factor = self._propagation_factor(ttl, propagation_factor)
+        return (latency_us * KILOMETERS_PER_MICROSECOND) / factor
 
     def estimate_os(self, ttl):
         """

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -55,7 +55,8 @@ MAXIMUM_PROPAGATION_FACTOR = 2.0
 # read the table.
 DEFAULT_PROPAGATION_FACTOR = 1.6
 
-# FoxIO gives the speed of light in fiber as 0.128 miles or 0.206 km per microsecond.
+# FoxIO gives the speed of light in fiber as 0.128 miles or 0.206 kilometers per
+# microsecond.
 # Verified against
 # https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4L.png
 # (retrieved 2026-08-06). The image holds both the table above and these two values.
@@ -166,10 +167,14 @@ class JA4LFingerprinter(BaseFingerprinter):
             propagation_factor: The factor the caller passed, or None.
 
         Returns:
-            The factor the caller passed, or the factor of the FoxIO table row for the
-            hop count the TTL implies, or `DEFAULT_PROPAGATION_FACTOR` when the caller
-            passes neither value. A TTL above the initial TTL implies a negative hop
-            count, which clamps to zero hops.
+            One of three values:
+
+            - The factor the caller passed.
+            - The factor of the FoxIO table row for the hop count the TTL implies.
+            - `DEFAULT_PROPAGATION_FACTOR`, when the caller passes neither value.
+
+            A TTL above the initial TTL implies a negative hop count, which clamps to
+            zero hops.
         """
         if propagation_factor is not None:
             return propagation_factor

--- a/tests/test_ja4l.py
+++ b/tests/test_ja4l.py
@@ -96,5 +96,65 @@ class TestJA4L(unittest.TestCase):
         self.assertEqual(self.ja4l_fp.estimate_hop_count(250), 5)  # 255 - 250
 
 
+class TestJA4LPropagationFactor(unittest.TestCase):
+    """The propagation delay factor follows the FoxIO hop-count table.
+
+    The table maps a hop count of 21 or fewer to 1.5, 22 to 1.6, 23 to 1.7, 24 to 1.8,
+    25 to 1.9, and 26 or more to 2.0. An initial TTL of 64 gives the hop count
+    `64 - ttl`, so each case below names the TTL that implies the hop count it tests.
+
+    Verified against https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4L.png
+    (retrieved 2026-08-06).
+    """
+
+    def setUp(self):
+        self.fingerprinter = JA4LFingerprinter()
+
+    def test_reads_a_different_distance_for_20_hops_and_for_30_hops(self):
+        """The table gives 1.5 for 20 hops and 2.0 for 30 hops."""
+        twenty_hops = self.fingerprinter.calculate_distance(1000, ttl=44)
+        thirty_hops = self.fingerprinter.calculate_distance(1000, ttl=34)
+
+        self.assertNotEqual(twenty_hops, thirty_hops)
+        self.assertAlmostEqual(twenty_hops, 1000 * 0.128 / 1.5, places=6)
+        self.assertAlmostEqual(thirty_hops, 1000 * 0.128 / 2.0, places=6)
+
+    def test_reads_each_row_of_the_foxio_table(self):
+        """Every hop count reads the factor of its row."""
+        rows = ((0, 1.5), (21, 1.5), (22, 1.6), (23, 1.7), (24, 1.8), (25, 1.9), (26, 2.0))
+        for hops, factor in rows:
+            with self.subTest(hops=hops):
+                distance = self.fingerprinter.calculate_distance(1000, ttl=64 - hops)
+                self.assertAlmostEqual(distance, 1000 * 0.128 / factor, places=6)
+
+    def test_reads_the_factor_2_0_for_a_hop_count_above_26(self):
+        """A TTL that implies 40 hops reads the last row of the table."""
+        distance = self.fingerprinter.calculate_distance(1000, ttl=24)
+
+        self.assertAlmostEqual(distance, 1000 * 0.128 / 2.0, places=6)
+
+    def test_clamps_a_negative_hop_count_to_zero_hops(self):
+        """A TTL above 255 implies a negative hop count, and the factor stays 1.5."""
+        distance = self.fingerprinter.calculate_distance(1000, ttl=300)
+
+        self.assertAlmostEqual(distance, 1000 * 0.128 / 1.5, places=6)
+
+    def test_an_explicit_propagation_factor_overrides_the_table(self):
+        """The caller's factor wins over the row the TTL selects."""
+        distance = self.fingerprinter.calculate_distance(1000, ttl=34, propagation_factor=1.6)
+
+        self.assertAlmostEqual(distance, 80.0, places=6)
+
+    def test_keeps_the_factor_1_6_when_the_caller_passes_no_ttl(self):
+        """A call without a TTL gives no hop count, so the table cannot answer."""
+        self.assertAlmostEqual(self.fingerprinter.calculate_distance(1000), 80.0, places=6)
+
+    def test_reads_the_foxio_table_for_a_distance_in_kilometers(self):
+        """The kilometer form reads the same table as the mile form."""
+        distance = self.fingerprinter.calculate_distance_km(1000, ttl=34)
+
+        self.assertAlmostEqual(distance, 1000 * 0.206 / 2.0, places=6)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_ja4l.py
+++ b/tests/test_ja4l.py
@@ -99,9 +99,9 @@ class TestJA4L(unittest.TestCase):
 class TestJA4LPropagationFactor(unittest.TestCase):
     """The propagation factor follows the FoxIO hop-count table.
 
-    The table maps a hop count of 21 or fewer to 1.5, 22 to 1.6, 23 to 1.7, 24 to 1.8,
-    25 to 1.9, and 26 or more to 2.0. An initial TTL of 64 gives the hop count
-    `64 - ttl`, so each case below names the TTL that implies the hop count it tests.
+    `PROPAGATION_FACTOR_TABLE` in `ja4plus/fingerprinters/ja4l.py` holds the table. An
+    initial TTL of 64 gives the hop count `64 - ttl`, so each case below names the TTL
+    that implies the hop count it tests.
 
     Verified against https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4L.png
     (retrieved 2026-08-06).
@@ -140,7 +140,7 @@ class TestJA4LPropagationFactor(unittest.TestCase):
         self.assertAlmostEqual(distance, 1000 * 0.128 / 1.5, places=6)
 
     def test_an_explicit_propagation_factor_overrides_the_table(self):
-        """The caller's factor wins over the row the TTL selects."""
+        """The caller's factor replaces the factor the TTL selects."""
         distance = self.fingerprinter.calculate_distance(1000, ttl=34, propagation_factor=1.6)
 
         self.assertAlmostEqual(distance, 80.0, places=6)

--- a/tests/test_ja4l.py
+++ b/tests/test_ja4l.py
@@ -97,7 +97,7 @@ class TestJA4L(unittest.TestCase):
 
 
 class TestJA4LPropagationFactor(unittest.TestCase):
-    """The propagation delay factor follows the FoxIO hop-count table.
+    """The propagation factor follows the FoxIO hop-count table.
 
     The table maps a hop count of 21 or fewer to 1.5, 22 to 1.6, 23 to 1.7, 24 to 1.8,
     25 to 1.9, and 26 or more to 2.0. An initial TTL of 64 gives the hop count
@@ -122,9 +122,9 @@ class TestJA4LPropagationFactor(unittest.TestCase):
     def test_reads_each_row_of_the_foxio_table(self):
         """Every hop count reads the factor of its row."""
         rows = ((0, 1.5), (21, 1.5), (22, 1.6), (23, 1.7), (24, 1.8), (25, 1.9), (26, 2.0))
-        for hops, factor in rows:
-            with self.subTest(hops=hops):
-                distance = self.fingerprinter.calculate_distance(1000, ttl=64 - hops)
+        for hop_count, factor in rows:
+            with self.subTest(hop_count=hop_count):
+                distance = self.fingerprinter.calculate_distance(1000, ttl=64 - hop_count)
                 self.assertAlmostEqual(distance, 1000 * 0.128 / factor, places=6)
 
     def test_reads_the_factor_2_0_for_a_hop_count_above_26(self):


### PR DESCRIPTION
## What

`calculate_distance` hardcoded the propagation factor 1.6 at `ja4l.py:101`. It now
accepts the observed TTL and reads the factor of the FoxIO table row for the hop count
that TTL implies. `calculate_distance_km` reads the same table.

Satisfies `FR-spec-conformance-9` and `FR-spec-conformance-10`.

## Why

The FoxIO JA4L material gives the factor as a table keyed on hop count. One fixed
factor gives a distance the reference does not give for any path other than a 22-hop
path.

## How

- `PROPAGATION_FACTOR_TABLE` holds the five bounded rows. `MAXIMUM_PROPAGATION_FACTOR`
  holds the last row, which covers 26 hops or more.
- `_propagation_factor` resolves one call: the caller's factor first, then the table
  row for the TTL, then `DEFAULT_PROPAGATION_FACTOR`.
- A TTL above the initial TTL implies a negative hop count. The lookup clamps it to
  zero hops, so the factor is 1.5.
- A call that passes no TTL gives no hop count, so the factor stays 1.6. The interface
  therefore stays compatible for every caller that passes latency alone.
- `MILES_PER_MICROSECOND` and `KILOMETERS_PER_MICROSECOND` replace the two literals.

## How tested

`tests/test_ja4l.py::TestJA4LPropagationFactor` holds seven tests, and they were
written first and committed red in `8d0d983`.

- `pytest tests/ -m "not spec_validation"` — 681 passed, 11 skipped, 93 subtests
  passed. The base gave 674 passed.
- `pytest tests/ -m spec_validation` — 624 passed, 141 skipped, 74 xfailed. The base
  gave the same counts. The divergence register holds 74 entries before and after, so
  this change moves no JA4L conformance value.
- `ruff check` clean. `ruff format --check` clean. `mypy ja4plus/` clean.
- `python -m build` builds the wheel and the source distribution.
- Coverage is 74 percent in total, against the floor of 70.
  `ja4plus/fingerprinters/ja4l.py` is 91 percent.

## Interface

Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4L.png
(retrieved 2026-08-06). The image gives the table `<=21` -> `1.5`, `22` -> `1.6`,
`23` -> `1.7`, `24` -> `1.8`, `25` -> `1.9`, `>=26` -> `2.0`, the formula `D = jc/p`,
and the speed of light in fiber as `0.128 miles or 0.206 km per µs`. The FoxIO Python
reference computes no distance, so the image is the only source.

## Docs

- `docs/usage.md` states the new interface and the table.
- `docs/specs/spec.md` gains the terms `hop count` and `propagation factor`. It moves
  no register entry.

Refs #30