### PR TITLE
Group a mirrored tunnel capture by its inner connection

### DIFF
--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -230,6 +230,29 @@ inner ports.
 `ja4plus/utils/tunnels.py` imports the scapy dissectors for Geneve, VXLAN and
 ERSPAN, because scapy leaves them unbound and stops at the tunnel header.
 
+### The connection key of a mirrored capture
+
+A mirror sends both directions of one session from one outer address to one
+other outer address. The outer address pair then separates no direction, and one
+key cannot hold both measurement points of the connection.
+
+`gre-erspan-vxlan.pcap` is such a capture. Every packet travels from
+`100.20.9.2` to `100.20.9.1`, and the inner session is `10.16.27.12:65174` to
+`10.16.27.131:80`. The SYN reached the key
+`tcp_100.20.9.1:80_100.20.9.2:65174`, and the SYN-ACK reached the key
+`tcp_100.20.9.1:65174_100.20.9.2:80`.
+
+`ja4plus/fingerprinters/ja4l.py` holds two keys for one connection:
+
+- The connection key groups the packets. It reads the inner address pair and the
+  inner port pair, which name both endpoints of a mirrored session.
+- The reported key names the stream. It reads the outer address pair and the
+  inner port pair, because the reference reports those. The SYN pairs the source
+  address with the source port, and a later packet does not move that pair.
+
+The expected-output file holds `JA4L-S` `997_64` and `JA4L-C` `953_64` on the
+stream `100.20.9.2:65174` to `100.20.9.1:80`. Read #101 for the measurement.
+
 ### The QUIC measurement points
 
 The reference reads four QUIC packets, and it reads the direction from port 443:

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -75,6 +75,10 @@ class JA4LFingerprinter(BaseFingerprinter):
         """Initialize the fingerprinter."""
         super().__init__()
         self.connections = {}
+        # A caller of `cleanup_connection` holds the address pair this fingerprinter
+        # reports, and a tunnelled connection groups under its inner address pair. This
+        # map reads the grouping key from the reported key.
+        self.grouping_keys = {}
 
     def process_packet(self, packet):
         """
@@ -131,7 +135,9 @@ class JA4LFingerprinter(BaseFingerprinter):
         # that packet, and it names the client first. The SYN carries that direction, so
         # a SYN replaces the pair the first packet of the connection gave.
         if conn.get("reported_key") is None or _opens_a_connection(port_layer, proto):
+            self.grouping_keys.pop(conn.get("reported_key"), None)
             conn["reported_key"] = _reported_key(proto, outer_layer, sport, dport)
+            self.grouping_keys[conn["reported_key"]] = conn_key
         fingerprint = generate_ja4l(packet, conn)
 
         if not fingerprint:
@@ -157,14 +163,17 @@ class JA4LFingerprinter(BaseFingerprinter):
         """Reset all fingerprints and connection tracking."""
         super().reset()
         self.connections = {}
+        self.grouping_keys = {}
 
     def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
         """Remove stored timing state for the given connection."""
         # JA4L normalizes the key so we must try both orderings
         fwd = f"{proto}_{src_ip}:{src_port}_{dst_ip}:{dst_port}"
         rev = f"{proto}_{dst_ip}:{dst_port}_{src_ip}:{src_port}"
-        self.connections.pop(fwd, None)
-        self.connections.pop(rev, None)
+        for reported in (fwd, rev):
+            # The caller names the address pair this fingerprinter reports. A tunnelled
+            # connection groups under another key, and the map holds that key.
+            self.connections.pop(self.grouping_keys.pop(reported, reported), None)
 
     def _propagation_factor(self, ttl, propagation_factor):
         """Return the propagation factor one distance call uses.

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -89,22 +89,23 @@ class JA4LFingerprinter(BaseFingerprinter):
         if (IP not in packet and IPv6 not in packet) or (TCP not in packet and UDP not in packet):
             return None
 
-        if TCP in packet:
-            proto = "tcp"
-            sport = packet[TCP].sport
-            dport = packet[TCP].dport
-        else:
-            proto = "udp"
-            sport = packet[UDP].sport
-            dport = packet[UDP].dport
-
         from ja4plus.utils.packet_utils import get_ip_layer
+        from ja4plus.utils.tunnels import innermost_layer
 
-        ip_layer = get_ip_layer(packet)
-        if ip_layer is None:
+        port_layer = innermost_layer(packet, (TCP, UDP))
+        outer_layer = get_ip_layer(packet)
+        if port_layer is None or outer_layer is None:
             return None
-        src_ip = ip_layer.src
-        dst_ip = ip_layer.dst
+        proto = "tcp" if isinstance(port_layer, TCP) else "udp"
+        sport = int(port_layer.sport)
+        dport = int(port_layer.dport)
+
+        # The reference reports the outer address pair, and it groups by the inner one.
+        # A mirror sends both directions of one session from one outer address to one
+        # other outer address, so the outer pair separates no direction there.
+        inner_layer = innermost_layer(packet, (IP, IPv6)) or outer_layer
+        src_ip = inner_layer.src
+        dst_ip = inner_layer.dst
 
         # Normalize connection key (ordered src/dst)
         if src_ip < dst_ip or (src_ip == dst_ip and sport < dport):
@@ -119,12 +120,18 @@ class JA4LFingerprinter(BaseFingerprinter):
                 "proto": proto,
                 "direction": direction,
                 "conn_key": conn_key,
+                "reported_key": None,
                 "timestamps": {},
                 "ttls": {},
                 "isns": {},
             }
 
         conn = self.connections[conn_key]
+        # The reference pairs the source address of a packet with the source port of
+        # that packet, and it names the client first. The SYN carries that direction, so
+        # a SYN replaces the pair the first packet of the connection gave.
+        if conn.get("reported_key") is None or _opens_a_connection(port_layer, proto):
+            conn["reported_key"] = _reported_key(proto, outer_layer, sport, dport)
         fingerprint = generate_ja4l(packet, conn)
 
         if not fingerprint:
@@ -142,7 +149,7 @@ class JA4LFingerprinter(BaseFingerprinter):
             conn["client_entry"] = len(self.fingerprints)
 
         self.fingerprints.append(
-            {"fingerprint": fingerprint, "packet": packet, "connection": conn_key}
+            {"fingerprint": fingerprint, "packet": packet, "connection": conn["reported_key"]}
         )
         return fingerprint
 
@@ -247,6 +254,43 @@ class JA4LFingerprinter(BaseFingerprinter):
             return 128 - ttl
         else:
             return 255 - ttl
+
+
+def _opens_a_connection(port_layer, proto):
+    """Report whether the packet is a TCP SYN that carries no acknowledgement.
+
+    Args:
+        port_layer: The TCP layer or the UDP layer of the packet.
+        proto: The protocol name of the connection, `tcp` or `udp`.
+
+    Returns:
+        True when the packet opens a TCP connection, and False otherwise.
+    """
+    if proto != "tcp":
+        return False
+    flags = int(port_layer.flags)
+    return bool(flags & 0x02) and not bool(flags & 0x10)
+
+
+def _reported_key(proto, outer_layer, sport, dport):
+    """Return the connection key the reference reports for one connection.
+
+    The reference reports the outer address pair and the inner port pair. It pairs the
+    source address of one packet with the source port of that packet.
+
+    Args:
+        proto: The protocol name of the connection, `tcp` or `udp`.
+        outer_layer: The outer address layer of the packet.
+        sport: The inner source port of the packet.
+        dport: The inner destination port of the packet.
+
+    Returns:
+        A key of the form `<protocol>_<address>:<port>_<address>:<port>`. The two
+        endpoints are in sorted order, so both directions of one connection give one
+        key.
+    """
+    first, second = sorted(((outer_layer.src, sport), (outer_layer.dst, dport)))
+    return "{}_{}:{}_{}:{}".format(proto, first[0], first[1], second[0], second[1])
 
 
 def _packet_microseconds(packet):
@@ -454,8 +498,13 @@ def generate_ja4l(packet, conn=None):
         return None
 
     from ja4plus.utils.packet_utils import get_ip_layer, get_ttl
+    from ja4plus.utils.tunnels import innermost_layer
 
-    ip_layer = get_ip_layer(packet)
+    # The measurement points belong to the two inner endpoints. A mirror carries both
+    # directions of one session under one outer address pair, so the outer address
+    # names no endpoint there. The TTL still comes from the outer layer, because the
+    # reference reports that value.
+    ip_layer = innermost_layer(packet, (IP, IPv6)) or get_ip_layer(packet)
     if ip_layer is None:
         return None
 

--- a/ja4plus/utils/tunnels.py
+++ b/ja4plus/utils/tunnels.py
@@ -1,4 +1,4 @@
-"""Registration of the scapy tunnel dissectors this project needs.
+"""The scapy tunnel dissectors this project needs, and the reader of an inner layer.
 
 `scapy.all` binds the common protocols, and it leaves Geneve, VXLAN and ERSPAN to a
 separate import. Without that import scapy stops at the tunnel header, so a
@@ -15,6 +15,8 @@ result as before the import.
 """
 
 import logging
+
+from scapy.packet import NoPayload
 
 logger = logging.getLogger(__name__)
 
@@ -39,3 +41,26 @@ def register_tunnel_dissectors():
             continue
         loaded.append(name)
     return tuple(loaded)
+
+
+def innermost_layer(packet, layer_classes):
+    """Return the deepest layer of one packet that has one of the classes, or None.
+
+    A tunnel carries a second address layer and a second port layer inside the first
+    one. A mirror sends both directions of one session from one outer address to one
+    other outer address, so only the inner layer separates the two directions.
+
+    Args:
+        packet: A network packet.
+        layer_classes: A tuple of scapy layer classes to look for.
+
+    Returns:
+        The deepest layer with one of the classes, or None when the packet holds none.
+    """
+    found = None
+    layer = packet
+    while not isinstance(layer, NoPayload):
+        if isinstance(layer, layer_classes):
+            found = layer
+        layer = layer.payload
+    return found

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -39,22 +39,6 @@
     "issue": 78,
     "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate."
   },
-  "gre-erspan-vxlan.pcap/0:65174/JA4L-C.1": {
-    "issue": 101,
-    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-C value."
-  },
-  "gre-erspan-vxlan.pcap/0:65174/JA4L-S.1": {
-    "issue": 101,
-    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-S value."
-  },
-  "gre-erspan-vxlan.pcap/JA4L-C": {
-    "issue": 101,
-    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-C value."
-  },
-  "gre-erspan-vxlan.pcap/JA4L-S": {
-    "issue": 101,
-    "cause": "ja4plus groups the two directions of this mirrored capture as two connections, so it emits no JA4L-S value."
-  },
   "gre-sample.pcap/JA4SSH": {
     "issue": 105,
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes."

--- a/tests/test_cleanup_connection.py
+++ b/tests/test_cleanup_connection.py
@@ -54,6 +54,29 @@ class TestJA4LCleanup(unittest.TestCase):
         fp.cleanup_connection("10.0.0.2", 443, "10.0.0.1", 12345, "tcp")
         self.assertEqual(len(fp.connections), 0)
 
+    def test_cleanup_removes_a_tunnelled_connection_by_the_reported_address(self):
+        """A caller of a tunnelled connection holds the outer address pair.
+
+        JA4L groups a tunnelled connection under its inner address pair, so a caller
+        that names the outer pair reaches no entry without the map of the two keys.
+        """
+        from scapy.layers.inet import GRE
+
+        from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+
+        fp = JA4LFingerprinter()
+        packet = (
+            IP(src="1.1.1.1", dst="2.2.2.2")
+            / GRE()
+            / IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=443, flags="S")
+        )
+        fp.process_packet(packet)
+        self.assertGreater(len(fp.connections), 0)
+
+        fp.cleanup_connection("1.1.1.1", 12345, "2.2.2.2", 443, "tcp")
+        self.assertEqual(len(fp.connections), 0)
+
 
 class TestJA4SSHCleanup(unittest.TestCase):
     def _make_ssh_pkt(self, src="10.0.0.1", dst="10.0.0.2", sport=54321, dport=22):

--- a/tests/test_ja4l_foxio.py
+++ b/tests/test_ja4l_foxio.py
@@ -55,6 +55,7 @@ BROWSERS_X509 = "tcp_13.107.21.239:443_172.27.7.31:54524"
 LATEST_HTTP = "tcp_172.16.225.48:52939_23.43.242.57:80"
 EMPTY_USERAGENT = "tcp_::1:9200_::1:57722"
 GRE_SAMPLE = "tcp_172.27.1.66:40264_66.59.109.137:22"
+GRE_ERSPAN_VXLAN = "tcp_100.20.9.1:80_100.20.9.2:65174"
 SSH2_QUIC = "udp_142.251.41.46:443_172.16.225.48:61861"
 
 
@@ -89,6 +90,19 @@ class TestJA4LAgainstTheFoxIOVectors:
         produced = values_on("gre-sample.pcap", GRE_SAMPLE)
         assert "JA4L-S=22952_236" in produced
         assert "JA4L-C=26150_255" in produced
+
+    def test_the_fingerprinter_groups_a_mirrored_capture_by_its_inner_connection(self):
+        # gre-erspan-vxlan.pcap is an ERSPAN mirror. Every packet travels from
+        # 100.20.9.2 to 100.20.9.1, so the outer address pair names no direction. The
+        # inner session 10.16.27.12:65174 to 10.16.27.131:80 names both directions.
+        produced = values_on("gre-erspan-vxlan.pcap", GRE_ERSPAN_VXLAN)
+        assert "JA4L-S=997_64" in produced
+        assert "JA4L-C=953_64" in produced
+
+    def test_the_mirrored_capture_holds_one_connection(self):
+        # The reference holds one stream for this capture. Two connection keys mean the
+        # fingerprinter split the two directions of one session.
+        assert list(values_of("gre-erspan-vxlan.pcap")) == [GRE_ERSPAN_VXLAN]
 
     def test_the_quic_form_reads_the_initial_and_the_handshake_packets(self):
         # ssh2.pcapng stream 36 is QUIC. JA4L-S measures the two Initial packets, and

--- a/tests/test_tunnels.py
+++ b/tests/test_tunnels.py
@@ -1,0 +1,37 @@
+"""Tests for the tunnel helpers in `ja4plus/utils/tunnels.py`."""
+
+from scapy.all import GRE, IP, IPv6, TCP, UDP, Ether
+
+from ja4plus.utils.tunnels import innermost_layer, register_tunnel_dissectors
+
+
+class TestRegisterTunnelDissectors:
+    """The dissector import reports the modules the installed scapy ships."""
+
+    def test_the_registration_returns_a_tuple_of_module_names(self):
+        loaded = register_tunnel_dissectors()
+        assert isinstance(loaded, tuple)
+        assert all(name.startswith("scapy.") for name in loaded)
+
+
+class TestInnermostLayer:
+    """`innermost_layer` reads the deepest layer of one class."""
+
+    def test_the_helper_returns_the_inner_address_layer_of_a_tunnel(self):
+        packet = Ether() / IP(src="10.0.0.1") / GRE() / IP(src="192.168.0.1") / TCP()
+        assert innermost_layer(packet, (IP, IPv6)).src == "192.168.0.1"
+
+    def test_the_helper_returns_the_only_address_layer_of_a_plain_packet(self):
+        packet = Ether() / IP(src="10.0.0.1") / TCP()
+        assert innermost_layer(packet, (IP, IPv6)).src == "10.0.0.1"
+
+    def test_the_helper_returns_the_inner_port_layer_of_a_tunnel(self):
+        packet = Ether() / IP() / UDP(sport=4789) / IP() / TCP(sport=1234)
+        assert innermost_layer(packet, (TCP, UDP)).sport == 1234
+
+    def test_the_helper_reads_an_address_layer_of_each_version(self):
+        packet = Ether() / IP() / GRE() / IPv6(src="2001:db8::1") / TCP()
+        assert innermost_layer(packet, (IP, IPv6)).src == "2001:db8::1"
+
+    def test_the_helper_returns_none_when_the_packet_holds_no_such_layer(self):
+        assert innermost_layer(Ether() / IP() / TCP(), (UDP,)) is None


### PR DESCRIPTION
## What

JA4L holds two keys for one connection.

- The connection key groups the packets. It reads the inner address pair and the inner port pair.
- The reported key names the stream. It reads the outer address pair and the inner port pair, because the reference reports those.

`ja4plus/utils/tunnels.py` gains `innermost_layer`, which reads the deepest address layer or port layer of one packet. `cleanup_connection` reads a map of the reported key to the grouping key, so a caller that names the outer address pair still removes the state.

## Why

`gre-erspan-vxlan.pcap` is an ERSPAN mirror. Every packet travels from `100.20.9.2` to `100.20.9.1`, so the outer address pair separates no direction. The SYN reached `tcp_100.20.9.1:80_100.20.9.2:65174` and the SYN-ACK reached `tcp_100.20.9.1:65174_100.20.9.2:80`, so no key held both measurement points and the fingerprinter reported nothing.

## How tested

Each test came before the code, and each one failed on the base:

- `test_the_fingerprinter_groups_a_mirrored_capture_by_its_inner_connection`
- `test_the_mirrored_capture_holds_one_connection`
- `test_cleanup_removes_a_tunnelled_connection_by_the_reported_address`
- Five cases in `tests/test_tunnels.py` cover `innermost_layer`.

`gre-erspan-vxlan.pcap` now produces `JA4L-S=997_64` and `JA4L-C=953_64` on the stream `100.20.9.2:65174` to `100.20.9.1:80`.

**The whole conformance suite is measured before and after.** A script dumped every produced fingerprint of all 37 vectors, grouped by stream identity. The only difference is the intended one:

```
147c147,156
<  "gre-erspan-vxlan.pcap": {},
---
>  "gre-erspan-vxlan.pcap": {
>   "100.20.9.1:80|100.20.9.2:65174": {
>    "JA4L-C": [ "953_64" ],
>    "JA4L-S": [ "997_64" ]
>   }
>  },
```

No vector that conformed before stopped conforming.

| Check | Base | This branch |
|---|---|---|
| `pytest tests/ -m spec_validation` | 625 passed, 141 skipped, 73 xfailed | 629 passed, 141 skipped, 69 xfailed |
| `pytest tests/ -m "not spec_validation"` | 700 passed, 9 skipped | 709 passed, 9 skipped, 93 subtests passed |
| `ruff check` and `ruff format --check` | clean | clean, 85 files already formatted |
| `mypy ja4plus/` | clean | Success: no issues found in 27 source files |
| coverage | 75% | 76% |

The deviation register falls from 73 entries to 69. The four entries this issue owned are deleted, and each of the four cases now passes.

`docs/implementation_notes.md` records the two keys and the measurement.

## Verified against

- https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata (retrieved 2026-08-06). `tests/foxio_vectors/gre-erspan-vxlan.pcap.json` holds `JA4L-S` `997_64` and `JA4L-C` `953_64`.
- https://scapy.readthedocs.io/en/latest/api/scapy.packet.html (scapy 2.7.0). The page documents `NoPayload` as a `Packet` subclass whose `add_payload` returns `NoReturn`. The page states nothing about the end of the layer chain, so `innermost_layer` was measured against the vector: the walk over `gre-erspan-vxlan.pcap` frame 1 reads 11 layers and stops at `NoPayload`.

## Follow-up filed

- #119: `_src_is_client` reads the outer address and compares it against the inner one. The function has no caller, so nothing reads a wrong answer today.

Refs #101