### PR TITLE
Produce the JA4 values the reference holds on tls-handshake.pcapng and tls-sni.pcapng

### DIFF
--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -127,6 +127,28 @@ the difference against the Python material, and #128 owns its cause.
 
 **Location:** `tests/test_quic_multipacket.py`.
 
+### The reader walks the records of a segment
+
+A TLS 1.3 client that receives a HelloRetryRequest sends a second ClientHello. The
+compatibility-mode ChangeCipherSpec record precedes that hello in the same TCP segment,
+so the first byte of the segment is `0x14` and not `0x16`.
+
+`parse_tls_handshake` read the first record of the segment alone, so it returned `None`
+on that segment and the second hello reached no fingerprinter. `tls-handshake.pcapng`
+and `tls-sni.pcapng` each hold five such streams, and the reference holds a `JA4.2` value
+for every one of them.
+
+The reader now walks the records of the segment, and it parses the first record whose
+content type is `0x16` and whose handshake type is 1 or 2. The per-record length comes
+from the packet, so the walk bounds every read on the real buffer length, always
+advances, and returns `None` on a length that overruns the buffer.
+
+No segment of these captures holds two ClientHellos, so the first handshake record of a
+segment is sufficient.
+
+**Location:** `ja4plus/utils/tls_utils.py:46`, in `parse_tls_handshake`.
+`tests/test_ja4_hello_retry.py` holds the measurement. #137 owns the change.
+
 ### Version mapping (beyond TLS 1.0-1.3)
 
 The spec only mentions TLS 1.0 through 1.3. The implementation also maps:

--- a/ja4plus/utils/tls_utils.py
+++ b/ja4plus/utils/tls_utils.py
@@ -45,41 +45,43 @@ def extract_tls_info(packet):
 
 def parse_tls_handshake(raw_data):
     """
-    Parse a TLS handshake message from raw bytes.
+    Parse the first ClientHello or ServerHello of a TLS segment.
+
+    The walk reads every record of the segment, because a hello does not always start
+    the segment. A TLS 1.3 client that answers a HelloRetryRequest puts the
+    compatibility-mode ChangeCipherSpec record before its second ClientHello, so the
+    first byte of that segment is 0x14.
 
     Args:
-        raw_data: Raw bytes of a TLS record
+        raw_data: Raw bytes of one TLS segment
 
     Returns:
         Dictionary with TLS handshake information or None
     """
-    # Check minimum length for TLS record header
-    if len(raw_data) < 5:
-        return None
+    offset = 0
 
-    record_type = raw_data[0]
-    if record_type != 0x16:  # 0x16 = Handshake
-        return None
+    # The per-record length comes from the packet, so the walk bounds every read on the
+    # real buffer length. A record header is five bytes, so the walk always advances.
+    while offset + 5 <= len(raw_data):
+        record_type = raw_data[offset]
+        record_length = (raw_data[offset + 3] << 8) | raw_data[offset + 4]
 
-    # Get TLS record version and length
-    record_length = (raw_data[3] << 8) | raw_data[4]
+        if record_type == 0x16 and offset + 6 <= len(raw_data):  # 0x16 = Handshake
+            handshake_type = raw_data[offset + 5]
 
-    # Ensure we have enough data
-    if len(raw_data) < 5 + record_length:
-        return None
+            if handshake_type in (1, 2):
+                # A truncated record holds no complete hello.
+                if offset + 5 + record_length > len(raw_data):
+                    return None
 
-    # Extract handshake type
-    if len(raw_data) < 6:
-        return None
+                record = raw_data[offset:]
+                if handshake_type == 1:
+                    return _parse_client_hello(record)
+                return _parse_server_hello(record)
 
-    handshake_type = raw_data[5]
+        offset += 5 + record_length
 
-    if handshake_type == 1:
-        return _parse_client_hello(raw_data)
-    elif handshake_type == 2:
-        return _parse_server_hello(raw_data)
-    else:
-        return None
+    return None
 
 
 def _parse_client_hello(raw_data):

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -348,89 +348,9 @@
     "decided": true,
     "issue": 105
   },
-  "tls-handshake.pcapng/38:50159/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/38:50159/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/38:50159/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/38:50159/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/41:50165/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/41:50165/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/41:50165/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/41:50165/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/42:50166/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/42:50166/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/42:50166/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/42:50166/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/44:50168/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/44:50168/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/44:50168/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/44:50168/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/45:50169/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/45:50169/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/45:50169/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-handshake.pcapng/45:50169/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
   "tls-handshake.pcapng/JA4": {
-    "cause": "ja4plus produces no JA4 fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
+    "cause": "ja4plus produces a JA4 fingerprint on 20 streams the reference does not hold. ja4plus produces every JA4 value the reference holds. Whether the FoxIO reference omits the 20 values, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-handshake.pcapng/JA4L-S": {
     "cause": "ja4plus emits more JA4L-S values than the reference holds.",
@@ -445,112 +365,32 @@
     "issue": 138
   },
   "tls-handshake.pcapng/JA4_o": {
-    "cause": "ja4plus produces no JA4_o fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
+    "cause": "ja4plus produces a JA4_o fingerprint on 20 streams the reference does not hold. ja4plus produces every JA4_o value the reference holds. Whether the FoxIO reference omits the 20 values, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-handshake.pcapng/JA4_r": {
-    "cause": "ja4plus produces no JA4_r fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
+    "cause": "ja4plus produces a JA4_r fingerprint on 20 streams the reference does not hold. ja4plus produces every JA4_r value the reference holds. Whether the FoxIO reference omits the 20 values, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-handshake.pcapng/JA4_ro": {
-    "cause": "ja4plus produces no JA4_ro fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/38:50159/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/38:50159/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/38:50159/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/38:50159/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/41:50165/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/41:50165/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/41:50165/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/41:50165/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/42:50166/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/42:50166/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/42:50166/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/42:50166/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/44:50168/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/44:50168/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/44:50168/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/44:50168/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/45:50169/JA4.2": {
-    "cause": "ja4plus produces no JA4 value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/45:50169/JA4_o.2": {
-    "cause": "ja4plus produces no JA4_o value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/45:50169/JA4_r.2": {
-    "cause": "ja4plus produces no JA4_r value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
-  },
-  "tls-sni.pcapng/45:50169/JA4_ro.2": {
-    "cause": "ja4plus produces no JA4_ro value on this stream. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
+    "cause": "ja4plus produces a JA4_ro fingerprint on 20 streams the reference does not hold. ja4plus produces every JA4_ro value the reference holds. Whether the FoxIO reference omits the 20 values, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-sni.pcapng/JA4": {
-    "cause": "ja4plus produces no JA4 fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
+    "cause": "ja4plus produces a JA4 fingerprint on 20 streams the reference does not hold. ja4plus produces every JA4 value the reference holds. Whether the FoxIO reference omits the 20 values, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-sni.pcapng/JA4_o": {
-    "cause": "ja4plus produces no JA4_o fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
+    "cause": "ja4plus produces a JA4_o fingerprint on 20 streams the reference does not hold. ja4plus produces every JA4_o value the reference holds. Whether the FoxIO reference omits the 20 values, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-sni.pcapng/JA4_r": {
-    "cause": "ja4plus produces no JA4_r fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
+    "cause": "ja4plus produces a JA4_r fingerprint on 20 streams the reference does not hold. ja4plus produces every JA4_r value the reference holds. Whether the FoxIO reference omits the 20 values, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls-sni.pcapng/JA4_ro": {
-    "cause": "ja4plus produces no JA4_ro fingerprint the reference holds. Which packet the JA4 reader never reaches is unknown. A measurement must name it before a fingerprinter changes.",
-    "issue": 137
+    "cause": "ja4plus produces a JA4_ro fingerprint on 20 streams the reference does not hold. ja4plus produces every JA4_ro value the reference holds. Whether the FoxIO reference omits the 20 values, or ja4plus reads a packet it must not, is unsettled.",
+    "issue": 138
   },
   "tls3.pcapng/JA4": {
     "cause": "ja4plus produces a JA4 fingerprint the reference does not hold. Whether the FoxIO reference omits the value, or ja4plus reads a packet it must not, is unsettled.",

--- a/tests/test_ja4_hello_retry.py
+++ b/tests/test_ja4_hello_retry.py
@@ -1,0 +1,91 @@
+"""JA4 reads the second ClientHello of a HelloRetryRequest flow.
+
+A TLS 1.3 client that receives a HelloRetryRequest sends a second ClientHello. The
+compatibility-mode ChangeCipherSpec record precedes that hello in the same TCP segment,
+so the first byte of the segment is `0x14` and not `0x16`. The reader walks the records
+of the segment to reach the hello.
+
+The vectors are `tls-handshake.pcapng` and `tls-sni.pcapng`, stream 38, port 50159.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+from ja4plus.utils.tls_utils import parse_tls_handshake
+
+VECTOR_DIR = Path(__file__).parent / "foxio_vectors"
+
+# The TLS 1.3 compatibility-mode ChangeCipherSpec record. It carries one payload byte.
+CHANGE_CIPHER_SPEC = b"\x14\x03\x03\x00\x01\x01"
+
+
+def _client_hello_record(ciphers=(0x1301,)):
+    """Return one TLS handshake record that holds a minimal ClientHello."""
+    body = bytearray(b"\x03\x03")
+    body += b"\x00" * 32  # Random
+    body += b"\x00"  # Session ID length
+    suites = b"".join(c.to_bytes(2, "big") for c in ciphers)
+    body += len(suites).to_bytes(2, "big") + suites
+    body += b"\x01\x00"  # Compression
+    handshake = b"\x01" + len(body).to_bytes(3, "big") + bytes(body)
+    return b"\x16\x03\x01" + len(handshake).to_bytes(2, "big") + handshake
+
+
+def _reference_stream(capture, port):
+    """Return the reference element of one capture that names the port."""
+    elements = json.loads((VECTOR_DIR / (capture + ".json")).read_text())
+    for element in elements:
+        if port in (element.get("srcport"), element.get("dstport")):
+            return element
+    raise AssertionError("The reference holds no stream on port " + port)
+
+
+def _produced_on_port(capture, port):
+    """Return every JA4 entry the fingerprinter produces on one TCP port."""
+    from scapy.all import TCP, rdpcap
+
+    fingerprinter = JA4Fingerprinter()
+    for packet in rdpcap(str(VECTOR_DIR / capture)):
+        if TCP not in packet:
+            continue
+        if str(packet[TCP].sport) != port and str(packet[TCP].dport) != port:
+            continue
+        fingerprinter.process_packet(packet)
+    return fingerprinter.fingerprints
+
+
+def test_the_reader_parses_a_hello_behind_a_change_cipher_spec_record():
+    """A segment that starts with ChangeCipherSpec still yields its ClientHello."""
+    info = parse_tls_handshake(CHANGE_CIPHER_SPEC + _client_hello_record())
+    assert info is not None
+    assert info["type"] == "client_hello"
+    assert info["ciphers"] == [0x1301]
+
+
+def test_the_reader_returns_nothing_when_a_record_length_overruns_the_buffer():
+    """A record length the packet inflates returns nothing, and raises nothing."""
+    # The declared length is 0xffff, and the buffer holds three payload bytes.
+    assert parse_tls_handshake(b"\x14\x03\x03\xff\xff\x01\x02\x03") is None
+
+
+def test_the_reader_returns_nothing_when_no_record_holds_a_hello():
+    """A segment of application data records yields nothing."""
+    assert parse_tls_handshake(b"\x17\x03\x03\x00\x02\x01\x02" * 3) is None
+
+
+@pytest.mark.parametrize("capture", ["tls-handshake.pcapng", "tls-sni.pcapng"])
+def test_the_capture_produces_both_reference_ja4_values(capture):
+    """Stream 38 produces the two JA4 values, and all four forms, the reference holds."""
+    reference = _reference_stream(capture, "50159")
+    produced = _produced_on_port(capture, "50159")
+
+    assert len(produced) == 2
+    for occurrence, entry in enumerate(produced, start=1):
+        suffix = ".{}".format(occurrence)
+        assert entry["fingerprint"] == reference["JA4" + suffix]
+        assert entry["raw"] == reference["JA4_r" + suffix]
+        assert entry["fingerprint_original_order"] == reference["JA4_o" + suffix]
+        assert entry["raw_original_order"] == reference["JA4_ro" + suffix]


### PR DESCRIPTION
Closes #137.

## The cause, reproduced

The second ClientHello of a TLS 1.3 HelloRetryRequest flow sits behind the
compatibility-mode ChangeCipherSpec record, in the same TCP segment.

```
.venv/bin/python -c "
from scapy.all import rdpcap, Raw, TCP
pkts = rdpcap('tests/foxio_vectors/tls-handshake.pcapng')
for i,p in enumerate(pkts,1):
    if TCP not in p or Raw not in p: continue
    if p[TCP].sport != 50159 and p[TCP].dport != 50159: continue
    d = bytes(p[Raw]); off=0
    lines=[]
    while off+5 <= len(d):
        ct=d[off]; ln=(d[off+3]<<8)|d[off+4]
        ht=d[off+5] if off+5 < len(d) else None
        lines.append(f'    record @offset {off:<5} content_type=0x{ct:02x} len={ln} handshake_type={ht}')
        if ln<=0: break
        off += 5+ln
    if lines:
        print(f'pkt#{i}  sport={p[TCP].sport}  tcplen={len(d)}')
        print('\n'.join(lines))
"
```

```
pkt#119  sport=50159  tcplen=517
    record @offset 0     content_type=0x16 len=512 handshake_type=1
pkt#124  sport=443  tcplen=99
    record @offset 0     content_type=0x16 len=88 handshake_type=2
    record @offset 93    content_type=0x14 len=1 handshake_type=1
pkt#125  sport=50159  tcplen=342
    record @offset 0     content_type=0x14 len=1 handshake_type=1
    record @offset 6     content_type=0x16 len=331 handshake_type=1
pkt#133  sport=443  tcplen=1410
    record @offset 0     content_type=0x16 len=155 handshake_type=2
    record @offset 160   content_type=0x17 len=36 handshake_type=134
    record @offset 201   content_type=0x17 len=6584 handshake_type=68
```

Packet 125 holds the second ClientHello at record offset 6. `raw_data[0]` is `0x14`, so
`parse_tls_handshake` returned `None` and the hello reached no fingerprinter. All four
forms of the stream failed together, because all four derive from that one hello. Ten
streams hold the same shape, five in each capture.

## The change

`ja4plus/utils/tls_utils.py` walks the records of the segment and parses the first
record whose content type is `0x16` and whose handshake type is 1 or 2. The per-record
length comes from the packet, so the walk bounds every read on the real buffer length,
always advances by at least five bytes, and returns `None` on a length that overruns the
buffer. It raises nothing.

No segment of these captures holds two ClientHellos, so the first handshake record of a
segment is sufficient. The change adds no multiple-hello handling.

`tests/test_ja4_hello_retry.py` holds the tests, written before the change. Three of the
five failed on the base commit.

## The register

`tests/foxio_deviations.json` loses the 40 entries whose values now match. The register
holds 103 keys, and the conformance suite reports 103 xfailed. Both numbers were 143.

Eight capture-level entries remain, and they now name #138. The measured difference on
the two captures changed:

| Capture | Base | Now |
|---|---|---|
| `tls-handshake.pcapng` JA4 | 20 extra, 5 missing | 20 extra, 0 missing |
| `tls-sni.pcapng` JA4 | 20 extra, 5 missing | 20 extra, 0 missing |

The 20 extra streams are the streams the reference does not hold, which is the question
#138 owns. The measurement above ran on the base commit and on this branch.

## Gates

```
pytest tests/ -m spec_validation        1324 passed, 141 skipped, 103 xfailed
pytest tests/ -m "not spec_validation"   875 passed, 8 xfailed, 93 subtests passed
ruff check ja4plus/ tests/               All checks passed!
ruff format --check ja4plus/ tests/      92 files already formatted
mypy ja4plus/                            Success: no issues found in 27 source files
coverage report --format=total           79 on the base commit, 79 on this branch
```

No vector that passed on the base commit fails now. No fingerprint of any other capture
changes.

Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata (retrieved 2026-08-07)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
