### PR TITLE
Remove the unused _src_is_client helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   now produces exactly one JA4SSH fingerprint, `c36s36_c76s124_c0s0`, which
   equals the reference.
 
+### Removed
+
+- **The private helper `_src_is_client` leaves `ja4plus/fingerprinters/ja4l.py`**
+  (#119). The helper read the outer address of a packet with `get_ip_layer`, and
+  it compared that address against the address the connection key holds. #101
+  made the JA4L connection key hold the inner address pair, so the two addresses
+  are never equal for a tunnelled packet. No caller reads the helper, so no
+  fingerprint changes. `FR-correctness-audit-11` asks for the removal.
+
 ## [0.6.0] - 2026-05
 
 Major spec-compliance update against the May 2026 FoxIO JA4+ spec

--- a/ja4plus/fingerprinters/ja4l.py
+++ b/ja4plus/fingerprinters/ja4l.py
@@ -601,32 +601,3 @@ def generate_ja4l(packet, conn=None):
     except (ValueError, TypeError, IndexError, AttributeError) as e:
         logger.debug(f"Packet does not contain JA4L data: {e}")
         return None
-
-
-def _src_is_client(packet, conn):
-    """
-    Determine if the source of the packet is the client side.
-
-    Args:
-        packet: The packet to analyze
-        conn: Connection tracking information
-
-    Returns:
-        True if the source is the client, False otherwise
-    """
-    from ja4plus.utils.packet_utils import get_ip_layer
-
-    ip_layer = get_ip_layer(packet)
-    if ip_layer is None:
-        return False
-
-    src_ip = ip_layer.src
-
-    if conn.get("direction") == "forward":
-        conn_key = conn.get("conn_key", "")
-        parts = conn_key.split("_")
-        if len(parts) >= 2:
-            client_part = parts[1].split(":")[0]
-            return src_ip == client_part
-
-    return False


### PR DESCRIPTION
Fixes the defect that #119 reports. The batch pull request closes the issue.

## What changed

`ja4plus/fingerprinters/ja4l.py` loses the private helper `_src_is_client`. The
CHANGELOG records the removal under `### Removed`.

## Why

The helper read the outer address of a packet with `get_ip_layer`, and it compared that
address against the address the connection key holds. #101 made the JA4L connection key
hold the inner address pair, because a mirror sends both directions of one session from
one outer address to one other outer address. The two addresses are therefore never equal
for a tunnelled packet.

A private helper with no caller and a known-wrong reading is a defect for the first
caller that arrives. `FR-correctness-audit-11` in
`docs/specs/features/02-correctness-audit.md` asks for the removal, and the checklist
item `rtk git grep -n "_src_is_client" ja4plus/` reports nothing now.

## No caller exists

Three searches ran on the worktree before the deletion:

- `rtk git grep -n "_src_is_client"` over every tracked file. It reported
  `ja4plus/fingerprinters/ja4l.py:606`, the definition site, plus three lines of
  `docs/specs/features/02-correctness-audit.md` that ask for the removal.
- `grep -rn "src_is_client" ja4plus/ tests/ examples/ docs/ README.md CHANGELOG.md` for
  the name without the leading underscore. It reported the same lines.
- `grep -n "getattr\|globals()\|__all__" ja4plus/fingerprinters/ja4l.py` for a dynamic
  read of the name. It reported nothing.

The command-line program is `ja4plus/cli.py`, and the first two searches cover it. No
caller exists, so the deletion changes no behaviour and the second search path stays
open for a reviewer to repeat.

## How it is tested

The deletion removes dead code, so no test states a new behaviour. The `tdd` practice
does not apply here, and this pull request adds no test rather than one that asserts the
absence of a name. The suites below prove that nothing depended on the helper.

- `pytest tests/ -m "not spec_validation"` — 752 passed, 3 skipped, 93 subtests passed.
- `pytest tests/ -m spec_validation` — 631 passed, 141 skipped, 67 xfailed. The register
  holds 67 entries on the base commit and 67 entries here, so it does not move.
- `ruff check ja4plus/ tests/` — clean.
- `ruff format --check ja4plus/ tests/` — 89 files already formatted.
- `mypy ja4plus/` — Success: no issues found in 27 source files.
- Coverage does not fall. `ja4plus/fingerprinters/ja4l.py` reports 92 percent on the base
  commit and 97 percent here. The total holds at 78 percent.

Refs #119. Cause: #101.