### PR TITLE
Compute the JA4H raw form and compare it against JA4H_ro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **JA4H computes its raw form** (#131). FoxIO publishes one raw key for JA4H,
+  `JA4H_ro`, and `ja4plus` computed none, so 89 reference values reached no
+  comparison. Every JA4H result now carries `raw_original_order`, and the
+  fingerprinter carries `last_raw_original_order`, so the processor and the
+  command-line program report the value the way they report `JA4_ro`. The form is
+  `<part a>_<header names>_<cookie names>_<cookie pairs>`, and every list holds the
+  wire order. A request that carries no cookie ends after the header names and one
+  underscore. 79 of the 89 values now match. The other ten sit on a stream whose
+  hashed JA4H value fails too, and #129 and #35 own them. No hashed fingerprint
+  changed.
+
 ### Fixed
 
 - **JA4S tells a QUIC server Initial packet from a client one** (#118). `ja4plus`

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -23,7 +23,7 @@ about another method, so each row below names its own evidence. The counts come 
 |---|---|---|---|
 | JA4 | `JA4_r`, `JA4_ro` | `JA4_r` sorts the ciphers and the extensions. It holds the signature algorithms in wire order. `JA4_ro` holds every list in wire order. | 160 `JA4_r` values. 156 of them carry a signature-algorithm section, and all 156 hold the ciphers and the extensions in numeric order and the signature algorithms in an order that is not numeric. The other four carry no extension and no signature algorithm. No `JA4_ro` value equals its `JA4_r` value. |
 | JA4S | `JA4S_r` | The extensions stay in wire order. JA4S sorts no list. | 84 `JA4S_r` values. 35 of them hold the extensions in an order that is not numeric order, and `badcurveball.pcap.json` gives `t1205h1_c02b_0000,ff01,000b,0023,0010`. No file carries a `JA4S_ro` key. |
-| JA4H | `JA4H_ro` | Not measured. | 89 `JA4H_ro` values, and no `JA4H_r` value. `ja4plus` computes no JA4H raw form, so all 89 fail. #131 owns them. |
+| JA4H | `JA4H_ro` | Every list holds the wire order. `JA4H_ro` holds the header names, the cookie names and the cookie name-and-value pairs as the request carries them. | 89 `JA4H_ro` values, and no `JA4H_r` value. `http1-with-cookies.pcapng.json` gives `yummy_cookie,tasty_cookie`, which is not sorted order, and the hashed form of the same request sorts the two names. 79 of the 89 values match after #131. |
 | JA4X, JA4SSH, JA4L, JA4T, JA4TS, JA4D, JA4D6 | None | Not applicable. | No expected-output file carries a raw key for these methods. |
 
 **Location:** `ja4plus/fingerprinters/ja4.py`, `ja4plus/fingerprinters/ja4s.py`.
@@ -47,6 +47,16 @@ already reports a count defect, and the raw comparison adds a value comparison.
 | `JA4_o` | 160 | 145 | 15 | #13 for 11, #132 for 4 |
 | `JA4S_r` | 84 | 84 | 0 | None |
 | `JA4H_ro` | 89 | 0 | 89 | #131 |
+
+#131 landed the JA4H raw form. The second measurement, on `epic/12-spec-conformance`:
+
+| Raw key | Values | Match | Differ | Owner of the failures |
+|---|---|---|---|---|
+| `JA4H_ro` | 89 | 79 | 10 | #129 for 9, #35 for 1 |
+
+The ten failures sit on a stream whose hashed `JA4H` value fails too. Nine of them are the
+two captures that carry a Decryption Secrets Block, and `ja4plus` decrypts nothing. The
+last one is `http-empty-useragent.pcap`, which produces no JA4H value at all.
 
 `JA4_o` holds a hash of the original-order fields rather than a raw form. The reference
 publishes it beside `JA4_ro`, so the suite compares it the same way.
@@ -610,6 +620,30 @@ which could corrupt streams with out-of-order TCP segments.
 ---
 
 ## JA4H - HTTP
+
+### The raw form holds the wire order
+
+FoxIO publishes one raw key for JA4H, `JA4H_ro`, and no `JA4H_r` key. `ja4plus` therefore
+computes one JA4H raw form. A sorted raw form matches no reference value and no other
+implementation, so the fingerprinter emits none.
+
+The form is `<part a>_<header names>_<cookie names>_<cookie pairs>`. A request that
+carries no cookie ends after the header names and one underscore, as
+`http1.pcapng.json` writes it:
+
+```
+po11nn050000_Host,Accept,User-Agent,Content-Type,Content-Length_
+ge11cr04da00_Host,User-Agent,Accept,Accept-Language_yummy_cookie,tasty_cookie_yummy_cookie=choco,tasty_cookie=strawberry
+```
+
+The header list drops the Cookie header, the Referer header and an HTTP/2
+pseudo-header, because the first section already reports the first two and the reference
+lists no pseudo-header. The hashed form and the raw form read one header list, so the raw
+form explains the hash.
+
+**Vector:** `http1-with-cookies.pcapng` and the 56 values of `http1.pcapng`.
+
+**Location:** `ja4plus/fingerprinters/ja4h.py`.
 
 ### TCP reassembly
 

--- a/ja4plus/fingerprinters/ja4h.py
+++ b/ja4plus/fingerprinters/ja4h.py
@@ -50,11 +50,17 @@ class JA4HFingerprinter(BaseFingerprinter):
 
     Supports HTTP requests spanning multiple TCP segments via
     stream reassembly.
+
+    Every entry of ``get_fingerprints()`` carries ``raw_original_order``, the FoxIO
+    `JA4H_ro` value, and ``last_raw_original_order`` holds the value of the most recent
+    request. FoxIO publishes no `JA4H_r` key, so this fingerprinter computes no sorted
+    raw form: a sorted value matches no reference value and no other implementation.
     """
 
     def __init__(self):
         super().__init__()
         self.reassembler = TCPStreamReassembler(max_streams=100)
+        self.last_raw_original_order = None
 
     def process_packet(self, packet):
         """
@@ -82,9 +88,12 @@ class JA4HFingerprinter(BaseFingerprinter):
         # Try to parse HTTP from reassembled stream
         if not is_http_request(stream_data):
             # Also try the single packet (backward compat)
-            fingerprint = generate_ja4h(packet)
+            http_info = extract_http_info(packet)
+            if not http_info:
+                return None
+            fingerprint = _generate_ja4h_from_info(http_info)
             if fingerprint:
-                self.add_fingerprint(fingerprint, packet)
+                self._record(fingerprint, http_info, packet)
                 return fingerprint
             return None
 
@@ -98,15 +107,28 @@ class JA4HFingerprinter(BaseFingerprinter):
 
         fingerprint = _generate_ja4h_from_info(http_info)
         if fingerprint:
-            self.add_fingerprint(fingerprint, packet)
+            self._record(fingerprint, http_info, packet)
             self.reassembler.remove_stream(stream_key)
             return fingerprint
 
         return None
 
+    def _record(self, fingerprint, http_info, packet):
+        """Append one JA4H result, with the raw original-order form beside the hash."""
+        raw_original_order = _generate_ja4h_raw_from_info(http_info)
+        self.last_raw_original_order = raw_original_order
+        self.fingerprints.append(
+            {
+                "fingerprint": fingerprint,
+                "raw_original_order": raw_original_order,
+                "packet": packet,
+            }
+        )
+
     def reset(self):
         super().reset()
         self.reassembler = TCPStreamReassembler(max_streams=100)
+        self.last_raw_original_order = None
 
     def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
         """Remove TCP stream buffer for the given connection."""
@@ -202,41 +224,68 @@ def _convert_parsed_to_extract_format(parsed):
     }
 
 
+def _ja4h_part_a(http_info):
+    """Return the first section of a JA4H fingerprint.
+
+    Args:
+        http_info: A parsed HTTP request.
+
+    Returns:
+        The 12-character section that names the method, the version, the cookie flag,
+        the referer flag, the header count and the language.
+    """
+    method = http_info.get("method", "").lower()
+    version_str = _http_version_to_str(http_info.get("version", ""))
+
+    has_cookie = "c" if http_info.get("cookie_fields", []) else "n"
+    has_referer = "r" if http_info.get("referer", "") else "n"
+
+    header_count = 0
+    for header in http_info.get("headers", []):
+        if header.lower() not in ["cookie", "referer"]:
+            header_count += 1
+    header_count = min(header_count, 99)
+    header_count_str = f"{header_count:02d}"
+
+    language = http_info.get("language", "")
+    lang_code = "0000"
+    if language:
+        lang_clean = language.replace("-", "").replace(";", ",").lower().split(",")[0]
+        lang_clean = lang_clean[:4]
+        lang_code = f"{lang_clean}{'0' * (4 - len(lang_clean))}" if lang_clean else "0000"
+
+    return f"{method[:2]}{version_str}{has_cookie}{has_referer}{header_count_str}{lang_code}"
+
+
+def _ja4h_header_names(http_info):
+    """Return the header names that the second section of a JA4H fingerprint holds.
+
+    The hashed form and the raw form read one list, so the raw form explains the hash.
+
+    Args:
+        http_info: A parsed HTTP request.
+
+    Returns:
+        The header names in wire order. The list drops the Cookie header and the Referer
+        header, because the first section already reports both, and it drops an HTTP/2
+        pseudo-header, because the reference lists none.
+    """
+    return [
+        h
+        for h in http_info.get("headers", [])
+        if h and not h.startswith(":") and h.lower() != "cookie" and h.lower() != "referer"
+    ]
+
+
 def _generate_ja4h_from_info(http_info):
     """Generate JA4H from an http_info dict."""
     if not http_info:
         return None
 
     try:
-        method = http_info.get("method", "").lower()
-        version_str = _http_version_to_str(http_info.get("version", ""))
+        part_a = _ja4h_part_a(http_info)
 
-        has_cookie = "c" if http_info.get("cookie_fields", []) else "n"
-        has_referer = "r" if http_info.get("referer", "") else "n"
-
-        header_count = 0
-        for header in http_info.get("headers", []):
-            if header.lower() not in ["cookie", "referer"]:
-                header_count += 1
-        header_count = min(header_count, 99)
-        header_count_str = f"{header_count:02d}"
-
-        language = http_info.get("language", "")
-        lang_code = "0000"
-        if language:
-            lang_clean = language.replace("-", "").replace(";", ",").lower().split(",")[0]
-            lang_clean = lang_clean[:4]
-            lang_code = f"{lang_clean}{'0' * (4 - len(lang_clean))}" if lang_clean else "0000"
-
-        part_a = f"{method[:2]}{version_str}{has_cookie}{has_referer}{header_count_str}{lang_code}"
-
-        headers = http_info.get("headers", [])
-        filtered_headers = [
-            h
-            for h in headers
-            if not h.startswith(":") and h.lower() != "cookie" and h.lower() != "referer" and h
-        ]
-        headers_str = ",".join(filtered_headers)
+        headers_str = ",".join(_ja4h_header_names(http_info))
         part_b = (
             hashlib.sha256(headers_str.encode()).hexdigest()[:12] if headers_str else "000000000000"
         )
@@ -262,6 +311,41 @@ def _generate_ja4h_from_info(http_info):
         )
 
         return f"{part_a}_{part_b}_{part_c}_{part_d}"
+
+    except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
+        logger.debug(f"Packet does not contain JA4H data: {e}")
+        return None
+
+
+def _generate_ja4h_raw_from_info(http_info):
+    """Return the JA4H raw original-order form of an http_info dict.
+
+    The form is `<part a>_<header names>_<cookie names>_<cookie pairs>`. Each list holds
+    the wire order, which is what makes the value the original-order form. A request that
+    carries no cookie ends after the header names and one underscore, as the FoxIO
+    reference writes it.
+
+    Args:
+        http_info: A parsed HTTP request.
+
+    Returns:
+        The FoxIO `JA4H_ro` value, or None when the request is unreadable.
+    """
+    if not http_info:
+        return None
+
+    try:
+        part_a = _ja4h_part_a(http_info)
+        headers_str = ",".join(_ja4h_header_names(http_info))
+        raw = f"{part_a}_{headers_str}_"
+
+        cookie_fields = http_info.get("cookie_fields", [])
+        if cookie_fields:
+            cookie_values = http_info.get("cookie_values", [])
+            pairs_str = ",".join(f"{k}={v}" for k, v in zip(cookie_fields, cookie_values))
+            raw += f"{','.join(cookie_fields)}_{pairs_str}"
+
+        return raw
 
     except (ValueError, TypeError, IndexError, KeyError, AttributeError) as e:
         logger.debug(f"Packet does not contain JA4H data: {e}")

--- a/tests/conformance_index.py
+++ b/tests/conformance_index.py
@@ -35,8 +35,7 @@ logger = logging.getLogger(__name__)
 # form. `JA4_o` holds a hash of the original-order fields rather than a raw form, and the
 # reference publishes it beside `JA4_ro`, so the index treats the two the same way.
 #
-# JA4H is absent because ja4plus computes no JA4H raw form. #131 owns the 89 `JA4H_ro`
-# values the reference publishes.
+# JA4H names only `JA4H_ro`, because the reference publishes no `JA4H_r` key.
 RAW_METHODS = {
     "JA4": (
         ("JA4_r", "raw"),
@@ -44,6 +43,7 @@ RAW_METHODS = {
         ("JA4_o", "fingerprint_original_order"),
     ),
     "JA4S": (("JA4S_r", "raw"),),
+    "JA4H": (("JA4H_ro", "raw_original_order"),),
 }
 
 # The methods the conformance suite reports. One fingerprinter produces one method,

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -1,19 +1,11 @@
 {
-  "CVE-2018-6794.pcap/0:8089/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "CVE-2018-6794.pcap/1:8089/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
   "CVE-2018-6794.pcap/JA4H": {
     "cause": "ja4plus produces no JA4H fingerprint the reference holds.",
     "issue": 35
   },
   "CVE-2018-6794.pcap/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "ja4plus produces no JA4H fingerprint the reference holds.",
+    "issue": 35
   },
   "CVE-2018-6794.pcap/JA4L-C": {
     "cause": "ja4plus emits more JA4L-C values than the reference holds.",
@@ -28,8 +20,8 @@
     "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4X.1": {
     "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
@@ -48,8 +40,8 @@
     "issue": 35
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4S": {
     "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. The reference reads no QUIC handshake on the stream whose source port is 50280, and the JA4 entry of this vector names the same stream.",
@@ -84,252 +76,16 @@
     "issue": 35
   },
   "http-empty-useragent.pcap/0:57722/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "ja4plus produces no JA4H value on this stream.",
+    "issue": 35
   },
   "http-empty-useragent.pcap/JA4H": {
     "cause": "ja4plus produces no JA4H fingerprint the reference holds.",
     "issue": 35
   },
   "http-empty-useragent.pcap/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1-with-cookies.pcapng/0:61256/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1-with-cookies.pcapng/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/0:48456/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/10:45050/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/11:48466/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/12:48468/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/13:45052/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/14:48470/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/15:45054/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/16:48472/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/18:48476/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/19:45056/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/1:45042/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/20:48478/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/21:48480/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/22:38660/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/23:41355/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/24:39698/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/25:44238/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/26:44239/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/27:44240/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/28:44241/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/29:44242/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/2:48458/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/30:44243/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/31:44244/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/32:44245/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/33:44250/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/34:44251/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/35:44252/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/36:44253/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/37:44254/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/38:44255/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/39:44256/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/3:45044/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/40:44257/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/41:45058/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/42:48482/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/43:48484/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/44:48486/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/45:45060/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/46:40978/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/47:60164/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/48:60180/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/49:60186/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/4:56404/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/4:56404/JA4H_ro.2": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/50:60200/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/51:45062/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/52:60204/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/53:60220/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/54:60222/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/55:60230/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/5:48460/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/6:45046/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/7:48462/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/8:45048/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/9:48464/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "http1.pcapng/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "ja4plus produces no JA4H fingerprint the reference holds.",
+    "issue": 35
   },
   "http2-with-cookies.pcapng/0:58847/JA4H.1": {
     "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
@@ -392,64 +148,64 @@
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.10": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.11": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.12": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.13": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.14": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.15": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.2": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.3": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.4": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.5": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.6": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.7": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.8": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.9": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.1": {
     "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
@@ -468,24 +224,16 @@
     "issue": 129
   },
   "http2-with-cookies.pcapng/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
+    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "http2-with-cookies.pcapng/JA4X": {
     "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
     "issue": 78
   },
-  "https-connect.pcap/0:54723/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
   "https-connect.pcap/JA4": {
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
     "issue": 13
-  },
-  "https-connect.pcap/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
   },
   "https-connect.pcap/JA4L-C": {
     "cause": "ja4plus emits more JA4L-C values than the reference holds.",
@@ -507,14 +255,6 @@
     "cause": "The client hello carries SNI as its only extension, and the reference gives 000000000000 as the JA4_o extension hash.",
     "issue": 132
   },
-  "latest.pcapng/6:52939/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "latest.pcapng/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
   "quic-tls-handshake.pcapng/JA4": {
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
     "issue": 13
@@ -522,42 +262,6 @@
   "quic-with-several-tls-frames.pcapng/JA4": {
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
     "issue": 13
-  },
-  "single-packets.pcap/0:49677/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "single-packets.pcap/1:49654/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "single-packets.pcap/2:49683/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "single-packets.pcap/3:49708/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "single-packets.pcap/4:49735/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "single-packets.pcap/5:49733/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "single-packets.pcap/6:49743/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "single-packets.pcap/7:49738/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "single-packets.pcap/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
   },
   "socks-https-example.pcap/0:53554/JA4_o.1": {
     "cause": "The client hello carries SNI as its only extension, and the reference gives 000000000000 as the JA4_o extension hash.",
@@ -599,21 +303,9 @@
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets.",
     "issue": 97
   },
-  "ssh2.pcapng/15:57380/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
-  "ssh2.pcapng/22:57396/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
   "ssh2.pcapng/JA4": {
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
     "issue": 13
-  },
-  "ssh2.pcapng/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
   },
   "ssh2.pcapng/JA4L-S": {
     "cause": "ja4plus emits more JA4L-S values than the reference holds.",
@@ -867,17 +559,9 @@
     "cause": "ja4plus produces no JA4_ro fingerprint the reference holds.",
     "issue": 13
   },
-  "tls3.pcapng/8:63249/JA4H_ro.1": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
-  },
   "tls3.pcapng/JA4": {
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
     "issue": 13
-  },
-  "tls3.pcapng/JA4H_ro": {
-    "cause": "ja4plus computes no JA4H raw form.",
-    "issue": 131
   },
   "tls3.pcapng/JA4S": {
     "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. The reference reads no QUIC handshake on the six streams the JA4 entry of this vector names.",

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -20,7 +20,7 @@
     "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H_ro.1": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the QUIC traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4X.1": {
@@ -40,7 +40,7 @@
     "issue": 35
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4H_ro": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the QUIC traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4S": {
@@ -148,63 +148,63 @@
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.1": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.10": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.11": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.12": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.13": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.14": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.15": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.2": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.3": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.4": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.5": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.6": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.7": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.8": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4H_ro.9": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.1": {
@@ -224,7 +224,7 @@
     "issue": 129
   },
   "http2-with-cookies.pcapng/JA4H_ro": {
-    "cause": "the reference decrypts the capture with the secrets it carries, and ja4plus reads no encrypted request.",
+    "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "http2-with-cookies.pcapng/JA4X": {

--- a/tests/test_foxio_deviations.py
+++ b/tests/test_foxio_deviations.py
@@ -114,11 +114,16 @@ class TestTheCommittedRegister:
 
 # Two vectors carry a Decryption Secrets Block, and the reference reads the HTTP
 # messages that the block decrypts. ja4plus reads no key material, so issue #129 owns
-# every JA4H case of those two vectors.
+# every JA4H case of those two vectors, the hashed form and the raw form alike.
 ENCRYPTED_HTTP_KEYS = (
-    ["http2-with-cookies.pcapng/JA4H"]
+    ["http2-with-cookies.pcapng/JA4H", "http2-with-cookies.pcapng/JA4H_ro"]
     + ["http2-with-cookies.pcapng/0:58847/JA4H.{}".format(count) for count in range(1, 16)]
-    + ["chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H.1"]
+    + ["http2-with-cookies.pcapng/0:58847/JA4H_ro.{}".format(count) for count in range(1, 16)]
+    + [
+        "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H.1",
+        "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H_ro.1",
+        "chrome-cloudflare-quic-with-secrets.pcapng/JA4H_ro",
+    ]
 )
 
 
@@ -133,5 +138,10 @@ class TestTheEncryptedHttpDeviations:
     def test_the_entry_states_that_ja4plus_reads_no_encrypted_request(self, key):
         assert "reads no encrypted request" in load_register()[key].cause
 
-    def test_the_cleartext_http1_vector_keeps_its_own_issue(self):
-        assert load_register()["http1-with-cookies.pcapng/JA4H_ro"].issue == 131
+    def test_the_cleartext_http1_vector_carries_no_entry(self):
+        """#131 computed the JA4H raw form, so the cleartext vector matches and left.
+
+        The check exists to prove that the entries above name the encrypted vectors
+        alone. A cleartext vector that reappears here is a defect.
+        """
+        assert "http1-with-cookies.pcapng/JA4H_ro" not in load_register()

--- a/tests/test_ja4h_raw.py
+++ b/tests/test_ja4h_raw.py
@@ -1,0 +1,179 @@
+"""The JA4H raw form, measured against the FoxIO reference.
+
+FoxIO publishes one raw key for JA4H, `JA4H_ro`. It holds the wire order of the header
+names, of the cookie names, and of the cookie name-and-value pairs. FoxIO publishes no
+`JA4H_r` key, so this project computes no sorted JA4H raw form.
+
+The form is `<part a>_<header names>_<cookie names>_<cookie pairs>`. A request that
+carries no cookie ends after the header names and one underscore.
+
+Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4h.py (retrieved
+2026-08-07) and the expected-output files under `tests/foxio_vectors/`.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ja4plus.fingerprinters.ja4h import (
+    JA4HFingerprinter,
+    _generate_ja4h_raw_from_info,
+)
+
+VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
+
+# Two cleartext HTTP vectors. `http2-with-cookies.pcapng` and
+# `chrome-cloudflare-quic-with-secrets.pcapng` carry a Decryption Secrets Block, and
+# ja4plus decrypts nothing, so #129 owns them. `http-empty-useragent.pcap` produces no
+# JA4H value at all, which #35 owns.
+COOKIE_VECTOR = "http1-with-cookies.pcapng"
+MANY_REQUEST_VECTOR = "http1.pcapng"
+
+
+def _info(method="GET", version="HTTP/1.1", headers=None, cookie_pairs=None, language=""):
+    """Return one http_info dict, with the cookies in the order given."""
+    cookie_pairs = cookie_pairs or []
+    return {
+        "method": method,
+        "path": "/",
+        "version": version,
+        "headers": headers or [],
+        "cookies": dict(cookie_pairs),
+        "cookie_fields": [name for name, _ in cookie_pairs],
+        "cookie_values": [value for _, value in cookie_pairs],
+        "language": language,
+        "referer": "",
+    }
+
+
+def _reference_values(vector, key):
+    """Return every value the FoxIO expected-output file holds for one key, in order."""
+    with open(VECTORS_DIR / "{}.json".format(vector)) as handle:
+        entries = json.load(handle)
+    values = [entry[key] for entry in entries if key in entry]
+    # An empty list compares equal to an empty produced list, so the caller would report
+    # a pass on nothing.
+    assert values, "{}.json holds no {} value".format(vector, key)
+    return values
+
+
+def _produced_raw(vector):
+    """Return every JA4H raw original-order value the fingerprinter reads from a capture."""
+    from scapy.all import rdpcap
+
+    fingerprinter = JA4HFingerprinter()
+    for packet in rdpcap(str(VECTORS_DIR / vector)):
+        fingerprinter.process_packet(packet)
+    return [entry["raw_original_order"] for entry in fingerprinter.get_fingerprints()]
+
+
+# ---------------------------------------------------------------------------
+# The form
+# ---------------------------------------------------------------------------
+
+
+def test_the_raw_form_holds_the_header_names_in_wire_order():
+    raw = _generate_ja4h_raw_from_info(_info(headers=["Host", "User-Agent", "Accept"]))
+    assert raw == "ge11nn030000_Host,User-Agent,Accept_"
+
+
+def test_the_raw_form_ends_after_the_header_names_when_no_cookie_is_present():
+    """A request with no cookie carries no cookie section, and one trailing underscore.
+
+    `http1.pcapng.json` gives
+    `po11nn050000_Host,Accept,User-Agent,Content-Type,Content-Length_` for such a request.
+    """
+    raw = _generate_ja4h_raw_from_info(_info(headers=["Host"]))
+    assert raw.endswith("_Host_")
+    assert raw.count("_") == 2
+
+
+def test_the_raw_form_drops_the_cookie_header_and_the_referer_header():
+    raw = _generate_ja4h_raw_from_info(
+        _info(headers=["Host", "Cookie", "Referer", "Accept"], cookie_pairs=[("a", "1")])
+    )
+    assert raw.split("_")[1] == "Host,Accept"
+
+
+def test_the_raw_form_drops_an_http2_pseudo_header():
+    """The reference lists no `:method` name.
+
+    `latest.pcapng.json` gives `ge20cn13enus_upgrade-insecure-requests,user-agent,...`.
+    """
+    raw = _generate_ja4h_raw_from_info(
+        _info(version="HTTP/2", headers=[":method", ":path", "user-agent"])
+    )
+    assert raw.split("_")[1] == "user-agent"
+
+
+def test_the_raw_form_holds_the_cookie_names_in_wire_order():
+    """The hashed form sorts the cookie names, and the raw original-order form does not.
+
+    `http1-with-cookies.pcapng.json` gives `yummy_cookie,tasty_cookie`, which is not
+    sorted order.
+    """
+    raw = _generate_ja4h_raw_from_info(
+        _info(headers=["Host"], cookie_pairs=[("zeta", "z"), ("alpha", "a")])
+    )
+    assert raw.endswith("_zeta,alpha_zeta=z,alpha=a")
+
+
+def test_the_raw_form_holds_one_name_and_value_pair_for_each_cookie():
+    raw = _generate_ja4h_raw_from_info(
+        _info(headers=["Host"], cookie_pairs=[("a", "1"), ("b", "2")])
+    )
+    assert raw == "ge11cn010000_Host_a,b_a=1,b=2"
+
+
+def test_the_raw_form_keeps_a_repeated_cookie_name():
+    """Two cookies of one name are two entries on the wire, and the raw form holds both."""
+    raw = _generate_ja4h_raw_from_info(
+        _info(headers=["Host"], cookie_pairs=[("a", "1"), ("a", "2")])
+    )
+    assert raw.endswith("_a,a_a=1,a=2")
+
+
+def test_the_raw_form_reports_nothing_for_an_empty_info():
+    assert _generate_ja4h_raw_from_info(None) is None
+
+
+# ---------------------------------------------------------------------------
+# The FoxIO vectors
+# ---------------------------------------------------------------------------
+
+
+def test_the_cookie_vector_produces_the_reference_raw_value():
+    """`http1-with-cookies.pcapng` produces the `JA4H_ro` value the reference holds."""
+    assert _produced_raw(COOKIE_VECTOR) == _reference_values(COOKIE_VECTOR, "JA4H_ro")
+
+
+def test_the_many_request_vector_produces_every_reference_raw_value():
+    """`http1.pcapng` produces the 56 `JA4H_ro` values the reference holds, in order."""
+    assert _produced_raw(MANY_REQUEST_VECTOR) == _reference_values(MANY_REQUEST_VECTOR, "JA4H_ro")
+
+
+def test_the_fingerprinter_reports_the_raw_value_of_the_last_request():
+    """The processor and the command-line program read `last_raw_original_order`."""
+    from scapy.all import rdpcap
+
+    fingerprinter = JA4HFingerprinter()
+    for packet in rdpcap(str(VECTORS_DIR / COOKIE_VECTOR)):
+        fingerprinter.process_packet(packet)
+    assert fingerprinter.last_raw_original_order == _reference_values(COOKIE_VECTOR, "JA4H_ro")[-1]
+
+
+def test_the_fingerprinter_reports_no_raw_value_before_it_reads_a_request():
+    assert JA4HFingerprinter().last_raw_original_order is None
+
+
+@pytest.mark.parametrize("vector", [COOKIE_VECTOR, MANY_REQUEST_VECTOR])
+def test_the_raw_value_and_the_hashed_value_share_one_part_a(vector):
+    """The raw form explains the hash, so the two forms hold one first section."""
+    from scapy.all import rdpcap
+
+    fingerprinter = JA4HFingerprinter()
+    for packet in rdpcap(str(VECTORS_DIR / vector)):
+        fingerprinter.process_packet(packet)
+    for entry in fingerprinter.get_fingerprints():
+        assert entry["raw_original_order"].split("_")[0] == entry["fingerprint"].split("_")[0]

--- a/tests/test_spec_validation.py
+++ b/tests/test_spec_validation.py
@@ -288,7 +288,7 @@ class TestConformanceIndex:
         assert stream.methods["JA4_r"] == {1: "t13d1715h2_002f,0035_0005,000a_0403"}
 
     def test_the_raw_method_map_names_only_a_key_the_reference_publishes(self):
-        published = {"JA4_r", "JA4_ro", "JA4_o", "JA4S_r"}
+        published = {"JA4_r", "JA4_ro", "JA4_o", "JA4S_r", "JA4H_ro"}
         named = {method for pairs in RAW_METHODS.values() for method, _ in pairs}
         assert named == published
 
@@ -345,14 +345,15 @@ class TestConformanceIndex:
 def test_the_produced_index_holds_every_raw_form_ja4plus_computes():
     """Read the raw keys of one vector out of the produced index.
 
-    `tls-alpn-h2.pcap` carries one client hello and one server hello, so it exercises
-    every raw key ja4plus computes.
+    `tls-alpn-h2.pcap` carries one client hello and one server hello, and
+    `http1-with-cookies.pcapng` carries one HTTP request, so the two exercise every raw
+    key ja4plus computes.
     """
-    produced = index_produced(VECTORS_DIR / "tls-alpn-h2.pcap")
     methods = set()
-    for values in produced.values():
-        methods.update(values)
-    assert {"JA4_r", "JA4_ro", "JA4_o", "JA4S_r"} <= methods
+    for vector in ("tls-alpn-h2.pcap", "http1-with-cookies.pcapng"):
+        for values in index_produced(VECTORS_DIR / vector).values():
+            methods.update(values)
+    assert {"JA4_r", "JA4_ro", "JA4_o", "JA4S_r", "JA4H_ro"} <= methods
 
 
 @pytest.mark.spec_validation


### PR DESCRIPTION
Closes #131.

Rebased onto `epic/12-spec-conformance` at `0e8abd8`, after #129 landed.

## What changed

FoxIO publishes one raw key for JA4H, `JA4H_ro`, and no `JA4H_r` key. `ja4plus`
computed no JA4H raw form, so 89 reference values reached no comparison and 100
register entries recorded it.

- `ja4plus/fingerprinters/ja4h.py` gains `_generate_ja4h_raw_from_info`. Every entry
  of `get_fingerprints()` now carries `raw_original_order`, and the fingerprinter
  carries `last_raw_original_order`. The processor and the command-line program
  already read both names, so `JA4H_ro` reaches a caller with no change to either.
- `_ja4h_part_a` and `_ja4h_header_names` now hold the two sections that the hashed
  form and the raw form share. The raw form therefore explains the hash. **No hashed
  fingerprint changed.**
- `tests/conformance_index.py` names `("JA4H_ro", "raw_original_order")` in
  `RAW_METHODS`, so the conformance suite compares the value.
- `tests/foxio_deviations.json` drops 79 entries and re-points 21.

## The form

```
<part a>_<header names>_<cookie names>_<cookie pairs>
```

Every list holds the wire order, which is what makes the value the original-order
form. The hashed form sorts the cookie names and the cookie pairs, and the raw form
does not. A request that carries no cookie ends after the header names and one
underscore.

```
po11nn050000_Host,Accept,User-Agent,Content-Type,Content-Length_
ge11cr04da00_Host,User-Agent,Accept,Accept-Language_yummy_cookie,tasty_cookie_yummy_cookie=choco,tasty_cookie=strawberry
```

The header list drops the Cookie header, the Referer header and an HTTP/2
pseudo-header. The first section already reports the first two, and the reference
lists no pseudo-header.

## The measurement

| Raw key | Values | Match | Differ | Owner of the failures |
|---|---|---|---|---|
| `JA4H_ro` | 89 | 79 | 10 | #129 for 9, #35 for 1 |

Seven of the eleven vectors that carry a `JA4H_ro` value now match every value on
every stream: `http1.pcapng` (56), `single-packets.pcap` (8), `ssh2.pcapng` (2),
`CVE-2018-6794.pcap` (2), `http1-with-cookies.pcapng`, `https-connect.pcap`,
`latest.pcapng` and `tls3.pcapng`.

The ten failures sit on a stream whose hashed `JA4H` value fails too, so this change
adds no new defect:

- `http2-with-cookies.pcapng` (15) and `chrome-cloudflare-quic-with-secrets.pcapng`
  (1) carry a Decryption Secrets Block, and `ja4plus` decrypts nothing. **#129.**
- `http-empty-useragent.pcap` (1) produces no JA4H value at all. **#35.**
- Three occurrence-key cases go with them, plus `CVE-2018-6794.pcap/JA4H_ro`, which
  reports the same over-production the existing `CVE-2018-6794.pcap/JA4H` entry
  reports. **#35.**

## What the rebase onto #129 changed

#129 re-pointed every hashed JA4H key of the two encrypted vectors at itself. The
second commit here follows it:

- The 18 `JA4H_ro` entries of those two vectors read the cause #129 wrote, one for
  the QUIC capture and one for the TLS 1.3 capture. Each raw key now names the same
  issue and the same mechanism as its hashed sibling.
- `ENCRYPTED_HTTP_KEYS` in `tests/test_foxio_deviations.py` names the raw keys beside
  the hashed keys, so the two #129 checks cover both forms.
- **`test_the_cleartext_http1_vector_keeps_its_own_issue` needed a change.** It
  asserted `load_register()["http1-with-cookies.pcapng/JA4H_ro"].issue == 131`, and
  this branch removes that key, because the vector now matches its reference value.
  Left alone it raises `KeyError`. It reads the absence instead and keeps its
  purpose: a cleartext vector that reappears in the register is a defect.

## Tests

`tests/test_ja4h_raw.py` is new. Eight cases fix the form, and four measure the two
FoxIO captures whose `JA4H_ro` values `ja4plus` reads: `http1-with-cookies.pcapng`
and the 56 values of `http1.pcapng`.

```
pytest tests/                            2138 passed, 141 skipped, 149 xfailed, 93 subtests
ruff check ja4plus/ tests/               All checks passed
ruff format --check ja4plus/ tests/      91 files already formatted
mypy ja4plus/                            Success: no issues found in 27 source files
```

Verified against: https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4h.py (retrieved 2026-08-07)
Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata (retrieved 2026-08-07)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
