### PR TITLE
Run the three tests that name a missing fixture path

### DIFF
--- a/.claude/rules/external-apis.md
+++ b/.claude/rules/external-apis.md
@@ -26,7 +26,7 @@ Code inside this repository is different. Read the code.
 | Interface | Version pinned | Documentation |
 |---|---|---|
 | FoxIO JA4+ specification | Upstream default branch, commit dated 2026-07-21 | https://github.com/FoxIO-LLC/ja4/tree/main/technical_details |
-| FoxIO test vectors | `pcap/` and `python/test/testdata/` at the pinned commit | https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata |
+| FoxIO test vectors | `pcap/`, `python/test/testdata/`, `wireshark/test/testdata/` and `rust/ja4/src/snapshots/` at the pinned commit | https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata |
 | FoxIO mapping file | `ja4plus-mapping.csv` at the pinned commit | https://github.com/FoxIO-LLC/ja4/blob/main/ja4plus-mapping.csv |
 | `ja4db.com` lookup | No published version | `https://ja4db.com/api/read/<fingerprint>` |
 | `scapy` | 2.4 or later | https://scapy.readthedocs.io/ |
@@ -54,6 +54,14 @@ is the only FoxIO implementation that writes a reference value for the two metho
 `tests/foxio_vectors/wireshark_expected/` holds a copy of its two files. The Zeek
 baseline `zeek/tests/Traces/Scripts.ja4-dhcp/ja4d.log` holds the same four JA4D values.
 `docs/implementation_notes.md` records the reading.
+
+**A snapshot under `rust/ja4/src/snapshots/` decides only where the Python file holds an
+empty array.** `python/test/testdata/quic-with-several-tls-frames.pcapng.json` holds
+`[]`, because the FoxIO Python implementation reads no ClientHello that several CRYPTO
+frames carry. The FoxIO Rust implementation reads it and writes the JA4 value.
+`tests/foxio_vectors/rust_expected/` holds a copy of that snapshot.
+`docs/implementation_notes.md` records the reading. Where both directories carry a value
+for a method, `python/test/testdata/` decides.
 
 **JA4D6 rests on one source.** No FoxIO implementation other than the Wireshark
 dissector writes a JA4D6 value, so nothing corroborates its six values the way the

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -32,16 +32,56 @@ about another method, so each row below names its own evidence. The counts come 
 
 ## JA4 - TLS Client Hello
 
-### ALPN non-ASCII handling
+### The ALPN value of a first byte that is not ASCII
 
-When the first byte of the first ALPN protocol has `ord() > 127`, the ALPN
-field is set to `'99'` rather than the hex representation of the byte.
+`ja4plus` follows the FoxIO prose here, and the FoxIO implementations disagree with it.
+#127 owns the decision. This section records the measurement, not a reading that the
+project has settled.
 
-**Location:** `ja4plus/fingerprinters/ja4.py:90`
+The FoxIO specification states the rule: "If the first or last byte of the first ALPN is
+not an ASCII alphanumeric character (meaning not `0x30-0x39`, `0x41-0x5A`, or
+`0x61-0x7A`), then we print the first and last characters of the hex representation of
+the first ALPN instead." `compute_alpn_value` applies that rule.
 
-**Rationale:** Simplifies output to a fixed 2-char field. The spec says
-"hex representation of the byte" but `'99'` is used as an unambiguous
-sentinel for non-ASCII protocols.
+The FoxIO Python implementation applies a different rule. `python/ja4.py` writes `'99'`
+when the first byte has `ord() > 127`. The FoxIO Rust implementation writes the same
+value.
+
+`tests/foxio_vectors/tls-non-ascii-alpn.pcapng` measures the difference. Its first ALPN
+value is the two bytes `0xba 0xad`.
+
+| Source | JA4 value |
+|---|---|
+| `ja4plus` | `t13d1516bd_8daaf6152771_e5627efa2ab1` |
+| FoxIO Python and FoxIO Rust | `t13d151699_8daaf6152771_e5627efa2ab1` |
+
+Only the two ALPN characters differ. The register entry
+`tls-non-ascii-alpn.pcapng/0:50112/JA4.1` holds the conformance case, and
+`tests/test_ja4_alpn.py` holds the unit case. Both name the difference until #127 settles
+it.
+
+**Location:** `ja4plus/fingerprinters/ja4.py`, in `compute_alpn_value`.
+
+### The QUIC reference value comes from the FoxIO Rust implementation
+
+`tests/foxio_vectors/quic-with-several-tls-frames.pcapng` holds one QUIC Initial packet.
+That packet carries the ClientHello in several CRYPTO frames. The FoxIO Python
+implementation reads no ClientHello from it, so
+`tests/foxio_vectors/quic-with-several-tls-frames.pcapng.json` holds `[]`.
+
+The FoxIO Rust implementation reads it and writes
+`ja4: q13d0310h3_55b375c5d22e_cd85d2d88918`.
+`tests/foxio_vectors/rust_expected/` holds a copy of that snapshot, taken without change
+from `rust/ja4/src/snapshots/` at the pinned upstream commit. `ja4plus` produces the same
+value.
+
+`.claude/rules/external-apis.md` records when a snapshot under `rust/ja4/src/snapshots/`
+carries the authority. The conformance suite reads only the top level of
+`tests/foxio_vectors/`, so the file adds no case to that suite and no entry to the
+deviation register. The register entry `quic-with-several-tls-frames.pcapng/JA4` records
+the difference against the Python material, and #128 owns its cause.
+
+**Location:** `tests/test_quic_multipacket.py`.
 
 ### Version mapping (beyond TLS 1.0-1.3)
 

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -60,7 +60,7 @@ Only the two ALPN characters differ. The register entry
 `tests/test_ja4_alpn.py` holds the unit case. Both name the difference until #127 settles
 it.
 
-**Location:** `ja4plus/fingerprinters/ja4.py`, in `compute_alpn_value`.
+**Location:** `ja4plus/fingerprinters/ja4.py:20`, in `compute_alpn_value`.
 
 ### The QUIC reference value comes from the FoxIO Rust implementation
 

--- a/tests/download_test_vectors.py
+++ b/tests/download_test_vectors.py
@@ -214,8 +214,9 @@ def download() -> None:
         print(f"rust_expected/{snapshot_name}")
         snapshot = _fetch(f"{FOXIO_RAW}/{RUST_EXPECTED_DIR}/{snapshot_name}")
         # A snapshot with no `ja4:` line compares no value, and the QUIC reference test
-        # would then report a pass on nothing. That is the defect #115 closes.
-        if b"\n  ja4: " not in snapshot:
+        # would then report a pass on nothing. That is the defect #115 closes. The test
+        # strips each line before it matches, so this check strips too.
+        if not any(line.strip().startswith(b"ja4: ") for line in snapshot.splitlines()):
             raise ValueError(f"rust_expected/{snapshot_name} holds no JA4 value")
         (RUST_DIR / snapshot_name).write_bytes(snapshot)
 

--- a/tests/download_test_vectors.py
+++ b/tests/download_test_vectors.py
@@ -21,9 +21,11 @@ FOXIO_RAW = f"https://raw.githubusercontent.com/FoxIO-LLC/ja4/{FOXIO_COMMIT}"
 PCAP_DIR = "pcap"
 EXPECTED_DIR = "python/test/testdata"
 WIRESHARK_EXPECTED_DIR = "wireshark/test/testdata"
+RUST_EXPECTED_DIR = "rust/ja4/src/snapshots"
 
 VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
 WIRESHARK_DIR = VECTORS_DIR / "wireshark_expected"
+RUST_DIR = VECTORS_DIR / "rust_expected"
 
 # Every capture in the upstream `pcap/` directory that has an expected-output file.
 # `dtls-udp.notest.cap` carries a `notest` marker upstream and has no expected
@@ -76,6 +78,16 @@ WIRESHARK_CAPTURES = [
     "dhcpv6.pcap",
 ]
 
+# The FoxIO Python implementation reads no ClientHello that several CRYPTO frames carry,
+# so the expected-output file of this capture holds an empty array. The FoxIO Rust
+# implementation reads it and writes the JA4 value.
+RUST_CAPTURES = [
+    "quic-with-several-tls-frames.pcapng",
+]
+
+# The Rust implementation writes one insta snapshot for each capture, under this name.
+RUST_SNAPSHOT_NAME = "ja4__insta@{capture}.snap"
+
 NOTICE_TEMPLATE = """\
 FoxIO JA4+ conformance vectors
 ==============================
@@ -105,8 +117,19 @@ The subdirectory `wireshark_expected/` holds two more expected-output files:
 The FoxIO Python implementation emits no JA4D and no JA4D6, so the two files under
 `{expected_dir}` hold an empty array. The Wireshark dissector is the only FoxIO
 implementation that writes a reference value for the two methods.
-`docs/implementation_notes.md` records the reading. The conformance suite reads
-only the top level of this directory, so the subdirectory adds no case to it.
+`docs/implementation_notes.md` records the reading.
+
+The subdirectory `rust_expected/` holds one more expected-output file:
+
+    {rust_dir}/ja4__insta@quic-with-several-tls-frames.pcapng.snap
+        ->  tests/foxio_vectors/rust_expected/ja4__insta@quic-with-several-tls-frames.pcapng.snap
+
+The FoxIO Python implementation reads no ClientHello that several CRYPTO frames
+carry, so `{expected_dir}/quic-with-several-tls-frames.pcapng.json` holds an empty
+array. The FoxIO Rust implementation reads it and writes the JA4 value.
+
+The conformance suite reads only the top level of this directory, so neither
+subdirectory adds a case to it.
 
 To move to a newer upstream commit, change FOXIO_COMMIT in
 tests/download_test_vectors.py and run that script. The script rewrites this
@@ -155,10 +178,11 @@ def download() -> None:
 
     Raises:
         urllib.error.URLError: A download failed.
-        ValueError: An expected-output file is not a JSON array.
+        ValueError: An expected-output file is not a JSON array, or holds no value.
     """
     VECTORS_DIR.mkdir(parents=True, exist_ok=True)
     WIRESHARK_DIR.mkdir(parents=True, exist_ok=True)
+    RUST_DIR.mkdir(parents=True, exist_ok=True)
 
     for capture in CAPTURES:
         print(f"{capture}")
@@ -185,6 +209,16 @@ def download() -> None:
             raise ValueError(f"wireshark_expected/{expected_name} is an empty array")
         (WIRESHARK_DIR / expected_name).write_bytes(expected)
 
+    for capture in RUST_CAPTURES:
+        snapshot_name = RUST_SNAPSHOT_NAME.format(capture=capture)
+        print(f"rust_expected/{snapshot_name}")
+        snapshot = _fetch(f"{FOXIO_RAW}/{RUST_EXPECTED_DIR}/{snapshot_name}")
+        # A snapshot with no `ja4:` line compares no value, and the QUIC reference test
+        # would then report a pass on nothing. That is the defect #115 closes.
+        if b"\n  ja4: " not in snapshot:
+            raise ValueError(f"rust_expected/{snapshot_name} holds no JA4 value")
+        (RUST_DIR / snapshot_name).write_bytes(snapshot)
+
     (VECTORS_DIR / "NOTICE").write_text(
         NOTICE_TEMPLATE.format(
             repo=FOXIO_REPO,
@@ -192,11 +226,13 @@ def download() -> None:
             pcap_dir=PCAP_DIR,
             expected_dir=EXPECTED_DIR,
             wireshark_dir=WIRESHARK_EXPECTED_DIR,
+            rust_dir=RUST_EXPECTED_DIR,
             count=len(CAPTURES),
         )
     )
     print(f"{len(CAPTURES)} vectors written to {VECTORS_DIR}")
     print(f"{len(WIRESHARK_CAPTURES)} expected-output files written to {WIRESHARK_DIR}")
+    print(f"{len(RUST_CAPTURES)} expected-output files written to {RUST_DIR}")
 
 
 if __name__ == "__main__":

--- a/tests/foxio_vectors/NOTICE
+++ b/tests/foxio_vectors/NOTICE
@@ -26,8 +26,19 @@ The subdirectory `wireshark_expected/` holds two more expected-output files:
 The FoxIO Python implementation emits no JA4D and no JA4D6, so the two files under
 `python/test/testdata` hold an empty array. The Wireshark dissector is the only FoxIO
 implementation that writes a reference value for the two methods.
-`docs/implementation_notes.md` records the reading. The conformance suite reads
-only the top level of this directory, so the subdirectory adds no case to it.
+`docs/implementation_notes.md` records the reading.
+
+The subdirectory `rust_expected/` holds one more expected-output file:
+
+    rust/ja4/src/snapshots/ja4__insta@quic-with-several-tls-frames.pcapng.snap
+        ->  tests/foxio_vectors/rust_expected/ja4__insta@quic-with-several-tls-frames.pcapng.snap
+
+The FoxIO Python implementation reads no ClientHello that several CRYPTO frames
+carry, so `python/test/testdata/quic-with-several-tls-frames.pcapng.json` holds an empty
+array. The FoxIO Rust implementation reads it and writes the JA4 value.
+
+The conformance suite reads only the top level of this directory, so neither
+subdirectory adds a case to it.
 
 To move to a newer upstream commit, change FOXIO_COMMIT in
 tests/download_test_vectors.py and run that script. The script rewrites this

--- a/tests/foxio_vectors/rust_expected/ja4__insta@quic-with-several-tls-frames.pcapng.snap
+++ b/tests/foxio_vectors/rust_expected/ja4__insta@quic-with-several-tls-frames.pcapng.snap
@@ -1,0 +1,13 @@
+---
+source: ja4/src/lib.rs
+expression: output
+---
+- stream: 0
+  transport: udp
+  src: 192.168.1.168
+  dst: 142.251.16.100
+  src_port: 55906
+  dst_port: 443
+  tls_server_name: ogs.google.com
+  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
+

--- a/tests/test_ja4_alpn.py
+++ b/tests/test_ja4_alpn.py
@@ -5,9 +5,16 @@ Spec: if first or last byte of the first ALPN value is not ASCII alnum
 hex representation of the FULL first ALPN string.
 """
 
+import json
+from pathlib import Path
+
 import pytest
 
 from ja4plus.fingerprinters.ja4 import compute_alpn_value
+
+VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+CAPTURE_PATH = VECTORS_DIR / "tls-non-ascii-alpn.pcapng"
+EXPECTED_PATH = VECTORS_DIR / "tls-non-ascii-alpn.pcapng.json"
 
 
 @pytest.mark.parametrize(
@@ -64,22 +71,59 @@ def test_compute_alpn_via_generate_ja4():
     assert part_a.endswith("3b"), f"got {part_a!r}"
 
 
-def test_compute_alpn_real_pcap_tls_non_ascii():
-    """If the FoxIO non-ASCII ALPN fixture is present, sanity-check the parse."""
-    import os
+def _reference_ja4():
+    """Return the JA4 value the FoxIO expected-output file holds for the capture.
+
+    Returns:
+        The `JA4.1` value of the first stream.
+
+    Raises:
+        FileNotFoundError: The expected-output file is absent.
+        AssertionError: The expected-output file names no stream.
+    """
+    with open(EXPECTED_PATH) as handle:
+        entries = json.load(handle)
+    # An empty file compares no value, and the assertion below passes on it. #115 exists
+    # to remove a test that reports a pass on nothing.
+    assert entries, "{} names no stream".format(EXPECTED_PATH)
+    return entries[0]["JA4.1"]
+
+
+def _produced_ja4():
+    """Return every JA4 value the fingerprinter produces from the FoxIO capture."""
     from scapy.all import rdpcap
+
     from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
 
-    path = "tests/foxio_vectors/pcap/tls-non-ascii-alpn.pcapng"
-    if not os.path.exists(path):
-        pytest.skip(f"fixture missing: {path}")
+    fingerprinter = JA4Fingerprinter()
+    produced = []
+    for packet in rdpcap(str(CAPTURE_PATH)):
+        fingerprint = fingerprinter.process_packet(packet)
+        if fingerprint:
+            produced.append(fingerprint)
+    return produced
 
-    fp_engine = JA4Fingerprinter()
-    pkts = rdpcap(path)
-    fingerprints = []
-    for pkt in pkts:
-        fp = fp_engine.process_packet(pkt)
-        if fp:
-            fingerprints.append(fp)
 
-    assert fingerprints, "no JA4 fingerprints produced from non-ascii ALPN pcap"
+def test_the_foxio_capture_carries_a_first_alpn_value_that_is_not_ascii():
+    """The first ALPN value of `tls-non-ascii-alpn.pcapng` is the two bytes `0xba 0xad`."""
+    from scapy.all import Raw, rdpcap
+
+    from ja4plus.utils.tls_utils import parse_tls_handshake
+
+    client_hellos = []
+    for packet in rdpcap(str(CAPTURE_PATH)):
+        if not packet.haslayer(Raw):
+            continue
+        info = parse_tls_handshake(bytes(packet[Raw].load))
+        if info and info.get("type") == "client_hello":
+            client_hellos.append(info)
+
+    assert len(client_hellos) == 1
+    # The parser keeps the ALPN bytes, because the ASCII decode drops the first value.
+    assert client_hellos[0]["alpn_raw"] == [b"\xba\xad", b"http/1.1"]
+    assert client_hellos[0]["alpn_protocols"] == ["", "http/1.1"]
+
+
+def test_the_foxio_capture_produces_the_reference_ja4_value():
+    """`tls-non-ascii-alpn.pcapng` produces the JA4 value the FoxIO reference holds."""
+    assert _produced_ja4() == [_reference_ja4()]

--- a/tests/test_ja4_alpn.py
+++ b/tests/test_ja4_alpn.py
@@ -83,8 +83,8 @@ def _reference_ja4():
     """
     with open(EXPECTED_PATH) as handle:
         entries = json.load(handle)
-    # An empty file compares no value, and the assertion below passes on it. #115 exists
-    # to remove a test that reports a pass on nothing.
+    # An empty file holds no reference value. This check names that cause, because the
+    # index below raises IndexError instead.
     assert entries, "{} names no stream".format(EXPECTED_PATH)
     return entries[0]["JA4.1"]
 

--- a/tests/test_ja4_alpn.py
+++ b/tests/test_ja4_alpn.py
@@ -124,6 +124,13 @@ def test_the_foxio_capture_carries_a_first_alpn_value_that_is_not_ascii():
     assert client_hellos[0]["alpn_protocols"] == ["", "http/1.1"]
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "issue #127: the FoxIO prose gives the hex characters `bd`, and two FoxIO "
+        "implementations give `99`."
+    ),
+)
 def test_the_foxio_capture_produces_the_reference_ja4_value():
     """`tls-non-ascii-alpn.pcapng` produces the JA4 value the FoxIO reference holds."""
     assert _produced_ja4() == [_reference_ja4()]

--- a/tests/test_ja4h_spec.py
+++ b/tests/test_ja4h_spec.py
@@ -110,8 +110,8 @@ def _reference_ja4h():
     with open(EXPECTED_PATH) as handle:
         entries = json.load(handle)
     values = [entry["JA4H"] for entry in entries if "JA4H" in entry]
-    # An empty list compares no value, and the assertion below passes on it. #115 exists
-    # to remove a test that reports a pass on nothing.
+    # Without this check, an empty list compares equal to an empty produced list, and the
+    # caller reports a pass on nothing. #115 exists to remove that defect.
     assert values, "{} holds no JA4H value".format(EXPECTED_PATH)
     return values
 

--- a/tests/test_ja4h_spec.py
+++ b/tests/test_ja4h_spec.py
@@ -5,11 +5,16 @@
 """
 
 import hashlib
-import os
+import json
+from pathlib import Path
 
 import pytest
 
 from ja4plus.fingerprinters.ja4h import _generate_ja4h_from_info, _http_version_to_str
+
+VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+CAPTURE_PATH = VECTORS_DIR / "http2-with-cookies.pcapng"
+EXPECTED_PATH = VECTORS_DIR / "http2-with-cookies.pcapng.json"
 
 
 @pytest.mark.parametrize(
@@ -92,30 +97,45 @@ def test_cookie_values_hash_input_form_is_name_value_pairs_sorted_by_name():
     assert fp.split("_")[-1] == expected
 
 
-@pytest.mark.skipif(
-    not os.path.exists("tests/foxio_vectors/pcap/http2-with-cookies.pcapng"),
-    reason="FoxIO http2-with-cookies fixture missing",
-)
-def test_http2_with_cookies_pcap_produces_20_in_part_a():
-    """Real pcap sanity check for HTTP/2 version mapping."""
+def _reference_ja4h():
+    """Return every JA4H value the FoxIO expected-output file holds, in file order.
+
+    Returns:
+        The list of `JA4H` values.
+
+    Raises:
+        FileNotFoundError: The expected-output file is absent.
+        AssertionError: The expected-output file holds no JA4H value.
+    """
+    with open(EXPECTED_PATH) as handle:
+        entries = json.load(handle)
+    values = [entry["JA4H"] for entry in entries if "JA4H" in entry]
+    # An empty list compares no value, and the assertion below passes on it. #115 exists
+    # to remove a test that reports a pass on nothing.
+    assert values, "{} holds no JA4H value".format(EXPECTED_PATH)
+    return values
+
+
+def _produced_ja4h():
+    """Return every JA4H value the fingerprinter produces from the FoxIO capture."""
     from scapy.all import rdpcap
+
     from ja4plus.fingerprinters.ja4h import JA4HFingerprinter
 
-    pkts = rdpcap("tests/foxio_vectors/pcap/http2-with-cookies.pcapng")
-    fp = JA4HFingerprinter()
-    seen = []
-    for pkt in pkts:
-        result = fp.process_packet(pkt)
-        if result:
-            seen.append(result)
+    fingerprinter = JA4HFingerprinter()
+    produced = []
+    for packet in rdpcap(str(CAPTURE_PATH)):
+        fingerprint = fingerprinter.process_packet(packet)
+        if fingerprint:
+            produced.append(fingerprint)
+    return produced
 
-    # Some HTTP/2 captures don't reassemble cleanly with our HTTP/1-style
-    # parser; we tolerate zero results but if any are produced, version
-    # must be '20'.
-    for fingerprint in seen:
-        # Part A: <method><ver><cookie><ref><cnt><lang> = e.g. 'ge2010...'
-        # method = 2 chars, version = 2 chars
-        version = fingerprint[2:4]
-        # http2 captures may also yield '11' if a fallback HTTP/1.1 parse
-        # happened — accept either as long as the structure is sane.
-        assert version in {"20", "11"}, f"unexpected version {version!r} in {fingerprint}"
+
+def test_every_reference_value_of_the_foxio_capture_carries_the_version_code_20():
+    """The FoxIO reference reads `20` as the version code of every request in the capture."""
+    assert [value[2:4] for value in _reference_ja4h()] == ["20"] * 15
+
+
+def test_the_foxio_capture_produces_the_reference_ja4h_values():
+    """`http2-with-cookies.pcapng` produces the JA4H values the FoxIO reference holds."""
+    assert _produced_ja4h() == _reference_ja4h()

--- a/tests/test_ja4h_spec.py
+++ b/tests/test_ja4h_spec.py
@@ -136,6 +136,30 @@ def test_every_reference_value_of_the_foxio_capture_carries_the_version_code_20(
     assert [value[2:4] for value in _reference_ja4h()] == ["20"] * 15
 
 
+def test_the_foxio_capture_carries_no_cleartext_http_request():
+    """Every HTTP request of `http2-with-cookies.pcapng` is inside a TLS record.
+
+    The capture carries a Decryption Secrets Block, and the FoxIO reference reads the 15
+    requests because it decrypts them. This test names the reason the comparison below
+    fails, so that a reader does not look for the cause in the JA4H parser.
+    """
+    from scapy.all import Raw, rdpcap
+
+    request_lines = []
+    for packet in rdpcap(str(CAPTURE_PATH)):
+        if packet.haslayer(Raw) and bytes(packet[Raw].load)[:4] in (b"GET ", b"POST", b"HTTP"):
+            request_lines.append(bytes(packet[Raw].load)[:16])
+
+    assert request_lines == []
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "issue #129: the reference decrypts the capture with the secrets it carries, and "
+        "ja4plus reads no encrypted request."
+    ),
+)
 def test_the_foxio_capture_produces_the_reference_ja4h_values():
     """`http2-with-cookies.pcapng` produces the JA4H values the FoxIO reference holds."""
     assert _produced_ja4h() == _reference_ja4h()

--- a/tests/test_quic_multipacket.py
+++ b/tests/test_quic_multipacket.py
@@ -150,8 +150,8 @@ def _reference_ja4():
         stripped = line.strip()
         if stripped.startswith("ja4: "):
             values.append(stripped[len("ja4: ") :])
-    # An empty list compares no value, and the assertion below passes on it. #115 exists
-    # to remove a test that reports a pass on nothing.
+    # Without this check, an empty list compares equal to an empty produced list, and the
+    # caller reports a pass on nothing. #115 exists to remove that defect.
     assert values, "{} holds no JA4 value".format(EXPECTED_PATH)
     return values
 

--- a/tests/test_quic_multipacket.py
+++ b/tests/test_quic_multipacket.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
 CAPTURE_PATH = VECTORS_DIR / "quic-with-several-tls-frames.pcapng"
-EXPECTED_PATH = VECTORS_DIR / "rust_expected" / "ja4__insta@quic-with-several-tls-frames.pcapng.snap"
+EXPECTED_PATH = (
+    VECTORS_DIR / "rust_expected" / "ja4__insta@quic-with-several-tls-frames.pcapng.snap"
+)
 
 
 def test_reassemble_crypto_fragments_basic():

--- a/tests/test_quic_multipacket.py
+++ b/tests/test_quic_multipacket.py
@@ -6,9 +6,11 @@ options), the CRYPTO frame is fragmented across multiple Initial
 packets sharing the same Destination Connection ID.
 """
 
-import os
+from pathlib import Path
 
-import pytest
+VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+CAPTURE_PATH = VECTORS_DIR / "quic-with-several-tls-frames.pcapng"
+EXPECTED_PATH = VECTORS_DIR / "rust_expected" / "ja4__insta@quic-with-several-tls-frames.pcapng.snap"
 
 
 def test_reassemble_crypto_fragments_basic():
@@ -129,22 +131,45 @@ def test_ja4_fingerprinter_buffers_quic_fragments():
         assert len(fp._quic_fragments[dcid.hex()]) == 2
 
 
-@pytest.mark.skipif(
-    not os.path.exists("tests/foxio_vectors/pcap/quic-with-several-tls-frames.pcapng"),
-    reason="quic-with-several-tls-frames fixture missing",
-)
-def test_quic_with_several_tls_frames_real_pcap():
-    """Real-world sanity: feed every UDP packet to the JA4 fingerprinter."""
+def _reference_ja4():
+    """Return every JA4 value the FoxIO Rust snapshot holds for the capture.
+
+    The snapshot writes one `ja4:` line for each stream that carries a value.
+
+    Returns:
+        The list of JA4 values, in file order.
+
+    Raises:
+        FileNotFoundError: The snapshot is absent.
+        AssertionError: The snapshot holds no JA4 value.
+    """
+    values = []
+    for line in EXPECTED_PATH.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("ja4: "):
+            values.append(stripped[len("ja4: ") :])
+    # An empty list compares no value, and the assertion below passes on it. #115 exists
+    # to remove a test that reports a pass on nothing.
+    assert values, "{} holds no JA4 value".format(EXPECTED_PATH)
+    return values
+
+
+def test_the_foxio_capture_produces_the_reference_ja4_value():
+    """`quic-with-several-tls-frames.pcapng` produces the JA4 value FoxIO holds.
+
+    The capture holds one QUIC Initial packet that carries the ClientHello in several
+    CRYPTO frames. A reader that joins no fragment produces nothing, so the match proves
+    that the reader joins them.
+    """
     from scapy.all import rdpcap
+
     from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
 
-    pkts = rdpcap("tests/foxio_vectors/pcap/quic-with-several-tls-frames.pcapng")
-    fp = JA4Fingerprinter()
-    fingerprints = []
-    for pkt in pkts:
-        r = fp.process_packet(pkt)
-        if r:
-            fingerprints.append(r)
-    # If the pcap contains a complete handshake we'll get one fingerprint;
-    # if not, we shouldn't crash, and the fragment buffer should be sane.
-    assert isinstance(fingerprints, list)
+    fingerprinter = JA4Fingerprinter()
+    produced = []
+    for packet in rdpcap(str(CAPTURE_PATH)):
+        fingerprint = fingerprinter.process_packet(packet)
+        if fingerprint:
+            produced.append(fingerprint)
+
+    assert produced == _reference_ja4()


### PR DESCRIPTION
## What

Three tests skipped on every run. Each one named a capture under
`tests/foxio_vectors/pcap/`, and this repository holds no such directory. All three now
run and compare a FoxIO reference value.

Refs #115.

## Why

A skipped test reads as a pass. This is the same defect as #109, which covered
`tests/test_ja4d_foxio.py` and `tests/test_ja4d6_foxio.py` alone.

## What each test skipped for

The plan asked for the cause of each skip. The three causes differ.

| Test | Capture | Reference material | Result |
|---|---|---|---|
| `tests/test_ja4_alpn.py` | `tls-non-ascii-alpn.pcapng` | Python, and Rust agrees | The value differs. #127 owns it. |
| `tests/test_ja4h_spec.py` | `http2-with-cookies.pcapng` | Python, 15 values | `ja4plus` reads no encrypted request. #129 owns it. |
| `tests/test_quic_multipacket.py` | `quic-with-several-tls-frames.pcapng` | Rust alone | `ja4plus` matches. |

Every capture was committed all along. Only the path was wrong.

## The QUIC test compares the FoxIO Rust snapshot

`python/test/testdata/quic-with-several-tls-frames.pcapng.json` holds `[]`, so the Python
material compares nothing. The capture holds one QUIC Initial packet, and that packet
carries the ClientHello in several CRYPTO frames. The FoxIO Python implementation reads
no ClientHello from it.

The FoxIO Rust implementation reads it and writes one value:

```
- stream: 0
  transport: udp
  src: 192.168.1.168
  dst: 142.251.16.100
  src_port: 55906
  dst_port: 443
  tls_server_name: ogs.google.com
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
```

`ja4plus` produces `q13d0310h3_55b375c5d22e_cd85d2d88918`. The two agree byte for byte.
This pull request commits that snapshot, without change, from the pinned upstream commit,
into the new `tests/foxio_vectors/rust_expected/`. `tests/download_test_vectors.py`
fetches it, and `.claude/rules/external-apis.md` records when a Rust snapshot carries the
authority: only where the Python file of the same capture holds an empty array. The
precedence everywhere else does not change.

**No expected value comes from `ja4plus` output.** Every value the three tests compare is
a verbatim copy of FoxIO material.

## Two comparisons fail, and each names its issue

Both carry `pytest.mark.xfail(strict=True)`. A strict marker turns a later pass into a
failure that names itself, so neither one can go quiet.

**#127 — the JA4 ALPN value of a first byte that is not ASCII.** The first ALPN value of
`tls-non-ascii-alpn.pcapng` is the two bytes `0xba 0xad`. The FoxIO prose in
`technical_details/JA4.md` gives the hex characters `bd`, which `ja4plus` produces. The
FoxIO Python implementation writes `'99'` when `ord(alpn[0]) > 127`, and the FoxIO Rust
implementation writes the same. Only the two ALPN characters differ; both hashes match.
`.claude/rules/conformance.md` states that a reference defect of this shape is a question
for the user, so #127 asks it. `docs/implementation_notes.md` claimed that `ja4plus`
writes `'99'`, which the code has not done since PR #277 landed. This pull request
corrects that section to the measurement.

**#129 — the JA4H values of a capture that carries TLS secrets.**
`http2-with-cookies.pcapng` carries a Decryption Secrets Block, and its 1607 packets hold
no cleartext HTTP request. The FoxIO reference reads the 15 requests because it decrypts
them. `ja4plus` decrypts no TLS record, so it reads none of them. #35 fixes a repeated
cookie name and the `HTTP/2` request line, and neither change reaches traffic that
`ja4plus` never decrypts. A second test,
`test_the_foxio_capture_carries_no_cleartext_http_request`, runs and passes, so the file
states that cause rather than leaving it in a comment.

## Issues opened

- #127 — Settle the JA4 ALPN value for a non-ASCII first byte.
- #128 — Correct the register causes that the evidence does not support. Seventeen JA4H
  entries name #35, which cannot make them pass.
- #129 — Decide whether `ja4plus` decrypts a capture that carries TLS secrets.

No register entry changes here. The register holds 67 entries on the base and 67 entries
on this branch. #128 owns the correction, and #121 is sequenced after this issue.

## How it is tested

**The tests came first.** Commit `4bd48ec` rewrites the three files with no marker and no
Rust snapshot. `pytest tests/test_ja4_alpn.py tests/test_ja4h_spec.py
tests/test_quic_multipacket.py` reports `3 failed, 34 passed`, and zero skipped. Commit
`0df5e05` adds the reference material and the two markers, and the same command reports
`36 passed, 2 xfailed`.

**Each comparison fails on a changed reference.** Three mutations, each reverted:

| Mutation | Result |
|---|---|
| One character changed in the Rust snapshot value | `FAILED ...::test_the_foxio_capture_produces_the_reference_ja4_value` |
| The `ja4:` line removed from the Rust snapshot | `FAILED ...::test_the_foxio_capture_produces_the_reference_ja4_value` |
| `t13d151699` changed to `t13d1516bd` in the Python file | `FAILED tests/test_ja4_alpn.py::test_the_foxio_capture_produces_the_reference_ja4_value` |

The third mutation is the strict marker at work. The comparison passed, and the strict
`xfail` turned that pass into a failure.

**No reference loader can pass on nothing.** Each one asserts that the file names a value.
The refresh script raises `ValueError: rust_expected/ja4__insta@quic-with-several-tls-frames.pcapng.snap holds no JA4 value` on a snapshot that holds no `ja4:` line.

**The refresh script reproduces the whole vector set.** `python tests/download_test_vectors.py`
rewrote all 39 committed files byte-identically and added the one new file, so the only
change under `tests/foxio_vectors/` is the new subdirectory and the NOTICE text.

## Local checks

```
pytest tests/ -m "not spec_validation"   756 passed, 2 xfailed, 0 skipped, 93 subtests passed
pytest tests/ -m spec_validation         631 passed, 141 skipped, 67 xfailed
ruff check ja4plus/ tests/               All checks passed!
ruff format --check ja4plus/ tests/      89 files already formatted
mypy ja4plus/                            Success: no issues found in 27 source files
```

The skip count falls from 3 to 0 in the unit suite. The pass count rises from 752 to 756:
three tests stop skipping, and three new tests state a fact that the reference material
supports. The conformance suite reports the same counts as the base.

Coverage rises. No line of `ja4plus/` changes in this pull request.

## Verified against

```
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/rust/ja4/src/snapshots/ja4__insta%40quic-with-several-tls-frames.pcapng.snap (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/rust/ja4/src/snapshots/ja4__insta%40tls-non-ascii-alpn.pcapng.snap (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/python/ja4.py (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/technical_details/JA4.md (retrieved 2026-08-06)
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/wireshark/test/testdata/quic-with-several-tls-frames.pcapng.json (retrieved 2026-08-06)
```
