### PR TITLE
fix(quic): bound the CRYPTO fragment buffer of the JA4 fingerprinter (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The QUIC CRYPTO fragment buffer of JA4 holds a limit** (#122).
+  `reassemble_crypto_fragments` allocated a buffer that reached the highest fragment
+  offset, and RFC 9000 Section 16 lets a CRYPTO frame offset reach
+  4611686018427387903. A client Initial packet derives its keys from the connection
+  ID the same packet carries in cleartext, so one UDP datagram from a sender who
+  holds no connection reached the allocation. One fragment of one byte at offset
+  `2**28` allocated 256 MiB, and offset `2**40` names 1024 GiB. The reader now drops
+  a fragment that ends past `MAXIMUM_CRYPTO_BUFFER_BYTES`, which is 16384 and comes
+  from the RFC 8446 Section 5.1 cap on a TLS record plaintext. The JA4 client path
+  collects through `collect_crypto_fragments`, which #102 already shipped, so the
+  per-connection list is bounded too. The fragment table of `JA4Fingerprinter` gains
+  a maximum entry count of 1000 connections and a maximum age of 30 seconds, which
+  the packet clock measures. No fingerprint changed.
+
 - **JA4S tells a QUIC server Initial packet from a client one** (#118). `ja4plus`
   read every QUIC Initial packet as a client Initial packet, because the two carry
   the same long-header packet type. It stored the connection ID of the server packet

--- a/ja4plus/fingerprinters/ja4.py
+++ b/ja4plus/fingerprinters/ja4.py
@@ -4,12 +4,23 @@ JA4 TLS Client Hello Fingerprinting implementation.
 
 import hashlib
 import logging
+import time
 from scapy.all import TCP, UDP, Raw, IP
 
 from ja4plus.utils.tls_utils import extract_tls_info, is_grease_value
 from ja4plus.fingerprinters.base import BaseFingerprinter
 
 logger = logging.getLogger(__name__)
+
+# The highest number of connections whose QUIC CRYPTO fragments one fingerprinter
+# holds. The table holds one entry for each Destination Connection ID, and a sender
+# names a new one on each datagram at no cost, so the table needs a limit.
+MAX_QUIC_FRAGMENT_CONNECTIONS = 1000
+
+# The longest a connection holds its fragments without a further packet. A ClientHello
+# that spans several datagrams arrives inside one round trip, so a connection that adds
+# no fragment for this long has abandoned its handshake.
+MAX_QUIC_FRAGMENT_AGE_SECONDS = 30
 
 
 def _is_alnum_byte(b):
@@ -308,6 +319,8 @@ class JA4Fingerprinter(BaseFingerprinter):
         # together regardless of UDP 5-tuple changes.
         self._quic_fragments = {}
         self._quic_dcid_to_tuple = {}
+        # DCID -> the time of the last packet that added a fragment.
+        self._quic_fragment_seen = {}
 
     def process_packet(self, packet):
         """Process a packet and extract JA4 fingerprint if applicable.
@@ -348,6 +361,7 @@ class JA4Fingerprinter(BaseFingerprinter):
         from ja4plus.utils.quic_utils import (
             decrypt_quic_initial_crypto,
             client_hello_from_crypto_fragments,
+            collect_crypto_fragments,
         )
 
         udp = packet.getlayer(UDP)
@@ -363,7 +377,12 @@ class JA4Fingerprinter(BaseFingerprinter):
 
         dcid_key = dcid.hex()
         existing = self._quic_fragments.setdefault(dcid_key, [])
-        existing.extend(fragments)
+        collect_crypto_fragments(existing, fragments)
+
+        # ja4l.py reads the packet clock the same way.
+        seconds = float(packet.time) if hasattr(packet, "time") else time.time()
+        self._quic_fragment_seen[dcid_key] = seconds
+        self._evict_quic_fragments(seconds)
 
         # Track DCID -> 5-tuple for cleanup_connection.
         from ja4plus.utils.packet_utils import get_ip_layer
@@ -376,9 +395,33 @@ class JA4Fingerprinter(BaseFingerprinter):
         tls_info = client_hello_from_crypto_fragments(existing)
         if tls_info is not None:
             # ClientHello is complete — release the buffer.
-            del self._quic_fragments[dcid_key]
-            self._quic_dcid_to_tuple.pop(dcid_key, None)
+            self._drop_quic_fragments(dcid_key)
         return tls_info
+
+    def _drop_quic_fragments(self, dcid_key):
+        """Drop every table entry one connection holds."""
+        self._quic_fragments.pop(dcid_key, None)
+        self._quic_dcid_to_tuple.pop(dcid_key, None)
+        self._quic_fragment_seen.pop(dcid_key, None)
+
+    def _evict_quic_fragments(self, now):
+        """Drop the connections that passed the maximum age, then the oldest half.
+
+        The eviction runs on each packet, because a run that a wall clock gates lets
+        the table grow without a limit between two runs. `ja4x._evict_processed_certs`
+        states the same reason.
+
+        Args:
+            now: The time of the packet that is being processed, in seconds.
+        """
+        for dcid_key, seen in list(self._quic_fragment_seen.items()):
+            if now - seen > MAX_QUIC_FRAGMENT_AGE_SECONDS:
+                self._drop_quic_fragments(dcid_key)
+        if len(self._quic_fragments) <= MAX_QUIC_FRAGMENT_CONNECTIONS:
+            return
+        # A dict keeps its insertion order, so the oldest entry comes first.
+        for dcid_key in list(self._quic_fragments)[: MAX_QUIC_FRAGMENT_CONNECTIONS // 2]:
+            self._drop_quic_fragments(dcid_key)
 
     def reset(self):
         super().reset()
@@ -387,6 +430,7 @@ class JA4Fingerprinter(BaseFingerprinter):
         self.last_fingerprint_original_order = None
         self._quic_fragments = {}
         self._quic_dcid_to_tuple = {}
+        self._quic_fragment_seen = {}
 
     def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
         """Drop any accumulated QUIC CRYPTO fragments for the given 5-tuple."""
@@ -394,8 +438,7 @@ class JA4Fingerprinter(BaseFingerprinter):
         rev_key = f"{dst_ip}:{dst_port}-{src_ip}:{src_port}"
         for dcid_key, tup in list(self._quic_dcid_to_tuple.items()):
             if tup == tuple_key or tup == rev_key:
-                self._quic_fragments.pop(dcid_key, None)
-                self._quic_dcid_to_tuple.pop(dcid_key, None)
+                self._drop_quic_fragments(dcid_key)
 
     def get_raw_fingerprint(self, packet, original_order=False):
         """

--- a/ja4plus/utils/quic_utils.py
+++ b/ja4plus/utils/quic_utils.py
@@ -298,10 +298,19 @@ def reassemble_crypto_fragments(fragments):
     # Deduplicate identical offsets (a fragment can appear in multiple Initials)
     by_offset = {}
     for offset, data in fragments:
+        # RFC 9000 Section 16 lets a CRYPTO frame offset reach 4611686018427387903,
+        # and the buffer below reaches the highest offset. A fragment that names an
+        # offset past the limit describes no real handshake message, so the reader
+        # drops it before it allocates. The reader returns nothing. It does not raise.
+        if offset + len(data) > MAXIMUM_CRYPTO_BUFFER_BYTES:
+            continue
         # Prefer the longest fragment seen for an offset (rare, but defensive).
         existing = by_offset.get(offset)
         if existing is None or len(data) > len(existing):
             by_offset[offset] = bytes(data)
+
+    if not by_offset:
+        return b""
 
     sorted_frags = sorted(by_offset.items())
     total_len = max(off + len(data) for off, data in sorted_frags)

--- a/tests/test_quic_crypto_buffer_bound.py
+++ b/tests/test_quic_crypto_buffer_bound.py
@@ -1,0 +1,215 @@
+"""The bound on the QUIC CRYPTO fragment buffer of the JA4 fingerprinter.
+
+RFC 9000 Section 16 lets a CRYPTO frame offset reach 4611686018427387903, and
+`reassemble_crypto_fragments` allocates a buffer that reaches the highest offset. A
+client Initial packet derives its keys from the connection ID the same packet carries
+in cleartext, so a sender needs no handshake to reach the allocation. Issue #122
+carries the measurement: one fragment at offset 2**40 names a buffer of 1024 GiB.
+
+Every test here asserts the bound rather than the crash, so each one still means
+something after the fix, and none of them allocates a large buffer.
+"""
+
+import pytest
+from scapy.all import IP, UDP, Raw
+
+from ja4plus.fingerprinters.ja4 import (
+    MAX_QUIC_FRAGMENT_AGE_SECONDS,
+    MAX_QUIC_FRAGMENT_CONNECTIONS,
+    JA4Fingerprinter,
+)
+from ja4plus.utils import quic_utils
+from ja4plus.utils.quic_utils import (
+    MAXIMUM_CRYPTO_BUFFER_BYTES,
+    reassemble_crypto_fragments,
+)
+
+# The highest offset RFC 9000 Section 16 encodes.
+RFC_9000_MAXIMUM_OFFSET = 4611686018427387903
+
+# A TLS ClientHello header that names a 16-byte body the fragments never carry, so the
+# reader keeps the buffer instead of releasing it.
+INCOMPLETE_CLIENT_HELLO = bytes([0x01, 0x00, 0x00, 0x10])
+
+
+def test_the_reassembler_drops_a_fragment_past_the_limit():
+    """A fragment whose offset reaches past the limit produces no buffer.
+
+    The reader returns nothing. It does not raise, and it does not allocate.
+    """
+    assert reassemble_crypto_fragments([(2**40, b"x")]) == b""
+
+
+def test_the_reassembler_drops_the_highest_offset_the_rfc_encodes():
+    """The reader holds against the largest offset a CRYPTO frame can carry."""
+    assert reassemble_crypto_fragments([(RFC_9000_MAXIMUM_OFFSET, b"x")]) == b""
+
+
+def test_the_reassembler_keeps_the_real_fragment_beside_a_hostile_one():
+    """A fragment past the limit drops, and the fragment below it survives."""
+    fragments = [(0, b"hello "), (2**40, b"x"), (6, b"world")]
+    assert reassemble_crypto_fragments(fragments) == b"hello world"
+
+
+def test_the_reassembler_allocates_no_more_than_the_limit():
+    """The buffer never passes `MAXIMUM_CRYPTO_BUFFER_BYTES`."""
+    fragments = [(MAXIMUM_CRYPTO_BUFFER_BYTES - 1, b"x")]
+    assert len(reassemble_crypto_fragments(fragments)) == MAXIMUM_CRYPTO_BUFFER_BYTES
+
+
+def test_the_reassembler_drops_a_fragment_that_ends_one_byte_past_the_limit():
+    """The limit is the last byte the buffer holds, not the first it drops."""
+    assert reassemble_crypto_fragments([(MAXIMUM_CRYPTO_BUFFER_BYTES, b"x")]) == b""
+
+
+def _quic_packet(sport=50000):
+    """Return one UDP datagram whose payload starts a QUIC long header."""
+    return (
+        IP(src="1.1.1.1", dst="2.2.2.2")
+        / UDP(sport=sport, dport=443)
+        / Raw(load=b"\x80" + b"\x00" * 30)
+    )
+
+
+def _stub_decrypt(monkeypatch, fragments_for):
+    """Point `decrypt_quic_initial_crypto` at a function the test drives.
+
+    Args:
+        monkeypatch: The pytest fixture, which restores the module on teardown.
+        fragments_for: A function of the call count returning (fragments, dcid).
+    """
+    calls = {"n": 0}
+
+    def fake_decrypt(_payload):
+        calls["n"] += 1
+        return fragments_for(calls["n"])
+
+    monkeypatch.setattr(quic_utils, "decrypt_quic_initial_crypto", fake_decrypt)
+    return calls
+
+
+def test_the_fingerprinter_collects_no_fragment_past_the_limit(monkeypatch):
+    """A decrypted packet naming a huge offset leaves the per-DCID buffer empty."""
+    dcid = b"\xaa\xbb\xcc\xdd"
+    _stub_decrypt(monkeypatch, lambda _n: ([(2**40, b"x")], dcid))
+
+    fingerprinter = JA4Fingerprinter()
+    assert fingerprinter.process_packet(_quic_packet()) is None
+    assert fingerprinter._quic_fragments[dcid.hex()] == []
+
+
+def test_the_fingerprinter_bounds_its_fragment_table_by_entry_count(monkeypatch):
+    """A sender that names a new connection ID on each datagram fills no table.
+
+    The table holds one entry for each Destination Connection ID, so a flood of
+    connection IDs grows it without a limit unless the fingerprinter evicts.
+    """
+    _stub_decrypt(
+        monkeypatch,
+        lambda n: ([(0, INCOMPLETE_CLIENT_HELLO)], n.to_bytes(8, "big")),
+    )
+
+    fingerprinter = JA4Fingerprinter()
+    for _ in range(MAX_QUIC_FRAGMENT_CONNECTIONS + 200):
+        fingerprinter.process_packet(_quic_packet())
+
+    assert len(fingerprinter._quic_fragments) <= MAX_QUIC_FRAGMENT_CONNECTIONS
+    # The bookkeeping tables track the fragment table rather than outliving it.
+    assert len(fingerprinter._quic_dcid_to_tuple) <= MAX_QUIC_FRAGMENT_CONNECTIONS
+    assert len(fingerprinter._quic_fragment_seen) <= MAX_QUIC_FRAGMENT_CONNECTIONS
+
+
+def test_the_fingerprinter_bounds_its_fragment_table_by_age(monkeypatch):
+    """A connection that adds no fragment for the maximum age leaves the table."""
+    first_dcid = b"\x01" * 8
+    second_dcid = b"\x02" * 8
+    _stub_decrypt(
+        monkeypatch,
+        lambda n: (
+            [(0, INCOMPLETE_CLIENT_HELLO)],
+            first_dcid if n == 1 else second_dcid,
+        ),
+    )
+
+    fingerprinter = JA4Fingerprinter()
+
+    first = _quic_packet()
+    first.time = 1000.0
+    fingerprinter.process_packet(first)
+    assert first_dcid.hex() in fingerprinter._quic_fragments
+
+    second = _quic_packet()
+    second.time = 1000.0 + MAX_QUIC_FRAGMENT_AGE_SECONDS + 1
+    fingerprinter.process_packet(second)
+
+    assert first_dcid.hex() not in fingerprinter._quic_fragments
+    assert first_dcid.hex() not in fingerprinter._quic_dcid_to_tuple
+    assert first_dcid.hex() not in fingerprinter._quic_fragment_seen
+    assert second_dcid.hex() in fingerprinter._quic_fragments
+
+
+def test_the_fingerprinter_keeps_a_connection_inside_the_maximum_age(monkeypatch):
+    """A connection that is still inside the maximum age keeps its fragments."""
+    first_dcid = b"\x01" * 8
+    second_dcid = b"\x02" * 8
+    _stub_decrypt(
+        monkeypatch,
+        lambda n: (
+            [(0, INCOMPLETE_CLIENT_HELLO)],
+            first_dcid if n == 1 else second_dcid,
+        ),
+    )
+
+    fingerprinter = JA4Fingerprinter()
+
+    first = _quic_packet()
+    first.time = 1000.0
+    fingerprinter.process_packet(first)
+
+    second = _quic_packet()
+    second.time = 1000.0 + MAX_QUIC_FRAGMENT_AGE_SECONDS - 1
+    fingerprinter.process_packet(second)
+
+    assert first_dcid.hex() in fingerprinter._quic_fragments
+    assert second_dcid.hex() in fingerprinter._quic_fragments
+
+
+def test_the_fingerprinter_reset_empties_every_fragment_table(monkeypatch):
+    """`reset` drops the age table beside the two tables it already dropped."""
+    _stub_decrypt(
+        monkeypatch,
+        lambda _n: ([(0, INCOMPLETE_CLIENT_HELLO)], b"\xaa" * 8),
+    )
+
+    fingerprinter = JA4Fingerprinter()
+    fingerprinter.process_packet(_quic_packet())
+    fingerprinter.reset()
+
+    assert fingerprinter._quic_fragments == {}
+    assert fingerprinter._quic_dcid_to_tuple == {}
+    assert fingerprinter._quic_fragment_seen == {}
+
+
+def test_the_fingerprinter_cleanup_drops_the_age_entry(monkeypatch):
+    """`cleanup_connection` drops every table entry the connection holds."""
+    dcid = b"\xaa" * 8
+    _stub_decrypt(monkeypatch, lambda _n: ([(0, INCOMPLETE_CLIENT_HELLO)], dcid))
+
+    fingerprinter = JA4Fingerprinter()
+    fingerprinter.process_packet(_quic_packet())
+    fingerprinter.cleanup_connection("1.1.1.1", 50000, "2.2.2.2", 443, "udp")
+
+    assert dcid.hex() not in fingerprinter._quic_fragments
+    assert dcid.hex() not in fingerprinter._quic_dcid_to_tuple
+    assert dcid.hex() not in fingerprinter._quic_fragment_seen
+
+
+@pytest.mark.parametrize("exponent", [28, 34, 40, 62])
+def test_the_reassembler_names_no_large_buffer_for_any_hostile_offset(exponent):
+    """No offset the RFC encodes produces a buffer above the limit.
+
+    The test names the offsets of the issue #122 measurement. Each one produced a
+    buffer of that many bytes before the bound existed.
+    """
+    offset = min(2**exponent, RFC_9000_MAXIMUM_OFFSET)
+    assert len(reassemble_crypto_fragments([(offset, b"x")])) <= MAXIMUM_CRYPTO_BUFFER_BYTES


### PR DESCRIPTION
Closes #122.

## The defect

`reassemble_crypto_fragments` allocated `bytearray(max(off + len(data)))`. A CRYPTO
frame offset is a QUIC variable-length integer, so RFC 9000 Section 16 lets it reach
4611686018427387903, and nothing checked it. A client Initial packet derives its keys
from the connection ID the same packet carries in cleartext, so one UDP datagram from
a sender who holds no connection reached the allocation.

## The measurement, reproduced on this branch

```
returned bytes: 268435457
peak RSS delta MiB: 512.0625
offset 2**28 -> would allocate 256 MiB
offset 2**34 -> would allocate 16384 MiB
offset 2**40 -> would allocate 1048576 MiB
offset 2**62 -> would allocate 4398046511104 MiB
```

## The change

1. `reassemble_crypto_fragments` drops a fragment that ends past
   `MAXIMUM_CRYPTO_BUFFER_BYTES`, so the allocation is bounded by construction and
   every caller is covered. The reader returns nothing. It does not raise.
2. `JA4Fingerprinter._try_quic_multi_packet` collects through
   `collect_crypto_fragments`, which #102 already shipped, so one connection holds no
   more than the limit.
3. The fragment table gains `MAX_QUIC_FRAGMENT_CONNECTIONS = 1000` and
   `MAX_QUIC_FRAGMENT_AGE_SECONDS = 30`. The eviction runs on each packet and reads
   the packet clock, as `ja4x._evict_processed_certs` and `ja4l` do.
4. `_drop_quic_fragments` drops the three tables together, so `reset`,
   `cleanup_connection` and the release path stay in step.

## The limit is 16384, and this pull request adds no second constant

The issue body proposed 65536. `MAXIMUM_CRYPTO_BUFFER_BYTES = 16384` already exists at
`ja4plus/utils/quic_utils.py:26` and already guards `collect_crypto_fragments`. It
names the same quantity, and 16384 comes from the protocol: RFC 8446 Section 5.1 caps
a TLS record plaintext at `2**14`. The largest ClientHello in real use carries a
post-quantum key share and reaches about 2 KiB, an eighth of the limit. The project
manager settled this on the issue.

## No fingerprint changed

Routing the JA4 client path through `collect_crypto_fragments` makes a retransmitted
fragment count toward the byte budget, because that collector removes no duplicate.
`quic-with-several-tls-frames.pcapng` and `chrome-cloudflare-quic-with-secrets.pcapng`
are the vectors that would show it. Both report the same value as before.

## Gates

| Gate | Before | After |
|---|---|---|
| `pytest tests/ -m "not spec_validation"` | — | 900 passed, 8 xfailed, 93 subtests passed |
| `pytest tests/ -m spec_validation` | 1324 passed, 141 skipped, 103 xfailed | 1324 passed, 141 skipped, 103 xfailed |
| `ruff check ja4plus/ tests/` | — | All checks passed |
| `ruff format --check ja4plus/ tests/` | — | 94 files already formatted |
| `mypy ja4plus/` | — | Success: no issues found in 27 source files |

`tests/foxio_deviations.json` holds 103 keys, which equals the xfailed count.

`tests/test_quic_crypto_buffer_bound.py` adds 15 tests. None allocates a large buffer:
each one asserts the bound before the allocation.

Verified against: https://www.rfc-editor.org/rfc/rfc9000#section-16 (RFC 9000)
Verified against: https://www.rfc-editor.org/rfc/rfc8446#section-5.1 (RFC 8446)

🤖 Generated with [Claude Code](https://claude.com/claude-code)