### PR TITLE
Record the ambiguous spec readings and replace the parity tests

### DIFF
--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -103,10 +103,17 @@ no reference value settles a question the image leaves open.
 
 ### The option list holds six option kinds
 
-`ja4plus` maps six TCP option kinds to their IANA numbers: 0 for EOL, 1 for NOP, 2 for
-MSS, 3 for Window Scale, 4 for SACK Permitted, and 8 for Timestamp. It drops an option
-kind outside those six, and it writes no number for that kind. A packet that carries no
-option of the six gives the value `0`.
+`ja4plus` maps six TCP option kinds to their IANA numbers.
+
+- 0 for EOL
+- 1 for NOP
+- 2 for MSS
+- 3 for Window Scale
+- 4 for SACK Permitted
+- 8 for Timestamp
+
+`ja4plus` drops an option kind outside those six, and it writes no number for that kind.
+A packet that carries no option of the six gives the value `0`.
 
 The list keeps the wire order. `ja4plus` never sorts it.
 
@@ -127,7 +134,7 @@ either method.
 expected-output path that this repository does not hold, so both files skip on every run.
 #109 owns that gap.
 
-### The readings of JA4D
+### How ja4plus reads JA4D
 
 The form is `{type}{size}{ip}{fqdn}_{options}_{parameters}`. `ja4plus` reads it as
 follows. The comment at `ja4plus/fingerprinters/ja4d.py:42` names two FoxIO pull
@@ -146,9 +153,9 @@ requests, 267 and 270, as the source of the skip set. No vector confirms the rea
 
 **Location:** `ja4plus/fingerprinters/ja4d.py:45` and `ja4plus/fingerprinters/ja4d.py:183`.
 
-### The readings of JA4D6
+### How ja4plus reads JA4D6
 
-The form matches JA4D, and three fields differ.
+The form matches JA4D, and five readings differ. The message type alone is unchanged.
 
 - The size is the byte length of the DUID inside option 1, as four decimal digits.
   `ja4plus` caps it at 9999, and it writes `0000` when the option is absent.

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -4,6 +4,10 @@ Behaviors in the Python ja4plus library that are not documented in the
 FoxIO JA4+ specification. The Go implementation MUST match these behaviors
 to produce identical fingerprints.
 
+FoxIO publishes seven of the twelve methods as an image. Where an image leaves a question
+open, the expected-output file decides, and the reading goes here. An entry names the
+vector that supports the reading, or it states that no FoxIO material validates it.
+
 ---
 
 ## JA4 - TLS Client Hello
@@ -54,11 +58,107 @@ ALPN (`0x0010`), which `JA4` removes. The vector
 `t13d1715h2_5b234860e130_014157ec0da2`, and that value is the hash of the
 `JA4_ro.1` fields.
 
-FoxIO publishes no `JA4S_o` key. JA4S hashes its extensions in wire order, and
-the published `JA4S_r` value holds that same wire order. The original-order
-hashed value of JA4S therefore equals the JA4S fingerprint. The
-`fingerprint_original_order` key carries it, so one caller reads one name on
-JA4 and on JA4S.
+The JA4S section below records the `JA4S_o` reading.
+
+---
+
+## JA4S - TLS Server Hello
+
+### The raw form holds the extensions in wire order
+
+FoxIO publishes JA4S as an image, so the expected-output file decides the extension
+order. `tls-alpn-h2.pcap.json` gives `JA4S_r` as `t1204h2_cca9_0000,ff01,000b,0010`.
+That order is not numeric order, so it is wire order.
+
+The JA4S fingerprint hashes the extensions in wire order, and it equals the reference
+`JA4S` value `t1204h2_cca9_1428ce7b4018`. The `raw_original_order` key holds the wire
+order, and it equals the reference `JA4S_r`. The `raw` key sorts the extensions, so it
+does not equal `JA4S_r`. #108 owns that difference.
+
+### The original-order hashed value has no reference
+
+No FoxIO expected-output file carries a `JA4S_o` key. The 37 files hold `JA4`, `JA4_r`,
+`JA4_o`, `JA4_ro`, `JA4S`, `JA4S_r`, `JA4H`, `JA4H_ro`, `JA4X`, `JA4SSH`, `JA4L-C` and
+`JA4L-S`, and no other method key.
+
+`ja4plus` derives the value from the reading above. JA4S hashes its extensions in wire
+order, so the original-order hash of JA4S equals the JA4S fingerprint. The
+`fingerprint_original_order` key carries that value, so one caller reads one name on JA4
+and on JA4S.
+
+**No FoxIO material validates this value, in either direction.** The `docs/specs/spec.md`
+changelog records it at round 11.
+
+**Location:** `ja4plus/fingerprinters/ja4s.py:102`.
+
+---
+
+## JA4T and JA4TS - TCP
+
+### No FoxIO vector validates JA4T or JA4TS
+
+No expected-output file of the 37 carries a `JA4T` key or a `JA4TS` key, and the vector
+set holds many TCP handshakes. The image is the only FoxIO material for both methods, and
+no reference value settles a question the image leaves open.
+
+### The option list holds six option kinds
+
+`ja4plus` maps six TCP option kinds to their IANA numbers: 0 for EOL, 1 for NOP, 2 for
+MSS, 3 for Window Scale, 4 for SACK Permitted, and 8 for Timestamp. It drops an option
+kind outside those six, and it writes no number for that kind. A packet that carries no
+option of the six gives the value `0`.
+
+The list keeps the wire order. `ja4plus` never sorts it.
+
+**Location:** `ja4plus/fingerprinters/ja4t.py:67` and `ja4plus/fingerprinters/ja4ts.py:68`.
+
+---
+
+## JA4D and JA4D6 - DHCP
+
+### No FoxIO vector validates JA4D or JA4D6
+
+FoxIO publishes `dhcp.pcapng` and `dhcpv6.pcap`, and the expected-output file of each one
+holds an empty array. `tests/foxio_vectors/dhcp.pcapng.json` and
+`tests/foxio_vectors/dhcpv6.pcap.json` each hold `[]`. No reference value validates
+either method.
+
+`tests/test_ja4d_foxio.py` and `tests/test_ja4d6_foxio.py` name a capture path and an
+expected-output path that this repository does not hold, so both files skip on every run.
+#109 owns that gap.
+
+### The readings of JA4D
+
+The form is `{type}{size}{ip}{fqdn}_{options}_{parameters}`. `ja4plus` reads it as
+follows. The comment at `ja4plus/fingerprinters/ja4d.py:42` names two FoxIO pull
+requests, 267 and 270, as the source of the skip set. No vector confirms the reading.
+
+- The type is a five-character abbreviation of the DHCP message type. An unknown type
+  gives the five-digit decimal value of the code.
+- The size is the maximum message size of option 57, as four decimal digits. `ja4plus`
+  caps it at 9999, and it writes `0000` when the option is absent.
+- The `ip` character is `i` when option 50 is present, and `n` when it is absent.
+- The `fqdn` character is `d` when option 81 is present, and `n` when it is absent.
+- The option list holds the option codes in wire order. It drops 0, 50, 53 and 81. The
+  end marker 255 stops the read and never reaches the list. An empty list gives `00`.
+- The parameter list holds the contents of option 55 in wire order. An empty list gives
+  `00`.
+
+**Location:** `ja4plus/fingerprinters/ja4d.py:45` and `ja4plus/fingerprinters/ja4d.py:183`.
+
+### The readings of JA4D6
+
+The form matches JA4D, and three fields differ.
+
+- The size is the byte length of the DUID inside option 1, as four decimal digits.
+  `ja4plus` caps it at 9999, and it writes `0000` when the option is absent.
+- The `ip` character reads option 4, which is IA_TA. The `fqdn` character reads option
+  39.
+- The option list holds every option code in presence order, and it drops none. The list
+  holds the codes nested inside IA_NA, IA_TA, IA_PD, IA Address and IA Prefix. The
+  parameter list holds the contents of option 6.
+
+**Location:** `ja4plus/fingerprinters/ja4d6.py:76` and `ja4plus/fingerprinters/ja4d6.py:202`.
 
 ---
 

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -8,9 +8,10 @@ test here does that.
 
 No test builds, runs or imports the port. The gate is the shared vector set.
 
-Verified against:
-https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/python/test/testdata/tls-alpn-h2.pcap.json
-(retrieved 2026-08-07).
+Every expected value comes from `tests/foxio_vectors/tls-alpn-h2.pcap.json`.
+`tests/foxio_vectors/NOTICE` records that file as a copy of
+`python/test/testdata/tls-alpn-h2.pcap.json` at FoxIO commit
+27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8.
 """
 
 import io
@@ -81,8 +82,13 @@ def fingerprints_of_capture(fingerprinter):
     return fingerprinter.get_fingerprints()
 
 
-def test_the_command_line_program_reports_the_reference_values_for_every_type_name():
-    """Every type name reaches a fingerprinter, and two methods give the reference value."""
+def test_the_command_line_program_accepts_every_type_name_and_reports_two_reference_values():
+    """The program accepts the ten type names, and JA4 and JA4S give the reference value.
+
+    The vector carries TLS alone, so `ja4h`, `ja4ssh`, `ja4d` and `ja4d6` produce nothing
+    on it. The program rejects an unknown type name with the exit code 1, so an exit code
+    of 0 proves that it accepts all ten names.
+    """
     expected = reference_stream()
     out, err, code = run_cli("--format", "json", "--types", TYPE_NAMES, "analyze", VECTOR_CAPTURE)
     assert code == 0, err
@@ -96,6 +102,11 @@ def test_the_command_line_program_reports_the_reference_values_for_every_type_na
 
     assert expected["JA4.1"] in produced["ja4"]
     assert expected["JA4S"] in produced["ja4s"]
+
+    # The exit code above proves that the program accepts the ten names only while the
+    # program still rejects a name outside the list.
+    _, _, unknown_code = run_cli("--types", "ja4nope", "analyze", VECTOR_CAPTURE)
+    assert unknown_code == 1
 
 
 def test_the_ja4_raw_forms_match_the_reference():
@@ -132,9 +143,10 @@ def test_the_ja4s_original_order_raw_form_matches_the_reference():
     # owns that difference.
     assert entry["raw_original_order"] == expected["JA4S_r"]
     assert fingerprinter.last_raw_original_order == expected["JA4S_r"]
-    # FoxIO publishes no `JA4S_o` key, so no vector validates this value.
+    # FoxIO publishes no `JA4S_o` key, so no vector validates this value. JA4S hashes the
+    # extensions in wire order, so the original-order hash equals the fingerprint.
     # `docs/implementation_notes.md` records the reading.
-    assert entry["fingerprint_original_order"] == expected["JA4S"]
+    assert entry["fingerprint_original_order"] == entry["fingerprint"]
 
 
 def test_the_ja4x_helpers_produce_the_reference_value():

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -1,159 +1,190 @@
-"""Parity tests: confirm Python ja4plus exposes the same surface area
-that ja4plus-go exposes: ComputeJA4XFromPEM/DER, FingerprintResult.Raw /
-RawOriginalOrder fields, CLI VALID_TYPES coverage."""
+"""Parity tests for the interface `ja4plus-go` shares with `ja4plus`.
 
+The port publishes `ComputeJA4XFromPEM`, `ComputeJA4XFromDER`, the `Raw` and
+`RawOriginalOrder` result fields, the ten command-line type names, and one shard-key
+format. A test here compares a value the shared FoxIO vector holds. A test that asserts
+only that a name exists passes on two implementations that disagree on every byte, so no
+test here does that.
+
+No test builds, runs or imports the port. The gate is the shared vector set.
+
+Verified against:
+https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/python/test/testdata/tls-alpn-h2.pcap.json
+(retrieved 2026-08-07).
+"""
+
+import io
+import json
 import os
+from unittest.mock import patch
 
-import pytest
+VECTOR_DIR = os.path.join(os.path.dirname(__file__), "foxio_vectors")
+
+# One vector carries every value these tests compare: JA4, both JA4 raw forms, the JA4
+# original-order hash, JA4S, JA4S_r and two JA4X values.
+VECTOR_CAPTURE = os.path.join(VECTOR_DIR, "tls-alpn-h2.pcap")
+VECTOR_EXPECTED = os.path.join(VECTOR_DIR, "tls-alpn-h2.pcap.json")
+
+# The ten type names the command-line program accepts. The port ships the same list.
+TYPE_NAMES = "ja4,ja4s,ja4h,ja4l,ja4t,ja4ts,ja4x,ja4ssh,ja4d,ja4d6"
 
 
-def test_cli_accepts_ja4d_in_types_arg():
-    """ja4d must be in VALID_TYPES per the user spec."""
-    from ja4plus.cli import VALID_TYPES, ALL_FINGERPRINTERS
+def reference_stream():
+    """Return the first stream of the expected-output file of the vector.
 
-    assert "ja4d" in VALID_TYPES
-    assert "ja4d6" in VALID_TYPES
-    assert "ja4d" in ALL_FINGERPRINTERS
-    assert "ja4d6" in ALL_FINGERPRINTERS
+    Returns:
+        The record, as a dictionary of method key to expected value.
+    """
+    with open(VECTOR_EXPECTED) as handle:
+        return json.load(handle)[0]
 
 
-def test_compute_ja4x_from_der_module_helper():
-    """compute_ja4x_from_der() should match JA4XFingerprinter().fingerprint_certificate()."""
-    from ja4plus import compute_ja4x_from_der
+def run_cli(*argv):
+    """Return the standard output, the standard error and the exit code of the program.
+
+    Args:
+        argv: The command-line arguments, without the program name.
+
+    Returns:
+        A (stdout, stderr, exit_code) triple. The exit code is 0 when `main` returns.
+    """
+    from ja4plus.cli import main
+
+    captured_out = io.StringIO()
+    captured_err = io.StringIO()
+    exit_code = 0
+    with (
+        patch("sys.argv", ["ja4plus"] + list(argv)),
+        patch("sys.stdout", captured_out),
+        patch("sys.stderr", captured_err),
+    ):
+        try:
+            main()
+        except SystemExit as error:
+            exit_code = error.code if error.code is not None else 0
+    return captured_out.getvalue(), captured_err.getvalue(), exit_code
+
+
+def fingerprints_of_capture(fingerprinter):
+    """Return the fingerprint entries one fingerprinter produces for the vector.
+
+    Args:
+        fingerprinter: A fingerprinter instance.
+
+    Returns:
+        The list of entries the fingerprinter collected.
+    """
+    from scapy.all import rdpcap
+
+    for packet in rdpcap(VECTOR_CAPTURE):
+        fingerprinter.process_packet(packet)
+    return fingerprinter.get_fingerprints()
+
+
+def test_the_command_line_program_reports_the_reference_values_for_every_type_name():
+    """Every type name reaches a fingerprinter, and two methods give the reference value."""
+    expected = reference_stream()
+    out, err, code = run_cli("--format", "json", "--types", TYPE_NAMES, "analyze", VECTOR_CAPTURE)
+    assert code == 0, err
+
+    produced = {}
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        produced.setdefault(record["type"], []).append(record["fingerprint"])
+
+    assert expected["JA4.1"] in produced["ja4"]
+    assert expected["JA4S"] in produced["ja4s"]
+
+
+def test_the_ja4_raw_forms_match_the_reference():
+    """The JA4 result carries the four values the reference publishes for the stream."""
+    from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+
+    expected = reference_stream()
+    fingerprinter = JA4Fingerprinter()
+    entries = fingerprints_of_capture(fingerprinter)
+    assert len(entries) == 1
+
+    entry = entries[0]
+    assert entry["fingerprint"] == expected["JA4.1"]
+    assert entry["raw"] == expected["JA4_r.1"]
+    assert entry["raw_original_order"] == expected["JA4_ro.1"]
+    assert entry["fingerprint_original_order"] == expected["JA4_o.1"]
+    assert fingerprinter.last_raw == expected["JA4_r.1"]
+    assert fingerprinter.last_raw_original_order == expected["JA4_ro.1"]
+
+
+def test_the_ja4s_original_order_raw_form_matches_the_reference():
+    """The JA4S original-order raw form holds the extensions in the reference order."""
+    from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
+
+    expected = reference_stream()
+    fingerprinter = JA4SFingerprinter()
+    entries = fingerprints_of_capture(fingerprinter)
+    assert len(entries) == 1
+
+    entry = entries[0]
+    assert entry["fingerprint"] == expected["JA4S"]
+    # The reference `JA4S_r` holds the extensions in wire order, and `raw_original_order`
+    # holds that same order. `raw` sorts them, so it does not match the reference. #108
+    # owns that difference.
+    assert entry["raw_original_order"] == expected["JA4S_r"]
+    assert fingerprinter.last_raw_original_order == expected["JA4S_r"]
+    # FoxIO publishes no `JA4S_o` key, so no vector validates this value.
+    # `docs/implementation_notes.md` records the reading.
+    assert entry["fingerprint_original_order"] == expected["JA4S"]
+
+
+def test_the_ja4x_helpers_produce_the_reference_value():
+    """`compute_ja4x_from_der` and `compute_ja4x_from_pem` give the reference JA4X value."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives.serialization import Encoding
+
+    from ja4plus import compute_ja4x_from_der, compute_ja4x_from_pem
     from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
 
-    # Use any real cert from the test suite
-    from cryptography import x509
-    from cryptography.hazmat.backends import default_backend
-    from cryptography.hazmat.primitives.serialization import Encoding
-    from cryptography.x509.oid import NameOID
-    from cryptography.hazmat.primitives.asymmetric import rsa
-    from cryptography.hazmat.primitives import hashes
-    import datetime
+    expected = reference_stream()
+    certificates = []
 
-    # Generate a self-signed cert in-memory
-    key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
-    name = x509.Name(
-        [
-            x509.NameAttribute(NameOID.COMMON_NAME, "test.example.com"),
-        ]
-    )
-    cert = (
-        x509.CertificateBuilder()
-        .subject_name(name)
-        .issuer_name(name)
-        .public_key(key.public_key())
-        .serial_number(1)
-        .not_valid_before(datetime.datetime(2020, 1, 1))
-        .not_valid_after(datetime.datetime(2030, 1, 1))
-        .sign(key, hashes.SHA256(), default_backend())
-    )
-    der = cert.public_bytes(Encoding.DER)
+    class RecordingFingerprinter(JA4XFingerprinter):
+        """Collect the certificate bytes the scan reads, then fingerprint them."""
 
-    via_helper = compute_ja4x_from_der(der)
-    via_class = JA4XFingerprinter().fingerprint_certificate(der)
-    assert via_helper == via_class
-    assert via_helper is not None
-    assert via_helper.count("_") == 2  # JA4X: 3 parts
+        def fingerprint_certificate(self, cert_data):
+            certificates.append(cert_data)
+            return super().fingerprint_certificate(cert_data)
+
+    fingerprints_of_capture(RecordingFingerprinter())
+    assert certificates, "the vector holds a Certificate message"
+
+    der = certificates[-1]
+    pem = x509.load_der_x509_certificate(der).public_bytes(Encoding.PEM)
+    assert compute_ja4x_from_der(der) == expected["JA4X.2"]
+    assert compute_ja4x_from_pem(pem) == expected["JA4X.2"]
 
 
-def test_compute_ja4x_from_pem_matches_der():
-    """PEM and DER variants must produce the same fingerprint."""
-    from ja4plus import compute_ja4x_from_der, compute_ja4x_from_pem
-    from cryptography import x509
-    from cryptography.hazmat.backends import default_backend
-    from cryptography.hazmat.primitives.serialization import Encoding
-    from cryptography.x509.oid import NameOID
-    from cryptography.hazmat.primitives.asymmetric import rsa
-    from cryptography.hazmat.primitives import hashes
-    import datetime
-
-    key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
-    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test.example.com")])
-    cert = (
-        x509.CertificateBuilder()
-        .subject_name(name)
-        .issuer_name(name)
-        .public_key(key.public_key())
-        .serial_number(2)
-        .not_valid_before(datetime.datetime(2020, 1, 1))
-        .not_valid_after(datetime.datetime(2030, 1, 1))
-        .sign(key, hashes.SHA256(), default_backend())
-    )
-    der = cert.public_bytes(Encoding.DER)
-    pem = cert.public_bytes(Encoding.PEM)
-
-    assert compute_ja4x_from_pem(pem) == compute_ja4x_from_der(der)
-
-
-def test_compute_ja4x_from_pem_accepts_str():
+def test_compute_ja4x_from_pem_returns_none_for_text_that_is_not_a_certificate():
+    """A caller that passes text which is not a certificate gets None, not an exception."""
     from ja4plus import compute_ja4x_from_pem
 
     assert compute_ja4x_from_pem("-----not a real PEM-----") is None
 
 
-def test_ja4_fingerprinter_exposes_raw_and_raw_original_order():
-    """Per spec: JA4 result must include 'raw' and 'raw_original_order'."""
-    from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+def test_the_shard_key_matches_the_port_format():
+    """The shard key reads `<protocol>:<address>:<port>-><address>:<port>`."""
+    from scapy.all import IP, TCP, UDP
 
-    fp = JA4Fingerprinter()
-    # No packet processed yet
-    assert fp.last_raw is None
-    assert fp.last_raw_original_order is None
+    from ja4plus.processor import Processor
 
-    # Simulate a parse via direct dict — easier than building a full pcap
-    # We'll use a real ClientHello pcap if available
-    pcap = "tests/foxio_vectors/pcap/tls-handshake.pcapng"
-    if not os.path.exists(pcap):
-        pytest.skip("tls-handshake.pcapng fixture missing")
+    processor = Processor()
+    # The port formats the key with `"%s:%s:%d->%s:%d"`. A shard key that reads any
+    # other way sends one connection to two shards when the two programs run together.
+    forward = IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=44100, dport=443)
+    assert processor.get_shard_key(forward) == "tcp:10.0.0.1:44100->10.0.0.2:443"
 
-    from scapy.all import rdpcap
+    reverse = IP(src="10.0.0.2", dst="10.0.0.1") / TCP(sport=443, dport=44100)
+    assert processor.get_shard_key(reverse) == "tcp:10.0.0.1:44100->10.0.0.2:443"
 
-    pkts = rdpcap(pcap)
-    fingerprinted = False
-    for pkt in pkts:
-        result = fp.process_packet(pkt)
-        if result:
-            fingerprinted = True
-            break
-
-    assert fingerprinted
-    assert fp.last_raw is not None
-    assert fp.last_raw_original_order is not None
-    # Stored entry must include raw fields
-    entry = fp.fingerprints[-1]
-    assert "raw" in entry
-    assert "raw_original_order" in entry
-    assert entry["raw"] == fp.last_raw
-    assert entry["raw_original_order"] == fp.last_raw_original_order
-
-
-def test_ja4s_fingerprinter_exposes_raw_and_raw_original_order():
-    """Per spec: JA4S result must include 'raw' and 'raw_original_order'."""
-    from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
-
-    fp = JA4SFingerprinter()
-    assert fp.last_raw is None
-    assert fp.last_raw_original_order is None
-
-    pcap = "tests/foxio_vectors/pcap/tls-handshake.pcapng"
-    if not os.path.exists(pcap):
-        pytest.skip("tls-handshake.pcapng fixture missing")
-
-    from scapy.all import rdpcap
-
-    pkts = rdpcap(pcap)
-    fingerprinted = False
-    for pkt in pkts:
-        result = fp.process_packet(pkt)
-        if result:
-            fingerprinted = True
-            break
-
-    if not fingerprinted:
-        pytest.skip("no ServerHello found in fixture")
-    assert fp.last_raw is not None
-    assert fp.last_raw_original_order is not None
-    entry = fp.fingerprints[-1]
-    assert "raw" in entry
-    assert "raw_original_order" in entry
+    datagram = IP(src="10.0.0.1", dst="10.0.0.2") / UDP(sport=51000, dport=443)
+    assert processor.get_shard_key(datagram) == "udp:10.0.0.1:51000->10.0.0.2:443"


### PR DESCRIPTION
## What

Records the readings this project made of the ambiguous parts of the FoxIO material, and
replaces the parity tests that asserted only that a name exists.

Part of #31. Part of #12, batch 3.

## Why

FoxIO publishes seven of the twelve methods as an image. Four of those seven held no
entry in `docs/implementation_notes.md`, so the readings this project made were recorded
nowhere. `tests/test_parity.py` held six tests, and none compared a fingerprint. Two
implementations pass every one of them and disagree on every byte.

## How

**`docs/implementation_notes.md`.** Three sections join the file, between the JA4 section
and the JA4L section. The entries that #78, #88 and #92 wrote are unchanged. The `JA4S_o`
paragraph moves from the JA4 section into the new JA4S section, because it describes JA4S.

- **JA4S.** `tls-alpn-h2.pcap.json` gives `JA4S_r` as `t1204h2_cca9_0000,ff01,000b,0010`.
  That order is not numeric order, so it is wire order, and that settles the question the
  image leaves open. No expected-output file of the 37 carries a `JA4S_o` key, so no FoxIO
  material validates the JA4S original-order hash in either direction. The
  `docs/specs/spec.md` changelog records it at round 11.
- **JA4T and JA4TS.** No expected-output file carries a `JA4T` key or a `JA4TS` key. The
  entry names the six TCP option kinds `ja4plus` maps, and states that it drops any other
  kind.
- **JA4D and JA4D6.** `tests/foxio_vectors/dhcp.pcapng.json` and
  `tests/foxio_vectors/dhcpv6.pcap.json` each hold `[]`, so no reference value validates
  either method. The entry lists each field reading with its location.

`#96`, `#97` and `#105` are documented divergences, not ambiguous readings, and this pull
request records none of them as readings.

**`tests/test_parity.py`.** Six tests become six tests, and each compares a value that
`tests/foxio_vectors/tls-alpn-h2.pcap.json` holds:

| Test | What it compares |
|---|---|
| `test_the_command_line_program_accepts_every_type_name_and_reports_two_reference_values` | The program accepts all ten type names, rejects a name outside them, and the produced `ja4` and `ja4s` values equal `JA4.1` and `JA4S`. |
| `test_the_ja4_raw_forms_match_the_reference` | `JA4.1`, `JA4_r.1`, `JA4_ro.1` and `JA4_o.1`. |
| `test_the_ja4s_original_order_raw_form_matches_the_reference` | `JA4S` and `JA4S_r`. |
| `test_the_ja4x_helpers_produce_the_reference_value` | `compute_ja4x_from_der` and `compute_ja4x_from_pem` against `JA4X.2`. |
| `test_compute_ja4x_from_pem_returns_none_for_text_that_is_not_a_certificate` | The failure mode of the helper. |
| `test_the_shard_key_matches_the_port_format` | Three exact keys, which proves the port's `"%s:%s:%d->%s:%d"` form. |

Two of the six tests this pull request removes named
`tests/foxio_vectors/pcap/tls-handshake.pcapng`, which this repository does not hold, so
they skipped on every run. The unit suite skip count falls from 11 to 9.

No test builds, runs or imports the port.

## The third acceptance criterion

`pytest tests/ -m spec_validation` passes today. It applies **74 registered deviations as
strict `xfail`**. Read the criterion as "the suite is green with the register applied",
not as "no deviation remains". The count is unchanged by this pull request.

## Two issues filed, not fixed

- **#108** — `ja4plus` sorts the JA4S extensions in the `raw` value, and the FoxIO
  `JA4S_r` holds them in wire order, so `raw` does not match the reference.
  `raw_original_order` does. The JA4S fingerprint itself is correct. The conformance suite
  compares no raw form, so no vector reports it.
- **#109** — `tests/test_ja4d_foxio.py` and `tests/test_ja4d6_foxio.py` skip on every run,
  because both name paths this repository does not hold.

## How tested

Run in the worktree, with `[skip ci]` on every commit, as a batch member of Epic #12.

```
pytest tests/ -m "not spec_validation"   676 passed, 9 skipped, 86 subtests passed
pytest tests/ -m spec_validation         624 passed, 141 skipped, 74 xfailed
ruff check ja4plus/ tests/               All checks passed!
ruff format --check ja4plus/ tests/      83 files already formatted
mypy ja4plus/                            Success: no issues found in 27 source files
coverage (unit suite)                    74%, floor 70, and 74% on the base commit
```

Each new test was run once against a mutated expected-output file. All four
vector-driven tests failed on the mutation, which proves they compare the value and do
not pass vacuously.

## Verified against

Every expected value comes from `tests/foxio_vectors/tls-alpn-h2.pcap.json`.
`tests/foxio_vectors/NOTICE` records that file as a copy of
`python/test/testdata/tls-alpn-h2.pcap.json` at FoxIO commit
`27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8`. This pull request fetched no document from
the network, and it cites no retrieval it did not make.

The method descriptions are at
https://github.com/FoxIO-LLC/ja4/tree/main/technical_details, and
`docs/specs/features/01-spec-conformance.md` records which of them are images.
