### PR TITLE
Repoint the register entries that name an epic or a closed issue

### DIFF
--- a/tests/foxio_deviation_owners.json
+++ b/tests/foxio_deviation_owners.json
@@ -1,0 +1,61 @@
+{
+  "owners": {
+    "105": {
+      "epic": false,
+      "state": "closed",
+      "title": "Record the JA4SSH divergence on the connection the reference indexes as stream zero"
+    },
+    "129": {
+      "epic": false,
+      "state": "open",
+      "title": "Decide whether ja4plus decrypts a capture that carries TLS secrets"
+    },
+    "13": {
+      "epic": true,
+      "state": "open",
+      "title": "Epic 2: Correctness audit"
+    },
+    "131": {
+      "epic": false,
+      "state": "open",
+      "title": "Compute the JA4H raw form and compare it against JA4H_ro"
+    },
+    "132": {
+      "epic": false,
+      "state": "open",
+      "title": "Settle the JA4_o extension hash when only SNI is present"
+    },
+    "137": {
+      "epic": false,
+      "state": "open",
+      "title": "Produce the JA4 values the reference holds on tls-handshake.pcapng and tls-sni.pcapng"
+    },
+    "138": {
+      "epic": false,
+      "state": "open",
+      "title": "Settle whether ja4plus emits a fingerprint on a stream the FoxIO reference ignores"
+    },
+    "34": {
+      "epic": false,
+      "state": "open",
+      "title": "Emit one JA4L client fingerprint per connection"
+    },
+    "35": {
+      "epic": false,
+      "state": "open",
+      "title": "Build both JA4H cookie hashes from one cookie list"
+    },
+    "96": {
+      "epic": false,
+      "state": "closed",
+      "title": "Decide how JA4SSH reads the FoxIO mode field"
+    },
+    "97": {
+      "epic": false,
+      "state": "closed",
+      "title": "Emit the JA4SSH occurrence a bare ACK produces after a window closes"
+    }
+  },
+  "retrieved": "2026-08-07",
+  "source": "gh issue list --state all --limit 500 --json number,state,labels,title"
+}

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -25,50 +25,51 @@
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4X.1": {
     "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
-    "issue": 78
+    "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4X.2": {
     "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
-    "issue": 78
+    "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4": {
-    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4H": {
-    "cause": "ja4plus produces no JA4H fingerprint the reference holds.",
-    "issue": 35
+    "cause": "The reference decrypts the QUIC traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
+    "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4H_ro": {
     "cause": "The reference decrypts the QUIC traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4S": {
-    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. The reference reads no QUIC handshake on the stream whose source port is 50280, and the JA4 entry of this vector names the same stream.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. The reference reads no QUIC handshake on the stream whose source port is 50280, and the JA4 entry of this vector names the same stream. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4S_r": {
-    "cause": "ja4plus produces a JA4S_r value on the stream whose source port is 50280, and the reference holds none. The hashed form of the same stream is registered under chrome-cloudflare-quic-with-secrets.pcapng/JA4S with the same cause.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S_r value on the stream whose source port is 50280, and the reference holds none. The hashed form of the same stream is registered under chrome-cloudflare-quic-with-secrets.pcapng/JA4S with the same cause. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4X": {
     "cause": "The reference decrypts the QUIC handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
-    "issue": 78
+    "issue": 129
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4_o": {
-    "cause": "ja4plus produces a JA4_o fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_o fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4_r": {
-    "cause": "ja4plus produces a JA4_r fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_r fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "chrome-cloudflare-quic-with-secrets.pcapng/JA4_ro": {
-    "cause": "ja4plus produces a JA4_ro fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_ro fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "gre-sample.pcap/JA4SSH": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes.",
+    "decided": true,
     "issue": 105
   },
   "http-empty-useragent.pcap/0:57722/JA4H.1": {
@@ -209,15 +210,15 @@
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.1": {
     "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
-    "issue": 78
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.2": {
     "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
-    "issue": 78
+    "issue": 129
   },
   "http2-with-cookies.pcapng/0:58847/JA4X.3": {
     "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
-    "issue": 78
+    "issue": 129
   },
   "http2-with-cookies.pcapng/JA4H": {
     "cause": "The reference decrypts the TLS 1.3 traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
@@ -229,11 +230,11 @@
   },
   "http2-with-cookies.pcapng/JA4X": {
     "cause": "The reference decrypts the TLS 1.3 handshake with the secrets the capture carries, and ja4plus reads no encrypted certificate.",
-    "issue": 78
+    "issue": 129
   },
   "https-connect.pcap/JA4": {
-    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "https-connect.pcap/JA4L-C": {
     "cause": "ja4plus emits more JA4L-C values than the reference holds.",
@@ -244,24 +245,24 @@
     "issue": 34
   },
   "https-connect.pcap/JA4S": {
-    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "https-connect.pcap/JA4X": {
-    "cause": "The reference reads no TLS on port 8080, and ja4plus reads the certificate of the tunnel from the record layer.",
-    "issue": 78
+    "cause": "The reference reads no TLS on port 8080, and ja4plus reads the certificate of the tunnel from the record layer. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "https3-301-get.pcap/0:62599/JA4_o.1": {
     "cause": "The client hello carries SNI as its only extension, and the reference gives 000000000000 as the JA4_o extension hash.",
     "issue": 132
   },
   "quic-tls-handshake.pcapng/JA4": {
-    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "quic-with-several-tls-frames.pcapng/JA4": {
-    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "The FoxIO Rust snapshot holds the exact JA4 value ja4plus produces. The FoxIO Python file holds an empty array, because it reads no client hello that several CRYPTO frames carry.",
+    "issue": 138
   },
   "socks-https-example.pcap/0:53554/JA4_o.1": {
     "cause": "The client hello carries SNI as its only extension, and the reference gives 000000000000 as the JA4_o extension hash.",
@@ -276,176 +277,184 @@
     "issue": 132
   },
   "socks4-https.pcap/JA4X": {
-    "cause": "The reference reads no TLS on port 9901, and ja4plus reads the certificate of the tunnel from the record layer.",
-    "issue": 78
+    "cause": "The reference reads no TLS on port 9901, and ja4plus reads the certificate of the tunnel from the record layer. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "ssh-r.pcap/0:64980/JA4SSH.2": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets.",
+    "decided": true,
     "issue": 97
   },
   "ssh-r.pcap/1:46394/JA4SSH.1": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window.",
+    "decided": true,
     "issue": 96
   },
   "ssh-r.pcap/2:46396/JA4SSH.1": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window.",
+    "decided": true,
     "issue": 96
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.3": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window.",
+    "decided": true,
     "issue": 96
   },
   "ssh-scp-1050.pcap/0:49237/JA4SSH.4": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #96. dict(ja4sh_stats) shares one payload list across every window and every connection, so the reference mode field reads the packet lengths of the whole capture. ja4plus reads the lengths of the window.",
+    "decided": true,
     "issue": 96
   },
   "ssh2.pcapng/14:57377/JA4SSH.2": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets.",
+    "decided": true,
     "issue": 97
   },
   "ssh2.pcapng/JA4": {
-    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "ssh2.pcapng/JA4L-S": {
     "cause": "ja4plus emits more JA4L-S values than the reference holds.",
     "issue": 34
   },
   "ssh2.pcapng/JA4S": {
-    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. The reference reads no QUIC handshake on stream 33 and on stream 36, and the JA4 entry of this vector names the same two streams.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. The reference reads no QUIC handshake on stream 33 and on stream 36, and the JA4 entry of this vector names the same two streams. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "ssh2.pcapng/JA4SSH": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #97. A bare ACK that follows a window boundary makes FoxIO write another occurrence from a window that holds no SSH packet. ja4plus emits a value only for a window that holds SSH packets.",
+    "decided": true,
     "issue": 97
   },
   "ssh2.pcapng/JA4S_r": {
-    "cause": "ja4plus produces a JA4S_r value on stream 33 and on stream 36, and the reference holds none. The hashed form of the same streams is registered under ssh2.pcapng/JA4S with the same cause.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S_r value on stream 33 and on stream 36, and the reference holds none. The hashed form of the same streams is registered under ssh2.pcapng/JA4S with the same cause. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "ssh2.pcapng/JA4_o": {
-    "cause": "ja4plus produces a JA4_o fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_o fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "ssh2.pcapng/JA4_r": {
-    "cause": "ja4plus produces a JA4_r fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_r fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "ssh2.pcapng/JA4_ro": {
-    "cause": "ja4plus produces a JA4_ro fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_ro fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "sshv1.pcap/JA4SSH": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes.",
+    "decided": true,
     "issue": 105
   },
   "tls-handshake.pcapng/38:50159/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/38:50159/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/38:50159/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/38:50159/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/41:50165/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/41:50165/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/41:50165/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/41:50165/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/42:50166/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/42:50166/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/42:50166/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/42:50166/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/44:50168/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/44:50168/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/44:50168/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/44:50168/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/45:50169/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/45:50169/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/45:50169/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/45:50169/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/JA4": {
-    "cause": "ja4plus produces no JA4 fingerprint the reference holds.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/JA4L-S": {
     "cause": "ja4plus emits more JA4L-S values than the reference holds.",
     "issue": 34
   },
   "tls-handshake.pcapng/JA4S": {
-    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-handshake.pcapng/JA4S_r": {
-    "cause": "ja4plus produces a JA4S_r fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S_r fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-handshake.pcapng/JA4_o": {
-    "cause": "ja4plus produces no JA4_o fingerprint the reference holds.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/JA4_r": {
-    "cause": "ja4plus produces no JA4_r fingerprint the reference holds.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-handshake.pcapng/JA4_ro": {
-    "cause": "ja4plus produces no JA4_ro fingerprint the reference holds.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-non-ascii-alpn.pcapng/0:50112/JA4.1": {
     "cause": "The produced JA4 value differs from the reference.",
@@ -464,127 +473,128 @@
     "issue": 13
   },
   "tls-sni.pcapng/38:50159/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/38:50159/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/38:50159/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/38:50159/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/41:50165/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/41:50165/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/41:50165/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/41:50165/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/42:50166/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/42:50166/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/42:50166/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/42:50166/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/44:50168/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/44:50168/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/44:50168/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/44:50168/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/45:50169/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/45:50169/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/45:50169/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/45:50169/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/JA4": {
-    "cause": "ja4plus produces no JA4 fingerprint the reference holds.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4 fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/JA4_o": {
-    "cause": "ja4plus produces no JA4_o fingerprint the reference holds.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_o fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/JA4_r": {
-    "cause": "ja4plus produces no JA4_r fingerprint the reference holds.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_r fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls-sni.pcapng/JA4_ro": {
-    "cause": "ja4plus produces no JA4_ro fingerprint the reference holds.",
-    "issue": 13
+    "cause": "ja4plus produces no JA4_ro fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
+    "issue": 137
   },
   "tls3.pcapng/JA4": {
-    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4 fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls3.pcapng/JA4S": {
-    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. The reference reads no QUIC handshake on the six streams the JA4 entry of this vector names.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S fingerprint the reference does not hold. The reference reads no QUIC handshake on the six streams the JA4 entry of this vector names. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls3.pcapng/JA4S_r": {
-    "cause": "ja4plus produces a JA4S_r value on the six streams the JA4 entry of this vector names, and the reference holds none. The hashed form of the same streams is registered under tls3.pcapng/JA4S with the same cause.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4S_r value on the six streams the JA4 entry of this vector names, and the reference holds none. The hashed form of the same streams is registered under tls3.pcapng/JA4S with the same cause. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls3.pcapng/JA4_o": {
-    "cause": "ja4plus produces a JA4_o fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_o fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls3.pcapng/JA4_r": {
-    "cause": "ja4plus produces a JA4_r fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_r fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls3.pcapng/JA4_ro": {
-    "cause": "ja4plus produces a JA4_ro fingerprint the reference does not hold.",
-    "issue": 13
+    "cause": "ja4plus produces a JA4_ro fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "v6.pcap/JA4SSH": {
     "cause": "A FoxIO reference defect this project declines to reproduce, decided on #105. finalize_ja4ssh guards with `if stream:`, and the stream index 0 is false in Python, so the reference emits no trailing window for the connection it holds at index 0. ja4plus emits the window for every connection that closes.",
+    "decided": true,
     "issue": 105
   }
 }

--- a/tests/foxio_deviations.py
+++ b/tests/foxio_deviations.py
@@ -40,6 +40,22 @@ A fix that lands makes the case pass, and the strict marker turns that pass into
 failure that names the case. Delete the entry in the same change that lands the fix.
 Never delete an entry to make a red suite green.
 
+## How to refresh the owner list
+
+`tests/foxio_deviation_owners.json` records the state of every issue the register names.
+`TestTheRegisterOwners` reads it and rejects an owner that no worker can act on: an epic,
+or a closed issue that no decision record explains. The register named the epic #13 for
+five batches, and no test caught it.
+
+The file is checked in, so the unit suite reaches no network. Refresh it with:
+
+```bash
+gh issue list --state all --limit 500 --json number,state,labels,title
+```
+
+An entry whose owner the file does not hold fails the test. Add the owner, or point the
+entry at an issue the file already holds.
+
 ## How to measure a new baseline
 
 Set `JA4PLUS_IGNORE_DEVIATIONS=1` and run the suite. The lookup returns nothing, so
@@ -57,6 +73,8 @@ logger = logging.getLogger(__name__)
 
 REGISTER_PATH = Path(__file__).parent / "foxio_deviations.json"
 
+OWNERS_PATH = Path(__file__).parent / "foxio_deviation_owners.json"
+
 # The suite reads this variable to measure a new baseline. It disables the lookup, so
 # every registered case fails and the failure list names every deviation.
 IGNORE_VARIABLE = "JA4PLUS_IGNORE_DEVIATIONS"
@@ -68,10 +86,13 @@ class Deviation(NamedTuple):
     Attributes:
         issue: The number of the issue that fixes the deviation.
         cause: One line that states the cause.
+        decided: True when the issue is a decision record. A decided deviation is
+            permanent, so its issue is closed and no fix removes the entry.
     """
 
     issue: int
     cause: str
+    decided: bool = False
 
     def reason(self):
         """Return the `xfail` reason that names the issue and the cause."""
@@ -140,7 +161,57 @@ def _read_entry(key, entry):
     cause = entry.get("cause")
     if not isinstance(cause, str) or not cause.strip():
         raise ValueError("deviation {}: the entry states no cause".format(key))
-    return Deviation(issue=issue, cause=cause)
+    decided = entry.get("decided", False)
+    if not isinstance(decided, bool):
+        raise ValueError("deviation {}: the decided field is not true or false".format(key))
+    return Deviation(issue=issue, cause=cause, decided=decided)
+
+
+class Owner(NamedTuple):
+    """The recorded state of one issue the register names.
+
+    Attributes:
+        number: The issue number.
+        state: The issue state, `open` or `closed`.
+        epic: True when the issue carries the `type:epic` label.
+        title: The issue title, which names the owner for a reader.
+    """
+
+    number: int
+    state: str
+    epic: bool
+    title: str
+
+
+def load_owners(path=OWNERS_PATH):
+    """Return the recorded state of every issue the register names.
+
+    The file is checked in, so no test reaches the network. The module docstring holds
+    the command that refreshes it.
+
+    Args:
+        path: The path of the owner file. Defaults to the committed file.
+
+    Returns:
+        A map of issue number to Owner.
+
+    Raises:
+        ValueError: An owner names a state the file does not allow.
+    """
+    with open(path) as handle:
+        document = json.load(handle)
+    owners = {}
+    for number, entry in document["owners"].items():
+        state = entry.get("state")
+        if state not in ("open", "closed"):
+            raise ValueError("owner {}: the state is not open or closed".format(number))
+        owners[int(number)] = Owner(
+            number=int(number),
+            state=state,
+            epic=bool(entry.get("epic", False)),
+            title=entry.get("title", ""),
+        )
+    return owners
 
 
 def lookup(register, key):

--- a/tests/test_foxio_deviations.py
+++ b/tests/test_foxio_deviations.py
@@ -10,12 +10,52 @@ import json
 import pytest
 
 from tests.foxio_deviations import (
+    OWNERS_PATH,
     REGISTER_PATH,
     Deviation,
+    Owner,
+    load_owners,
     load_register,
     occurrence_key,
     value_key,
 )
+
+
+def unusable_owners(register, owners):
+    """Return one message for every entry whose owner no worker can act on.
+
+    An epic is never an owner, because an epic is not schedulable. A closed issue is an
+    owner only when the entry is decided, which records a permanent divergence.
+
+    Args:
+        register: The register that `load_register` returns.
+        owners: The owner map that `load_owners` returns.
+
+    Returns:
+        A list of messages. An empty list means every entry names a usable owner.
+    """
+    messages = []
+    for key, deviation in sorted(register.items()):
+        owner = owners.get(deviation.issue)
+        if owner is None:
+            messages.append(
+                "{} names #{}, and the owner list holds no state for it".format(
+                    key, deviation.issue
+                )
+            )
+            continue
+        if owner.epic:
+            messages.append(
+                "{} names the epic #{}, and an epic is not schedulable".format(key, owner.number)
+            )
+            continue
+        if owner.state == "closed" and not deviation.decided:
+            messages.append(
+                "{} names the closed issue #{}, and the entry is not decided".format(
+                    key, owner.number
+                )
+            )
+    return messages
 
 
 class TestTheKeyForms:
@@ -85,6 +125,23 @@ class TestTheRegisterReader:
     def test_the_reader_returns_an_empty_register_for_a_missing_file(self, tmp_path):
         assert load_register(tmp_path / "absent.json") == {}
 
+    def test_the_reader_reads_no_decided_flag_as_false(self, tmp_path):
+        path = self._write(tmp_path, {"a.pcap/0/JA4.1": {"issue": 13, "cause": "x"}})
+        assert load_register(path)["a.pcap/0/JA4.1"].decided is False
+
+    def test_the_reader_reads_the_decided_flag(self, tmp_path):
+        path = self._write(
+            tmp_path, {"a.pcap/0/JA4.1": {"issue": 13, "cause": "x", "decided": True}}
+        )
+        assert load_register(path)["a.pcap/0/JA4.1"].decided is True
+
+    def test_the_reader_rejects_a_decided_flag_that_is_not_a_boolean(self, tmp_path):
+        path = self._write(
+            tmp_path, {"a.pcap/0/JA4.1": {"issue": 13, "cause": "x", "decided": "yes"}}
+        )
+        with pytest.raises(ValueError, match="a.pcap/0/JA4.1"):
+            load_register(path)
+
     def test_the_reason_names_the_issue_and_the_cause(self):
         deviation = Deviation(issue=30, cause="JA4L needs the hop count.")
         assert deviation.reason() == "issue #30: JA4L needs the hop count."
@@ -122,6 +179,7 @@ ENCRYPTED_HTTP_KEYS = (
     + [
         "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H.1",
         "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H_ro.1",
+        "chrome-cloudflare-quic-with-secrets.pcapng/JA4H",
         "chrome-cloudflare-quic-with-secrets.pcapng/JA4H_ro",
     ]
 )
@@ -145,3 +203,81 @@ class TestTheEncryptedHttpDeviations:
         alone. A cleartext vector that reappears here is a defect.
         """
         assert "http1-with-cookies.pcapng/JA4H_ro" not in load_register()
+
+
+class TestTheOwnerReader:
+    """Check the reader of the checked-in owner list."""
+
+    def _write(self, tmp_path, owners):
+        path = tmp_path / "owners.json"
+        path.write_text(json.dumps({"owners": owners}))
+        return path
+
+    def test_the_reader_keys_the_map_by_issue_number(self, tmp_path):
+        path = self._write(tmp_path, {"13": {"state": "open", "epic": True, "title": "Epic 2"}})
+        assert load_owners(path)[13] == Owner(number=13, state="open", epic=True, title="Epic 2")
+
+    def test_the_reader_reads_no_epic_flag_as_false(self, tmp_path):
+        path = self._write(tmp_path, {"34": {"state": "open", "title": "Emit one value"}})
+        assert load_owners(path)[34].epic is False
+
+    def test_the_reader_rejects_a_state_it_does_not_allow(self, tmp_path):
+        path = self._write(tmp_path, {"34": {"state": "merged", "title": "Emit one value"}})
+        with pytest.raises(ValueError, match="34"):
+            load_owners(path)
+
+
+class TestTheRegisterOwners:
+    """Check that every register entry names an issue a worker can act on.
+
+    The register named the epic #13 for five batches, and no test caught it. An epic
+    holds sub-issues, so no worker is assigned to it and no fix removes the entry.
+    """
+
+    def test_the_owner_list_reads(self):
+        assert load_owners()
+
+    def test_the_owner_list_holds_every_issue_the_register_names(self):
+        named = {deviation.issue for deviation in load_register().values()}
+        missing = sorted(named - set(load_owners()))
+        assert not missing, "the owner list holds no state for {}".format(missing)
+
+    def test_no_entry_names_an_epic_or_a_closed_issue(self):
+        messages = unusable_owners(load_register(), load_owners())
+        assert not messages, "\n".join(messages)
+
+    def test_the_check_reports_an_entry_that_names_an_epic(self):
+        register = {"a.pcap/JA4": Deviation(issue=13, cause="x")}
+        owners = {13: Owner(number=13, state="open", epic=True, title="Epic 2")}
+        assert unusable_owners(register, owners) == [
+            "a.pcap/JA4 names the epic #13, and an epic is not schedulable"
+        ]
+
+    def test_the_check_reports_an_entry_that_names_a_closed_issue(self):
+        register = {"a.pcap/JA4": Deviation(issue=78, cause="x")}
+        owners = {78: Owner(number=78, state="closed", epic=False, title="Fix JA4X")}
+        assert unusable_owners(register, owners) == [
+            "a.pcap/JA4 names the closed issue #78, and the entry is not decided"
+        ]
+
+    def test_the_check_accepts_a_decided_entry_that_names_a_closed_issue(self):
+        register = {"a.pcap/JA4SSH": Deviation(issue=96, cause="x", decided=True)}
+        owners = {96: Owner(number=96, state="closed", epic=False, title="Decide the mode")}
+        assert unusable_owners(register, owners) == []
+
+    def test_the_check_reports_an_owner_the_list_does_not_hold(self):
+        register = {"a.pcap/JA4": Deviation(issue=999, cause="x")}
+        assert unusable_owners(register, {}) == [
+            "a.pcap/JA4 names #999, and the owner list holds no state for it"
+        ]
+
+    def test_the_check_accepts_an_open_issue(self):
+        register = {"a.pcap/JA4": Deviation(issue=137, cause="x")}
+        owners = {137: Owner(number=137, state="open", epic=False, title="Produce the values")}
+        assert unusable_owners(register, owners) == []
+
+    def test_the_owner_list_records_where_it_came_from(self):
+        with open(OWNERS_PATH) as handle:
+            document = json.load(handle)
+        assert document["source"].startswith("gh issue list")
+        assert document["retrieved"]


### PR DESCRIPTION
Closes #128.

## What changed

`tests/foxio_deviations.json` held 76 entries whose `issue` field read 13. Issue #13 is
an epic, so no worker was ever assigned to any of them. Nineteen more entries named a
closed issue. The register pointed at the epic for five batches, and no test caught it.

| Entries | From | To | Selector |
|---|---|---|---|
| 48 | #13 | #137 | Capture is `tls-handshake.pcapng` or `tls-sni.pcapng`, and the cause states that `ja4plus` produces no JA4 value. |
| 21 | #13 | #138 | Cause states that `ja4plus` produces a fingerprint the reference does not hold. |
| 2 | #13 | #138 | `tls-handshake.pcapng/JA4S` and `tls-handshake.pcapng/JA4S_r`. |
| 1 | #13 | #138 | `quic-with-several-tls-frames.pcapng/JA4`, with a new cause. |
| 2 | #78 | #138 | `https-connect.pcap/JA4X` and `socks4-https.pcap/JA4X`. |
| 7 | #78 | #129 | The reference decrypts the capture, and `ja4plus` reads no encrypted certificate. |
| 1 | #35 | #129 | `chrome-cloudflare-quic-with-secrets.pcapng/JA4H`. |
| 10 | #96, #97, #105 | unchanged | The entries gain the `decided` field. |

The two selectors the issue names produce exactly 48 and 21, as the issue requires.

**The cause now states the question.** A `#137` entry keeps its measured symptom and adds
"Which packet the JA4 reader never reaches is unknown. A measurement must name it before a
fingerprinter changes." A `#138` entry adds "Whether the FoxIO reference omits the value,
or `ja4plus` reads a packet it must not, is unsettled."

**`quic-with-several-tls-frames.pcapng/JA4` no longer reads as a defect in `ja4plus`.**
Its cause now reads: "The FoxIO Rust snapshot holds the exact JA4 value `ja4plus`
produces. The FoxIO Python file holds an empty array, because it reads no client hello
that several CRYPTO frames carry."

## The test, and why it reads a checked-in list

`TestTheRegisterOwners` fails when a register entry names an issue labeled `type:epic`,
names a closed issue that no decision explains, or names an issue the owner list does not
hold.

**The list is checked in, at `tests/foxio_deviation_owners.json`.** The unit suite runs
offline, in a sandbox and on a contributor machine that holds no `gh` credential. A test
that queries the forge would fail for a reason that has nothing to do with the register,
and a flaky gate teaches a reader to ignore it. The file records the command that
refreshes it, and `tests/foxio_deviations.py` documents the refresh under "How to refresh
the owner list":

```bash
gh issue list --state all --limit 500 --json number,state,labels,title
```

An entry whose owner the file does not hold fails the test, so a new owner cannot enter
the register without its state being recorded. That is the gate the epic slipped through.

## Two judgement calls to review

**1. A closed issue is a valid owner when the entry is decided.** Ten entries name #96,
#97 and #105. Those three issues are decision records: the register text reads "A FoxIO
reference defect this project declines to reproduce, decided on #96". They are correctly
closed, the divergence is permanent, and no fix will ever remove the entry. A flat "no
closed issue" rule would have forced ten correct entries to name a fabricated owner, which
is the harm this issue exists to stop. `Deviation` therefore gains an optional `decided`
flag, and the rule reads: an epic is never an owner; a closed issue is an owner only when
the entry is decided.

**2. Four entries still name #13.** They are the `tls-non-ascii-alpn.pcapng` entries that
#127 removes. This branch leaves them alone, as the issue instructs, so
`test_no_entry_names_an_epic_or_a_closed_issue` fails on this branch until #127 merges
into `epic/12-spec-conformance`. The failure names all four keys. Nothing else in the unit
suite fails.

**One thing to watch.** #129 is open today, and the 17 entries it owns record a permanent
limitation rather than a defect. When #129 closes, those entries need `decided: true`.
This test is what will say so.

## Verification

```
pytest tests/ -m "not spec_validation"   1 failed, 874 passed, 2 xfailed, 93 subtests passed
pytest tests/ -m spec_validation         1280 passed, 141 skipped, 147 xfailed
ruff check ja4plus/ tests/               All checks passed!
mypy ja4plus/                            Success: no issues found in 27 source files
```

The one unit failure is the four #127 entries described above.

**No fingerprint changes, and the conformance counts did not move.** The register holds
147 keys before this change and 147 after, and the key sets are identical:

```
base keys 147 head keys 147
key sets equal: True
owners changed: 82
```

The suite marks a case `xfail` by key, so an identical key set marks an identical set of
cases. The conformance run above confirms it: 147 xfailed, no failure.

```
Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/rust/ja4/src/snapshots/ja4__insta%40quic-with-several-tls-frames.pcapng.snap (retrieved 2026-08-06)
Verified against: gh issue list --state all --limit 500 --json number,state,labels,title (retrieved 2026-08-07)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
