### PR TITLE
Run the JA4D and JA4D6 reference tests

### DIFF
--- a/.claude/rules/external-apis.md
+++ b/.claude/rules/external-apis.md
@@ -44,7 +44,16 @@ under `python/test/testdata/` decide. Record the reading in
 
 **The files under `wireshark/test/testdata/` are not the authority.**
 `wireshark/test/testdata/tls12.pcap.json` is an empty array, while the file with the
-same name under `python/test/testdata/` holds four fingerprints.
+same name under `python/test/testdata/` holds four fingerprints. Where both directories
+carry a value for a method, `python/test/testdata/` decides.
+
+**JA4D and JA4D6 are the one exception.** The FoxIO Python implementation emits neither
+method, so `python/test/testdata/dhcp.pcapng.json` and
+`python/test/testdata/dhcpv6.pcap.json` each hold an empty array. The Wireshark dissector
+is the only FoxIO implementation that writes a reference value for the two methods, and
+`tests/foxio_vectors/wireshark_expected/` holds a copy of its two files. The Zeek
+baseline `zeek/tests/Traces/Scripts.ja4-dhcp/ja4d.log` holds the same four JA4D values.
+`docs/implementation_notes.md` records the reading.
 
 **`ja4db.com` publishes no versioned document.** Treat any unexpected response shape as
 a miss. Never let its response shape reach a caller unchecked.

--- a/.claude/rules/external-apis.md
+++ b/.claude/rules/external-apis.md
@@ -50,7 +50,7 @@ carry a value for a method, `python/test/testdata/` decides.
 **JA4D and JA4D6 are the one exception.** The FoxIO Python implementation emits neither
 method, so `python/test/testdata/dhcp.pcapng.json` and
 `python/test/testdata/dhcpv6.pcap.json` each hold an empty array. The Wireshark dissector
-is the only FoxIO implementation that writes a reference value for the two methods, and
+is the only FoxIO implementation that writes a reference value for the two methods.
 `tests/foxio_vectors/wireshark_expected/` holds a copy of its two files. The Zeek
 baseline `zeek/tests/Traces/Scripts.ja4-dhcp/ja4d.log` holds the same four JA4D values.
 `docs/implementation_notes.md` records the reading.

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -128,21 +128,22 @@ The list keeps the wire order. `ja4plus` never sorts it.
 The FoxIO Python implementation emits no JA4D and no JA4D6, so the expected-output file
 of each DHCP capture holds an empty array. `tests/foxio_vectors/dhcp.pcapng.json` and
 `tests/foxio_vectors/dhcpv6.pcap.json` each hold `[]`. The FoxIO Rust implementation
-emits neither method either, and both of its snapshots hold `[]`.
+emits neither method. Both of its snapshots hold `[]`.
 
 The FoxIO Wireshark dissector does write a reference value for both methods.
 `tests/foxio_vectors/wireshark_expected/` holds a copy of the two files, taken without
 change from `wireshark/test/testdata/` at the pinned upstream commit.
 
 `.claude/rules/external-apis.md` states that the files under `wireshark/test/testdata/`
-are not the authority, because one of them holds an empty array where the Python file of
-the same name holds four fingerprints. These two methods are the reverse case, and the
+are not the authority. `wireshark/test/testdata/tls12.pcap.json` holds an empty array
+where the Python file of the same name holds four fingerprints. These two methods are the
+reverse case, and the
 Wireshark file is the only FoxIO reference output for them. The FoxIO Zeek baseline
 `zeek/tests/Traces/Scripts.ja4-dhcp/ja4d.log` holds the same four JA4D values, which is a
 second FoxIO implementation that agrees. No second FoxIO implementation emits JA4D6.
 
-`ja4plus` matches every one of the ten reference values, and it emits no fingerprint the
-reference does not hold.
+`ja4plus` matches every one of the ten reference values, and every fingerprint it emits
+appears in the reference.
 
 | Capture | Frame | Reference value |
 |---|---|---|
@@ -157,8 +158,8 @@ reference does not hold.
 | `dhcpv6.pcap` | 11 | `relse0014nn_1-2-6-8-25-26_23-24` |
 | `dhcpv6.pcap` | 12 | `reply0014nn_1-2-13_00` |
 
-The conformance suite reads only the top level of `tests/foxio_vectors/`, so the two
-files add no case to it and no entry to the deviation register.
+The conformance suite reads only the top level of `tests/foxio_vectors/`. The two files
+add no case to that suite and no entry to the deviation register.
 `tests/test_ja4d_foxio.py` and `tests/test_ja4d6_foxio.py` compare them, and both run in
 the unit suite. #109 closed the gap.
 

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -123,22 +123,53 @@ The list keeps the wire order. `ja4plus` never sorts it.
 
 ## JA4D and JA4D6 - DHCP
 
-### No FoxIO vector validates JA4D or JA4D6
+### The reference values come from the FoxIO Wireshark dissector
 
-FoxIO publishes `dhcp.pcapng` and `dhcpv6.pcap`, and the expected-output file of each one
-holds an empty array. `tests/foxio_vectors/dhcp.pcapng.json` and
-`tests/foxio_vectors/dhcpv6.pcap.json` each hold `[]`. No reference value validates
-either method.
+The FoxIO Python implementation emits no JA4D and no JA4D6, so the expected-output file
+of each DHCP capture holds an empty array. `tests/foxio_vectors/dhcp.pcapng.json` and
+`tests/foxio_vectors/dhcpv6.pcap.json` each hold `[]`. The FoxIO Rust implementation
+emits neither method either, and both of its snapshots hold `[]`.
 
-`tests/test_ja4d_foxio.py` and `tests/test_ja4d6_foxio.py` name a capture path and an
-expected-output path that this repository does not hold, so both files skip on every run.
-#109 owns that gap.
+The FoxIO Wireshark dissector does write a reference value for both methods.
+`tests/foxio_vectors/wireshark_expected/` holds a copy of the two files, taken without
+change from `wireshark/test/testdata/` at the pinned upstream commit.
+
+`.claude/rules/external-apis.md` states that the files under `wireshark/test/testdata/`
+are not the authority, because one of them holds an empty array where the Python file of
+the same name holds four fingerprints. These two methods are the reverse case, and the
+Wireshark file is the only FoxIO reference output for them. The FoxIO Zeek baseline
+`zeek/tests/Traces/Scripts.ja4-dhcp/ja4d.log` holds the same four JA4D values, which is a
+second FoxIO implementation that agrees. No second FoxIO implementation emits JA4D6.
+
+`ja4plus` matches every one of the ten reference values, and it emits no fingerprint the
+reference does not hold.
+
+| Capture | Frame | Reference value |
+|---|---|---|
+| `dhcp.pcapng` | 1 | `disco0000in_61-55_1-3-6-42` |
+| `dhcp.pcapng` | 2 | `offer0000nn_1-58-59-51-54_00` |
+| `dhcp.pcapng` | 3 | `reqst0000in_61-54-55_1-3-6-42` |
+| `dhcp.pcapng` | 4 | `dpack0000nn_58-59-51-54-1_00` |
+| `dhcpv6.pcap` | 2 | `solct0014nn_1-6-8-25_23-24` |
+| `dhcpv6.pcap` | 5 | `advrt0014nn_25-26-1-2_00` |
+| `dhcpv6.pcap` | 7 | `reqst0014nn_1-2-6-8-25-26_23-24` |
+| `dhcpv6.pcap` | 8 | `reply0014nn_25-26-1-2_00` |
+| `dhcpv6.pcap` | 11 | `relse0014nn_1-2-6-8-25-26_23-24` |
+| `dhcpv6.pcap` | 12 | `reply0014nn_1-2-13_00` |
+
+The conformance suite reads only the top level of `tests/foxio_vectors/`, so the two
+files add no case to it and no entry to the deviation register.
+`tests/test_ja4d_foxio.py` and `tests/test_ja4d6_foxio.py` compare them, and both run in
+the unit suite. #109 closed the gap.
+
+**Location:** `tests/test_ja4d_foxio.py` and `tests/test_ja4d6_foxio.py`.
 
 ### How ja4plus reads JA4D
 
 The form is `{type}{size}{ip}{fqdn}_{options}_{parameters}`. `ja4plus` reads it as
 follows. The comment at `ja4plus/fingerprinters/ja4d.py:42` names two FoxIO pull
-requests, 267 and 270, as the source of the skip set. No vector confirms the reading.
+requests, 267 and 270, as the source of the skip set. The four reference values of
+`dhcp.pcapng` confirm the reading.
 
 - The type is a five-character abbreviation of the DHCP message type. An unknown type
   gives the five-digit decimal value of the code.

--- a/tests/download_test_vectors.py
+++ b/tests/download_test_vectors.py
@@ -20,8 +20,10 @@ FOXIO_RAW = f"https://raw.githubusercontent.com/FoxIO-LLC/ja4/{FOXIO_COMMIT}"
 
 PCAP_DIR = "pcap"
 EXPECTED_DIR = "python/test/testdata"
+WIRESHARK_EXPECTED_DIR = "wireshark/test/testdata"
 
 VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+WIRESHARK_DIR = VECTORS_DIR / "wireshark_expected"
 
 # Every capture in the upstream `pcap/` directory that has an expected-output file.
 # `dtls-udp.notest.cap` carries a `notest` marker upstream and has no expected
@@ -66,6 +68,14 @@ CAPTURES = [
     "v6.pcap",
 ]
 
+# The FoxIO Python implementation emits no JA4D and no JA4D6, so the expected-output
+# file of each DHCP capture holds an empty array. The Wireshark dissector is the only
+# FoxIO implementation that writes a reference value for the two methods.
+WIRESHARK_CAPTURES = [
+    "dhcp.pcapng",
+    "dhcpv6.pcap",
+]
+
 NOTICE_TEMPLATE = """\
 FoxIO JA4+ conformance vectors
 ==============================
@@ -86,6 +96,17 @@ This directory holds {count} captures and {count} expected-output files.
 
 `dtls-udp.notest.cap` is present upstream but is not copied here. It carries a
 `notest` marker and has no expected-output file, so it is not a vector.
+
+The subdirectory `wireshark_expected/` holds two more expected-output files:
+
+    {wireshark_dir}/dhcp.pcapng.json  ->  tests/foxio_vectors/wireshark_expected/dhcp.pcapng.json
+    {wireshark_dir}/dhcpv6.pcap.json  ->  tests/foxio_vectors/wireshark_expected/dhcpv6.pcap.json
+
+The FoxIO Python implementation emits no JA4D and no JA4D6, so the two files under
+`{expected_dir}` hold an empty array. The Wireshark dissector is the only FoxIO
+implementation that writes a reference value for the two methods.
+`docs/implementation_notes.md` records the reading. The conformance suite reads
+only the top level of this directory, so the subdirectory adds no case to it.
 
 To move to a newer upstream commit, change FOXIO_COMMIT in
 tests/download_test_vectors.py and run that script. The script rewrites this
@@ -137,6 +158,7 @@ def download() -> None:
         ValueError: An expected-output file is not a JSON array.
     """
     VECTORS_DIR.mkdir(parents=True, exist_ok=True)
+    WIRESHARK_DIR.mkdir(parents=True, exist_ok=True)
 
     for capture in CAPTURES:
         print(f"{capture}")
@@ -150,16 +172,31 @@ def download() -> None:
             raise ValueError(f"{expected_name} is not a JSON array")
         (VECTORS_DIR / expected_name).write_bytes(expected)
 
+    for capture in WIRESHARK_CAPTURES:
+        expected_name = f"{capture}.json"
+        print(f"wireshark_expected/{expected_name}")
+        expected = _fetch(f"{FOXIO_RAW}/{WIRESHARK_EXPECTED_DIR}/{expected_name}")
+        entries = json.loads(expected)
+        if not isinstance(entries, list):
+            raise ValueError(f"{expected_name} is not a JSON array")
+        # An empty file compares no value, and the JA4D reference test would then
+        # report a pass on nothing. That is the defect #109 closes.
+        if not entries:
+            raise ValueError(f"wireshark_expected/{expected_name} is an empty array")
+        (WIRESHARK_DIR / expected_name).write_bytes(expected)
+
     (VECTORS_DIR / "NOTICE").write_text(
         NOTICE_TEMPLATE.format(
             repo=FOXIO_REPO,
             commit=FOXIO_COMMIT,
             pcap_dir=PCAP_DIR,
             expected_dir=EXPECTED_DIR,
+            wireshark_dir=WIRESHARK_EXPECTED_DIR,
             count=len(CAPTURES),
         )
     )
     print(f"{len(CAPTURES)} vectors written to {VECTORS_DIR}")
+    print(f"{len(WIRESHARK_CAPTURES)} expected-output files written to {WIRESHARK_DIR}")
 
 
 if __name__ == "__main__":

--- a/tests/foxio_vectors/NOTICE
+++ b/tests/foxio_vectors/NOTICE
@@ -18,6 +18,17 @@ This directory holds 37 captures and 37 expected-output files.
 `dtls-udp.notest.cap` is present upstream but is not copied here. It carries a
 `notest` marker and has no expected-output file, so it is not a vector.
 
+The subdirectory `wireshark_expected/` holds two more expected-output files:
+
+    wireshark/test/testdata/dhcp.pcapng.json  ->  tests/foxio_vectors/wireshark_expected/dhcp.pcapng.json
+    wireshark/test/testdata/dhcpv6.pcap.json  ->  tests/foxio_vectors/wireshark_expected/dhcpv6.pcap.json
+
+The FoxIO Python implementation emits no JA4D and no JA4D6, so the two files under
+`python/test/testdata` hold an empty array. The Wireshark dissector is the only FoxIO
+implementation that writes a reference value for the two methods.
+`docs/implementation_notes.md` records the reading. The conformance suite reads
+only the top level of this directory, so the subdirectory adds no case to it.
+
 To move to a newer upstream commit, change FOXIO_COMMIT in
 tests/download_test_vectors.py and run that script. The script rewrites this
 file.

--- a/tests/foxio_vectors/wireshark_expected/dhcp.pcapng.json
+++ b/tests/foxio_vectors/wireshark_expected/dhcp.pcapng.json
@@ -1,0 +1,58 @@
+[
+  {
+    "_index": "packets-2004-12-05",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "1"
+        ],
+        "ja4.ja4d": [
+          "disco0000in_61-55_1-3-6-42"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2004-12-05",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "2"
+        ],
+        "ja4.ja4d": [
+          "offer0000nn_1-58-59-51-54_00"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2004-12-05",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "3"
+        ],
+        "ja4.ja4d": [
+          "reqst0000in_61-54-55_1-3-6-42"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2004-12-05",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "4"
+        ],
+        "ja4.ja4d": [
+          "dpack0000nn_58-59-51-54-1_00"
+        ]
+      }
+    }
+  }
+]

--- a/tests/foxio_vectors/wireshark_expected/dhcpv6.pcap.json
+++ b/tests/foxio_vectors/wireshark_expected/dhcpv6.pcap.json
@@ -1,0 +1,86 @@
+[
+  {
+    "_index": "packets-2015-01-02",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "2"
+        ],
+        "ja4.ja4d": [
+          "solct0014nn_1-6-8-25_23-24"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2015-01-02",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "5"
+        ],
+        "ja4.ja4d": [
+          "advrt0014nn_25-26-1-2_00"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2015-01-02",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "7"
+        ],
+        "ja4.ja4d": [
+          "reqst0014nn_1-2-6-8-25-26_23-24"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2015-01-02",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "8"
+        ],
+        "ja4.ja4d": [
+          "reply0014nn_25-26-1-2_00"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2015-01-02",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "11"
+        ],
+        "ja4.ja4d": [
+          "relse0014nn_1-2-6-8-25-26_23-24"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2015-01-02",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "12"
+        ],
+        "ja4.ja4d": [
+          "reply0014nn_1-2-13_00"
+        ]
+      }
+    }
+  }
+]

--- a/tests/test_ja4d6_foxio.py
+++ b/tests/test_ja4d6_foxio.py
@@ -37,8 +37,8 @@ def _load_expected():
     for entry in entries:
         layers = entry["_source"]["layers"]
         expected[int(layers["frame.number"][0])] = layers["ja4.ja4d"][0]
-    # An empty map compares no value, and every assertion below passes on it. This
-    # check is what stops the file from reporting a pass on nothing.
+    # An empty map compares no value, and every assertion below passes on it. Without
+    # this check, the file would report a pass on nothing.
     assert expected, "{} names no frame".format(EXPECTED_PATH)
     return expected
 

--- a/tests/test_ja4d6_foxio.py
+++ b/tests/test_ja4d6_foxio.py
@@ -1,94 +1,94 @@
-"""FoxIO reference vector validation for JA4D6 (DHCPv6).
+"""Compare the JA4D6 output of `ja4plus` against the FoxIO reference values.
 
-Compares ja4plus output against the canonical Wireshark dissector
-expected values stored in tests/foxio_vectors/ja4_expected/.
+The FoxIO Python implementation emits no JA4D6, so `tests/foxio_vectors/dhcpv6.pcap.json`
+holds an empty array. The reference values come from the FoxIO Wireshark dissector.
+`docs/implementation_notes.md` records why this method reads that file.
 """
 
 import json
-import os
+from pathlib import Path
 
-import pytest
+from scapy.all import IP, IPv6, UDP, Raw, rdpcap
 
-PCAP_PATH = "tests/foxio_vectors/pcap/dhcpv6.pcap"
-EXPECTED_PATH = "tests/foxio_vectors/ja4_expected/dhcpv6.pcap.ja4d.json"
-
-
-pytestmark = pytest.mark.skipif(
-    not (os.path.exists(PCAP_PATH) and os.path.exists(EXPECTED_PATH)),
-    reason="FoxIO test fixtures not available (download to tests/foxio_vectors/)",
+from ja4plus.fingerprinters.ja4d6 import (
+    DHCPV6_MESSAGE_TYPES,
+    JA4D6Fingerprinter,
+    generate_ja4d6,
 )
+
+VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+PCAP_PATH = VECTORS_DIR / "dhcpv6.pcap"
+EXPECTED_PATH = VECTORS_DIR / "wireshark_expected" / "dhcpv6.pcap.json"
 
 
 def _load_expected():
-    with open(EXPECTED_PATH) as f:
-        data = json.load(f)
-    out = {}
-    for entry in data:
+    """Return the reference fingerprint of every frame the expected-output file names.
+
+    Returns:
+        A map of frame number to the `ja4.ja4d` value.
+
+    Raises:
+        FileNotFoundError: The expected-output file is absent.
+        AssertionError: The expected-output file names no frame.
+    """
+    with open(EXPECTED_PATH) as handle:
+        entries = json.load(handle)
+    expected = {}
+    for entry in entries:
         layers = entry["_source"]["layers"]
-        frame = int(layers["frame.number"][0])
-        out[frame] = layers["ja4.ja4d"][0]
-    return out
+        expected[int(layers["frame.number"][0])] = layers["ja4.ja4d"][0]
+    # An empty map compares no value, and every assertion below passes on it. This
+    # check is what stops the file from reporting a pass on nothing.
+    assert expected, "{} names no frame".format(EXPECTED_PATH)
+    return expected
 
 
 def test_ja4d6_matches_foxio_dhcpv6_pcap():
-    from scapy.all import rdpcap
-    from ja4plus.fingerprinters.ja4d6 import generate_ja4d6
-
     expected = _load_expected()
-    pkts = rdpcap(PCAP_PATH)
 
     actual = {}
-    for i, pkt in enumerate(pkts, start=1):
-        fp = generate_ja4d6(pkt)
-        if fp:
-            actual[i] = fp
+    for number, packet in enumerate(rdpcap(str(PCAP_PATH)), start=1):
+        fingerprint = generate_ja4d6(packet)
+        if fingerprint:
+            actual[number] = fingerprint
 
-    for frame, want in expected.items():
-        assert frame in actual, f"missing JA4D6 for frame {frame}"
-        assert actual[frame] == want, f"frame {frame}: got {actual[frame]!r}, want {want!r}"
+    # A method that emits more fingerprints than the reference is a defect, and so is
+    # one that emits fewer. Only the whole map compares both directions.
+    assert actual == expected
 
 
 def test_message_type_table_completeness():
-    from ja4plus.fingerprinters.ja4d6 import DHCPV6_MESSAGE_TYPES
-
-    # Every entry must be exactly 5 chars
+    # Every abbreviation holds five characters, because the first section of the
+    # fingerprint has a fixed width.
     for code, abbrev in DHCPV6_MESSAGE_TYPES.items():
         assert len(abbrev) == 5, f"DHCPv6 type {code} abbrev {abbrev!r} not 5 chars"
 
-    # All 37 types must be present (1..37 from the spec)
     for code in range(1, 38):
         assert code in DHCPV6_MESSAGE_TYPES, f"missing DHCPv6 type {code}"
 
 
 def test_unknown_message_type_uses_numeric_format():
-    from scapy.all import IP, IPv6, UDP, Raw
-    from ja4plus.fingerprinters.ja4d6 import generate_ja4d6
-
-    # msgtype = 200 (unknown), 3-byte txid, no options
+    # The message type is 200, which the table does not hold. The transaction
+    # identifier is three bytes, and the message carries no option.
     payload = bytes([200, 0, 0, 0])
-    pkt = IPv6() / UDP(sport=546, dport=547) / Raw(load=payload)
-    fp = generate_ja4d6(pkt)
-    assert fp is not None
-    assert fp.startswith("00200")  # %05u of 200
+    packet = IPv6() / UDP(sport=546, dport=547) / Raw(load=payload)
+    fingerprint = generate_ja4d6(packet)
+    assert fingerprint is not None
+    assert fingerprint.startswith("00200")
 
 
 def test_non_dhcpv6_port_returns_none():
-    from scapy.all import IP, UDP, Raw
-    from ja4plus.fingerprinters.ja4d6 import generate_ja4d6
-
-    pkt = IP() / UDP(sport=1234, dport=5678) / Raw(load=bytes([1, 0, 0, 0]))
-    assert generate_ja4d6(pkt) is None
+    packet = IP() / UDP(sport=1234, dport=5678) / Raw(load=bytes([1, 0, 0, 0]))
+    assert generate_ja4d6(packet) is None
 
 
 def test_fingerprinter_class_collects_results():
-    from scapy.all import rdpcap
-    from ja4plus.fingerprinters.ja4d6 import JA4D6Fingerprinter
+    expected = _load_expected()
 
-    fp = JA4D6Fingerprinter()
-    pkts = rdpcap(PCAP_PATH)
-    for pkt in pkts:
-        fp.process_packet(pkt)
+    fingerprinter = JA4D6Fingerprinter()
+    for packet in rdpcap(str(PCAP_PATH)):
+        fingerprinter.process_packet(packet)
 
-    assert len(fp.get_fingerprints()) == 6
-    fp.reset()
-    assert len(fp.get_fingerprints()) == 0
+    assert len(fingerprinter.get_fingerprints()) == len(expected)
+    fingerprinter.reset()
+    assert len(fingerprinter.get_fingerprints()) == 0

--- a/tests/test_ja4d_foxio.py
+++ b/tests/test_ja4d_foxio.py
@@ -1,48 +1,53 @@
-"""FoxIO reference vector validation for JA4D (PR #267 + #270).
+"""Compare the JA4D output of `ja4plus` against the FoxIO reference values.
 
-Compares ja4plus output against the canonical Wireshark dissector
-expected values stored in tests/foxio_vectors/ja4_expected/.
+The FoxIO Python implementation emits no JA4D, so `tests/foxio_vectors/dhcp.pcapng.json`
+holds an empty array. The reference values come from the FoxIO Wireshark dissector.
+`docs/implementation_notes.md` records why this method reads that file.
 """
 
 import json
-import os
+from pathlib import Path
 
-import pytest
+from scapy.all import rdpcap
 
-PCAP_PATH = "tests/foxio_vectors/pcap/dhcp.pcapng"
-EXPECTED_PATH = "tests/foxio_vectors/ja4_expected/dhcp.pcapng.ja4d.json"
+from ja4plus.fingerprinters.ja4d import generate_ja4d
 
-
-pytestmark = pytest.mark.skipif(
-    not (os.path.exists(PCAP_PATH) and os.path.exists(EXPECTED_PATH)),
-    reason="FoxIO test fixtures not available (download to tests/foxio_vectors/)",
-)
+VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+PCAP_PATH = VECTORS_DIR / "dhcp.pcapng"
+EXPECTED_PATH = VECTORS_DIR / "wireshark_expected" / "dhcp.pcapng.json"
 
 
 def _load_expected():
-    with open(EXPECTED_PATH) as f:
-        data = json.load(f)
-    out = {}
-    for entry in data:
+    """Return the reference fingerprint of every frame the expected-output file names.
+
+    Returns:
+        A map of frame number to the `ja4.ja4d` value.
+
+    Raises:
+        FileNotFoundError: The expected-output file is absent.
+        AssertionError: The expected-output file names no frame.
+    """
+    with open(EXPECTED_PATH) as handle:
+        entries = json.load(handle)
+    expected = {}
+    for entry in entries:
         layers = entry["_source"]["layers"]
-        frame = int(layers["frame.number"][0])
-        out[frame] = layers["ja4.ja4d"][0]
-    return out
+        expected[int(layers["frame.number"][0])] = layers["ja4.ja4d"][0]
+    # An empty map compares no value, and every assertion below passes on it. This
+    # check is what stops the file from reporting a pass on nothing.
+    assert expected, "{} names no frame".format(EXPECTED_PATH)
+    return expected
 
 
 def test_ja4d_matches_foxio_dhcp_pcapng():
-    from scapy.all import rdpcap
-    from ja4plus.fingerprinters.ja4d import generate_ja4d
-
     expected = _load_expected()
-    pkts = rdpcap(PCAP_PATH)
 
     actual = {}
-    for i, pkt in enumerate(pkts, start=1):
-        fp = generate_ja4d(pkt)
-        if fp:
-            actual[i] = fp
+    for number, packet in enumerate(rdpcap(str(PCAP_PATH)), start=1):
+        fingerprint = generate_ja4d(packet)
+        if fingerprint:
+            actual[number] = fingerprint
 
-    for frame, want in expected.items():
-        assert frame in actual, f"missing JA4D for frame {frame}"
-        assert actual[frame] == want, f"frame {frame}: got {actual[frame]!r}, want {want!r}"
+    # A method that emits more fingerprints than the reference is a defect, and so is
+    # one that emits fewer. Only the whole map compares both directions.
+    assert actual == expected

--- a/tests/test_ja4d_foxio.py
+++ b/tests/test_ja4d_foxio.py
@@ -33,8 +33,8 @@ def _load_expected():
     for entry in entries:
         layers = entry["_source"]["layers"]
         expected[int(layers["frame.number"][0])] = layers["ja4.ja4d"][0]
-    # An empty map compares no value, and every assertion below passes on it. This
-    # check is what stops the file from reporting a pass on nothing.
+    # An empty map compares no value, and every assertion below passes on it. Without
+    # this check, the file would report a pass on nothing.
     assert expected, "{} names no frame".format(EXPECTED_PATH)
     return expected
 


### PR DESCRIPTION
## What

`tests/test_ja4d_foxio.py` and `tests/test_ja4d6_foxio.py` skipped on every run. Each one
named a capture path and an expected-output path this repository does not hold, so two of
the twelve methods carried no reference test that runs. Both files now run and compare ten
FoxIO reference values.

Refs #109.

## Why

A skipped test reads as a pass. Nothing tested JA4D or JA4D6.

The issue offered two paths. The honest deliverable depended on whether the FoxIO material
holds a reference value for either method, so that question came first.

**The FoxIO Python implementation emits neither method.** `tests/foxio_vectors/dhcp.pcapng.json`
and `tests/foxio_vectors/dhcpv6.pcap.json` each hold `[]`, which #31 measured. The FoxIO
Rust snapshots for the same two captures also hold `[]`.

**The FoxIO Wireshark dissector does write a reference value for both.**
`wireshark/test/testdata/dhcp.pcapng.json` holds four values and
`wireshark/test/testdata/dhcpv6.pcap.json` holds six. Both files carry the `ja4.ja4d` key
that the two test files already parsed, and their docstrings already named the Wireshark
dissector as the source. This pull request takes path 1 of the issue: it commits those two
files, without change, from the pinned upstream commit.

**No expected value comes from `ja4plus` output.** Every one of the ten values is a
verbatim copy of FoxIO material.

## The authority question — please read

`.claude/rules/external-apis.md` states that the files under `wireshark/test/testdata/`
are not the authority, because `wireshark/test/testdata/tls12.pcap.json` is an empty array
where the Python file of the same name holds four fingerprints. JA4D and JA4D6 are the
reverse case: the Python file is the empty one, and the Wireshark file is the only FoxIO
reference output that exists for either method.

A second FoxIO implementation corroborates the JA4D values. The Zeek baseline
`zeek/tests/Traces/Scripts.ja4-dhcp/ja4d.log` holds the same four values, byte for byte:

```
disco0000in_61-55_1-3-6-42
offer0000nn_1-58-59-51-54_00
reqst0000in_61-54-55_1-3-6-42
dpack0000nn_58-59-51-54-1_00
```

No second FoxIO implementation emits JA4D6, so the Wireshark dissector stands alone for
those six values. The rule now records the exception and keeps the existing precedence
everywhere else.

## Result

`ja4plus` matches all ten reference values, and it emits no fingerprint the reference does
not hold. The two fingerprinters are unchanged. This pull request adds coverage; it moves
no fingerprint.

| Capture | Frame | Reference value |
|---|---|---|
| `dhcp.pcapng` | 1 | `disco0000in_61-55_1-3-6-42` |
| `dhcp.pcapng` | 2 | `offer0000nn_1-58-59-51-54_00` |
| `dhcp.pcapng` | 3 | `reqst0000in_61-54-55_1-3-6-42` |
| `dhcp.pcapng` | 4 | `dpack0000nn_58-59-51-54-1_00` |
| `dhcpv6.pcap` | 2 | `solct0014nn_1-6-8-25_23-24` |
| `dhcpv6.pcap` | 5 | `advrt0014nn_25-26-1-2_00` |
| `dhcpv6.pcap` | 7 | `reqst0014nn_1-2-6-8-25-26_23-24` |
| `dhcpv6.pcap` | 8 | `reply0014nn_25-26-1-2_00` |
| `dhcpv6.pcap` | 11 | `relse0014nn_1-2-6-8-25-26_23-24` |
| `dhcpv6.pcap` | 12 | `reply0014nn_1-2-13_00` |

## How it is tested

**The tests came first.** Commit `6d8d336` rewrites both files and fails with
`FileNotFoundError`: `3 failed, 3 passed`, and zero skipped. Commit `ee6846a` adds the
expected output, and the same command gives `6 passed`.

**Each test compares a value, and a mutated expected-output file proves it.**

- A changed value in each file: `2 failed, 4 passed`, and both reference tests failed.
- One frame dropped from `dhcpv6.pcap.json`: `2 failed, 3 passed`.

**The comparison runs in both directions.** The assertion compares the whole map of frame
number to fingerprint, so a method that emits more fingerprints than the reference fails,
and so does one that emits fewer.

**`_load_expected` fails on an empty file.** The refresh script also fails when either
Wireshark file holds an empty array. Neither one can quietly return to a pass on nothing.

**The refresh script reproduces the whole vector set.** Running
`python tests/download_test_vectors.py` rewrote all 37 committed vectors byte-identically
and added the two new files, so the only change to `tests/foxio_vectors/` is the new
subdirectory and the NOTICE text.

## Local checks

```
pytest tests/ -m "not spec_validation"   706 passed, 3 skipped, 93 subtests passed
pytest tests/ -m spec_validation         625 passed, 141 skipped, 73 xfailed
ruff check ja4plus/ tests/               All checks passed!
ruff format --check ja4plus/ tests/      84 files already formatted
mypy ja4plus/                            Success: no issues found in 27 source files
```

The deviation register holds 73 entries on the base and 73 entries here. The conformance
suite globs only `tests/foxio_vectors/*.json`, so the subdirectory adds no case and no
register entry.

Coverage rises. Two test files moved from zero cases that run to six that run.

## Out of scope

Three more tests skip for the same reason, and each names a capture under
`tests/foxio_vectors/pcap/`. They are filed as #115, not fixed here.

## Verified against

```
Verified against: https://github.com/FoxIO-LLC/ja4/tree/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/wireshark/test/testdata (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/zeek/tests/Traces/Scripts.ja4-dhcp/ja4d.log (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/tree/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/rust/ja4/src/snapshots (retrieved 2026-08-06)
```
