### PR TITLE
Hold the JA4L QUIC measurement points against the reference

### DIFF
--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -505,14 +505,20 @@ discards that packet, and it reports no value at all for the flow.
 `ClientInitial`, and its first state discards a `ServerInitial`.
 
 The FoxIO Rust implementation is the only FoxIO implementation that reads a QUIC
-handshake, so it decides both cases. No FoxIO vector holds either case. Two synthetic
-captures measure them, and `tests/test_ja4l_quic_repeated_connection.py` holds the
-measurement:
+handshake, so it decides both cases. No FoxIO vector holds either case.
+`tests/build_quic_ja4l_captures.py` writes the two synthetic captures that measure
+them. The reference ran at the commit `tests/download_test_vectors.py` pins:
 
 ```
-ja4 quic_repeat.pcap     -> ja4l_c: 500_64   ja4l_s: 5000_56
-ja4 quic_mirrored.pcap   -> []
+$ ja4 quic_repeat.pcap
+  ja4l_c: 500_64
+  ja4l_s: 5000_56
+$ ja4 quic_mirrored.pcap
+[]
 ```
+
+`tests/test_ja4l_quic_repeated_connection.py` reads the same packets from the same
+builder, so the tests and the measurement cover one capture each.
 
 `ja4plus` reports the same value pair for the first capture. For the second capture it
 reports no server value, and it reports `JA4L-C=500_64` where the reference reports

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -491,6 +491,33 @@ The reference reads four QUIC packets, and it reads the direction from port 443:
 `JA4L-S` is half the time from `A` to `B`, and `JA4L-C` is half the time from `C`
 to `D`.
 
+### The QUIC measurement points never restart
+
+A client repeats a QUIC handshake over one address pair and port pair. The reference
+reads the first handshake, and it reports one value pair for the whole flow. It reads
+no later handshake.
+
+A server Initial packet arrives before its client Initial packet. The reference
+discards that packet, and it reports no value at all for the flow.
+
+`rust/ja4/src/time/udp.rs` states the mechanism. The state machine holds a terminal
+`Done` state that ignores every later packet. Its `Handshake` state discards a later
+`ClientInitial`, and its first state discards a `ServerInitial`.
+
+The FoxIO Rust implementation is the only FoxIO implementation that reads a QUIC
+handshake, so it decides both cases. No FoxIO vector holds either case. Two synthetic
+captures measure them, and `tests/test_ja4l_quic_repeated_connection.py` holds the
+measurement:
+
+```
+ja4 quic_repeat.pcap     -> ja4l_c: 500_64   ja4l_s: 5000_56
+ja4 quic_mirrored.pcap   -> []
+```
+
+`ja4plus` reports the same value pair for the first capture. For the second capture it
+reports no server value, and it reports `JA4L-C=500_64` where the reference reports
+nothing. #123 carries that open reading.
+
 ### A time of one second or more
 
 The FoxIO program reads the difference of two timestamps as a `timedelta`, and it

--- a/docs/specs/spec.md
+++ b/docs/specs/spec.md
@@ -80,6 +80,7 @@ that user, because comparison is the only thing a fingerprint is for.
 | Initial packet | noun | One QUIC packet whose long-header type is Initial. RFC 9000 Section 17.2 gives the layout. | first packet, opening packet |
 | connection ID | noun | The QUIC identifier that names one endpoint of a connection. The Initial keys derive from the one the client chooses. | CID, connection identifier, DCID |
 | Retry packet | noun | One QUIC packet that asks the client to send its Initial packet again with another connection ID. RFC 9000 Section 17.2.5 gives the layout. | retry, redirect |
+| Handshake packet | noun | One QUIC packet whose long-header type is Handshake. RFC 9000 Section 17.2.4 gives the layout. | handshake, HS packet |
 | key material | noun | One secret that decrypts recorded traffic, such as a TLS session key. | secret, key log, session keys |
 | Decryption Secrets Block | noun | The pcapng block that carries key material inside a capture file. | DSB, secrets block, key log block |
 

--- a/tests/build_quic_ja4l_captures.py
+++ b/tests/build_quic_ja4l_captures.py
@@ -1,0 +1,132 @@
+"""Build the two captures that measure the JA4L QUIC measurement points.
+
+No FoxIO vector holds a repeated QUIC connection, and none holds a server Initial
+packet that leads its client Initial packet. #123 asks for a behaviour change on both
+cases, so both need a measurement of the reference.
+
+These two captures supply it. They are synthetic. The packets carry no real handshake,
+because JA4L reads the long-header packet type and the direction only.
+
+Run this file to write the captures:
+
+```
+python tests/build_quic_ja4l_captures.py /tmp
+```
+
+Then build the FoxIO Rust implementation at the commit
+`tests/download_test_vectors.py` pins, and run it on each capture:
+
+```
+ja4 /tmp/quic_repeat.pcap
+ja4 /tmp/quic_mirrored.pcap
+```
+
+`docs/implementation_notes.md` records the output, and
+`tests/test_ja4l_quic_repeated_connection.py` holds `ja4plus` against it.
+"""
+
+import sys
+from pathlib import Path
+
+from scapy.all import IP, UDP, Ether, Raw, wrpcap
+
+from tests.quic_builder import (
+    ACK_FRAME,
+    client_initial,
+    crypto_frame,
+    handshake_packet,
+    server_hello,
+    server_initial,
+)
+
+CLIENT_IP = "10.0.0.1"
+SERVER_IP = "10.0.0.2"
+CLIENT_PORT = 44444
+SERVER_PORT = 443
+
+CLIENT_TTL = 64
+SERVER_TTL = 56
+
+FIRST_DCID = bytes.fromhex("0102030405060708")
+SECOND_DCID = bytes.fromhex("1112131415161718")
+
+SERVER_HELLO_FRAMES = crypto_frame(0, server_hello()) + ACK_FRAME
+
+
+# The FoxIO Rust implementation reads a capture through tshark, and tshark needs a
+# link layer. Every packet therefore carries one.
+def _to_server(payload, t):
+    """Return one client packet that carries the payload at the timestamp."""
+    packet = (
+        Ether()
+        / IP(src=CLIENT_IP, dst=SERVER_IP, ttl=CLIENT_TTL)
+        / UDP(sport=CLIENT_PORT, dport=SERVER_PORT)
+        / Raw(load=payload)
+    )
+    packet.time = t
+    return packet
+
+
+def _from_server(payload, t):
+    """Return one server packet that carries the payload at the timestamp."""
+    packet = (
+        Ether()
+        / IP(src=SERVER_IP, dst=CLIENT_IP, ttl=SERVER_TTL)
+        / UDP(sport=SERVER_PORT, dport=CLIENT_PORT)
+        / Raw(load=payload)
+    )
+    packet.time = t
+    return packet
+
+
+def handshake_round(dcid, base):
+    """Return the four packets of one complete QUIC handshake.
+
+    Args:
+        dcid: The connection ID the client chooses.
+        base: The timestamp of the client Initial packet, in seconds.
+
+    Returns:
+        The client Initial packet, the server Initial packet, one server Handshake
+        packet and one client Handshake packet, in that order.
+    """
+    return [
+        _to_server(client_initial(dcid), base + 0.000),
+        _from_server(server_initial(dcid, SERVER_HELLO_FRAMES), base + 0.010),
+        _from_server(handshake_packet(), base + 0.011),
+        _to_server(handshake_packet(), base + 0.012),
+    ]
+
+
+def mirrored_round(dcid, base):
+    """Return the four packets of one handshake whose server Initial packet leads.
+
+    Args:
+        dcid: The connection ID the client chooses.
+        base: The timestamp of the server Initial packet, in seconds.
+
+    Returns:
+        The server Initial packet, the client Initial packet, one server Handshake
+        packet and one client Handshake packet, in that order.
+    """
+    return [
+        _from_server(server_initial(dcid, SERVER_HELLO_FRAMES), base + 0.000),
+        _to_server(client_initial(dcid), base + 0.010),
+        _from_server(handshake_packet(), base + 0.011),
+        _to_server(handshake_packet(), base + 0.012),
+    ]
+
+
+def write_captures(directory):
+    """Write both captures into the directory and return their two paths."""
+    directory = Path(directory)
+    repeat = directory / "quic_repeat.pcap"
+    mirrored = directory / "quic_mirrored.pcap"
+    wrpcap(str(repeat), handshake_round(FIRST_DCID, 1000.0) + handshake_round(SECOND_DCID, 1001.0))
+    wrpcap(str(mirrored), mirrored_round(FIRST_DCID, 2000.0))
+    return repeat, mirrored
+
+
+if __name__ == "__main__":
+    for path in write_captures(sys.argv[1] if len(sys.argv) > 1 else "."):
+        print(path)

--- a/tests/quic_builder.py
+++ b/tests/quic_builder.py
@@ -99,8 +99,8 @@ def handshake_packet(payload_length=32, version=QUIC_VERSION_1):
     """Return the UDP payload of one QUIC Handshake packet.
 
     The packet carries no readable frame. A JA4L test reads the packet type only.
-    RFC 9001 Section 5.4.1 protects the low four bits of the first byte, and it leaves
-    bits 4 and 5 clear, so a reader states the packet type without any key.
+    RFC 9001 Section 5.4.1 protects the low four bits of the first byte. It leaves bits
+    4 and 5 clear, so a reader states the packet type without any key.
 
     Args:
         payload_length: The number of protected payload bytes.

--- a/tests/quic_builder.py
+++ b/tests/quic_builder.py
@@ -14,7 +14,7 @@ import struct
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from ja4plus.utils.quic_utils import derive_initial_secrets, derive_key_iv_hp
+from ja4plus.utils.quic_utils import QUIC_HANDSHAKE, derive_initial_secrets, derive_key_iv_hp
 
 # The QUIC version 1 number, which RFC 9000 Section 15 gives as 0x00000001.
 QUIC_VERSION_1 = 1
@@ -93,6 +93,28 @@ def client_initial(dcid, version=QUIC_VERSION_1):
     header += encode_varint(len(payload) + 1)
     header += b"\x00"  # The packet number.
     return header + payload
+
+
+def handshake_packet(payload_length=32, version=QUIC_VERSION_1):
+    """Return the UDP payload of one QUIC Handshake packet.
+
+    The packet carries no readable frame. A JA4L test reads the packet type only.
+    RFC 9001 Section 5.4.1 protects the low four bits of the first byte, and it leaves
+    bits 4 and 5 clear, so a reader states the packet type without any key.
+
+    Args:
+        payload_length: The number of protected payload bytes.
+        version: The QUIC version number.
+
+    Returns:
+        The bytes of the UDP payload.
+    """
+    header = bytes([0xC0 | (QUIC_HANDSHAKE << 4)]) + struct.pack("!I", version)
+    header += b"\x00"  # An empty destination connection ID.
+    header += b"\x00"  # An empty source connection ID.
+    header += encode_varint(payload_length + 1)
+    header += b"\x00"  # The packet number.
+    return header + b"\x00" * payload_length
 
 
 def server_initial(client_dcid, plaintext, packet_number=0, version=QUIC_VERSION_1, trailer=b""):

--- a/tests/test_ja4l_quic_repeated_connection.py
+++ b/tests/test_ja4l_quic_repeated_connection.py
@@ -1,120 +1,79 @@
 """Tests for the JA4L QUIC measurement points across a repeated connection.
 
-Issue #123 asks the QUIC path to restart its measurement points when a client repeats
-the handshake over one address pair and port pair, and to complete the server value
-when a server Initial packet arrives before its client Initial packet. The FoxIO Rust
-implementation is the only FoxIO implementation that reads a QUIC handshake, so it
-decides both cases. A measurement of it at the pinned commit rejects both changes.
+#123 asks the QUIC path to restart its measurement points when a client repeats the
+handshake over one address pair and port pair. It also asks the path to complete the
+server value when a server Initial packet leads its client Initial packet.
 
-The measurement used two synthetic captures that `tests/quic_builder.py` builds:
+The FoxIO Rust implementation is the only FoxIO implementation that reads a QUIC
+handshake, so it decides both cases. A measurement of it rejects both changes.
 
-    ja4 /tmp/quic_repeat.pcap     -> ja4l_c: 500_64   ja4l_s: 5000_56
-    ja4 /tmp/quic_mirrored.pcap   -> []
+`tests/build_quic_ja4l_captures.py` writes the two captures the measurement reads, and
+these tests read the same packets from the same builder. The reference ran at commit
+`27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8`, which `tests/download_test_vectors.py`
+pins:
+
+    $ ja4 quic_repeat.pcap
+      ja4l_c: 500_64
+      ja4l_s: 5000_56
+    $ ja4 quic_mirrored.pcap
+    []
 
 The first capture holds two complete handshakes over one address pair and port pair.
-The reference reports one value pair, and it reads the first handshake. The second
+The reference reports one value pair, so it restarts on neither handshake. The second
 capture holds one server Initial packet before its client Initial packet. The
-reference reports nothing, so it never completes the server value.
+reference reports no value at all, so it completes no server value.
 
 `rust/ja4/src/time/udp.rs` states the mechanism. The state machine holds a terminal
-`Done` state that ignores every later packet, and its `Handshake` state discards a
-later `ClientInitial`. Its first state discards a `ServerInitial`.
+`Done` state that ignores every later packet. Its `Handshake` state discards a later
+`ClientInitial`, and its first state discards a `ServerInitial`.
 
-These tests hold the two readers together on the cases the vector set omits. A restart
-would make this project report a value pair the reference does not report.
-
-Measured against the FoxIO reference at commit
-27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8, which `tests/download_test_vectors.py` pins.
+These tests hold `ja4plus` against those two measurements, so that a restart cannot
+land without a vector.
 """
 
-from scapy.all import IP, UDP, Raw
+from tests.build_quic_ja4l_captures import (
+    FIRST_DCID,
+    SECOND_DCID,
+    handshake_round,
+    mirrored_round,
+)
 
 from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
 
-from tests.quic_builder import (
-    ACK_FRAME,
-    client_initial,
-    crypto_frame,
-    handshake_packet,
-    server_hello,
-    server_initial,
-)
 
-CLIENT_IP = "10.0.0.1"
-SERVER_IP = "10.0.0.2"
-CLIENT_PORT = 44444
-SERVER_PORT = 443
-
-FIRST_DCID = bytes.fromhex("0102030405060708")
-SECOND_DCID = bytes.fromhex("1112131415161718")
-
-SERVER_HELLO_FRAMES = crypto_frame(0, server_hello()) + ACK_FRAME
-
-CLIENT_TTL = 64
-SERVER_TTL = 56
-
-
-def _to_server(payload, t):
-    """Return one client packet that carries the payload at the timestamp."""
-    packet = (
-        IP(src=CLIENT_IP, dst=SERVER_IP, ttl=CLIENT_TTL)
-        / UDP(sport=CLIENT_PORT, dport=SERVER_PORT)
-        / Raw(load=payload)
-    )
-    packet.time = t
-    return packet
-
-
-def _from_server(payload, t):
-    """Return one server packet that carries the payload at the timestamp."""
-    packet = (
-        IP(src=SERVER_IP, dst=CLIENT_IP, ttl=SERVER_TTL)
-        / UDP(sport=SERVER_PORT, dport=CLIENT_PORT)
-        / Raw(load=payload)
-    )
-    packet.time = t
-    return packet
-
-
-def _handshake_round(fingerprinter, dcid, base):
-    """Send the four packets of one complete QUIC handshake to the fingerprinter."""
-    fingerprinter.process_packet(_to_server(client_initial(dcid), base + 0.000))
-    fingerprinter.process_packet(
-        _from_server(server_initial(dcid, SERVER_HELLO_FRAMES), base + 0.010)
-    )
-    fingerprinter.process_packet(_from_server(handshake_packet(), base + 0.011))
-    fingerprinter.process_packet(_to_server(handshake_packet(), base + 0.012))
+def _read(packets):
+    """Return the JA4L values one fingerprinter reports for the packets."""
+    fingerprinter = JA4LFingerprinter()
+    for packet in packets:
+        fingerprinter.process_packet(packet)
+    return [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
 
 
 def test_a_repeated_quic_handshake_reports_one_value_pair():
-    """The fingerprinter reads the first handshake and reports no second value pair.
+    """The fingerprinter reports one value pair for two handshakes on one port pair.
 
-    The reference reports `ja4l_c: 500_64` and `ja4l_s: 5000_56` for this traffic. A
-    restart on the second client Initial packet would report the second handshake as
-    well, and no FoxIO implementation reports it.
+    The reference reports `ja4l_c: 500_64` and `ja4l_s: 5000_56` for this capture, and
+    `ja4plus` reports the same pair. A restart on the second client Initial packet
+    would report a second pair that no FoxIO implementation reports.
     """
-    fingerprinter = JA4LFingerprinter()
-    _handshake_round(fingerprinter, FIRST_DCID, 1000.0)
-    _handshake_round(fingerprinter, SECOND_DCID, 1001.0)
+    packets = handshake_round(FIRST_DCID, 1000.0) + handshake_round(SECOND_DCID, 1001.0)
 
-    values = [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
-    assert values == ["JA4L-S=5000_56", "JA4L-C=500_64"]
+    assert _read(packets) == ["JA4L-S=5000_56", "JA4L-C=500_64"]
 
 
-def test_a_server_initial_packet_before_its_client_initial_packet_gives_no_server_value():
+def test_a_leading_server_initial_packet_gives_no_server_value():
     """The fingerprinter completes no server value from a server Initial packet that leads.
 
-    The reference reports nothing at all for this traffic, so it holds no server value.
-    A server measurement point taken from the leading packet would report a latency the
+    The reference reports no value at all for this capture, so it holds no server
+    value. A server point taken from the leading packet would report a latency the
     reference does not report.
-    """
-    fingerprinter = JA4LFingerprinter()
-    fingerprinter.process_packet(
-        _from_server(server_initial(FIRST_DCID, SERVER_HELLO_FRAMES), 2000.000)
-    )
-    fingerprinter.process_packet(_to_server(client_initial(FIRST_DCID), 2000.010))
-    fingerprinter.process_packet(_from_server(handshake_packet(), 2000.011))
-    fingerprinter.process_packet(_to_server(handshake_packet(), 2000.012))
 
-    values = [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
-    assert not [value for value in values if value.startswith("JA4L-S=")]
+    The client value below is a known divergence, and #123 carries it. The reference
+    reports a value pair only when it collects all four measurement points, and
+    `ja4plus` reports each value as it reads it. This test states the divergence so
+    that a change to it stays deliberate.
+    """
+    values = _read(mirrored_round(FIRST_DCID, 2000.0))
+
+    assert [value for value in values if value.startswith("JA4L-S=")] == []
+    assert values == ["JA4L-C=500_64"]

--- a/tests/test_ja4l_quic_repeated_connection.py
+++ b/tests/test_ja4l_quic_repeated_connection.py
@@ -1,0 +1,120 @@
+"""Tests for the JA4L QUIC measurement points across a repeated connection.
+
+Issue #123 asks the QUIC path to restart its measurement points when a client repeats
+the handshake over one address pair and port pair, and to complete the server value
+when a server Initial packet arrives before its client Initial packet. The FoxIO Rust
+implementation is the only FoxIO implementation that reads a QUIC handshake, so it
+decides both cases. A measurement of it at the pinned commit rejects both changes.
+
+The measurement used two synthetic captures that `tests/quic_builder.py` builds:
+
+    ja4 /tmp/quic_repeat.pcap     -> ja4l_c: 500_64   ja4l_s: 5000_56
+    ja4 /tmp/quic_mirrored.pcap   -> []
+
+The first capture holds two complete handshakes over one address pair and port pair.
+The reference reports one value pair, and it reads the first handshake. The second
+capture holds one server Initial packet before its client Initial packet. The
+reference reports nothing, so it never completes the server value.
+
+`rust/ja4/src/time/udp.rs` states the mechanism. The state machine holds a terminal
+`Done` state that ignores every later packet, and its `Handshake` state discards a
+later `ClientInitial`. Its first state discards a `ServerInitial`.
+
+These tests hold the two readers together on the cases the vector set omits. A restart
+would make this project report a value pair the reference does not report.
+
+Measured against the FoxIO reference at commit
+27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8, which `tests/download_test_vectors.py` pins.
+"""
+
+from scapy.all import IP, UDP, Raw
+
+from ja4plus.fingerprinters.ja4l import JA4LFingerprinter
+
+from tests.quic_builder import (
+    ACK_FRAME,
+    client_initial,
+    crypto_frame,
+    handshake_packet,
+    server_hello,
+    server_initial,
+)
+
+CLIENT_IP = "10.0.0.1"
+SERVER_IP = "10.0.0.2"
+CLIENT_PORT = 44444
+SERVER_PORT = 443
+
+FIRST_DCID = bytes.fromhex("0102030405060708")
+SECOND_DCID = bytes.fromhex("1112131415161718")
+
+SERVER_HELLO_FRAMES = crypto_frame(0, server_hello()) + ACK_FRAME
+
+CLIENT_TTL = 64
+SERVER_TTL = 56
+
+
+def _to_server(payload, t):
+    """Return one client packet that carries the payload at the timestamp."""
+    packet = (
+        IP(src=CLIENT_IP, dst=SERVER_IP, ttl=CLIENT_TTL)
+        / UDP(sport=CLIENT_PORT, dport=SERVER_PORT)
+        / Raw(load=payload)
+    )
+    packet.time = t
+    return packet
+
+
+def _from_server(payload, t):
+    """Return one server packet that carries the payload at the timestamp."""
+    packet = (
+        IP(src=SERVER_IP, dst=CLIENT_IP, ttl=SERVER_TTL)
+        / UDP(sport=SERVER_PORT, dport=CLIENT_PORT)
+        / Raw(load=payload)
+    )
+    packet.time = t
+    return packet
+
+
+def _handshake_round(fingerprinter, dcid, base):
+    """Send the four packets of one complete QUIC handshake to the fingerprinter."""
+    fingerprinter.process_packet(_to_server(client_initial(dcid), base + 0.000))
+    fingerprinter.process_packet(
+        _from_server(server_initial(dcid, SERVER_HELLO_FRAMES), base + 0.010)
+    )
+    fingerprinter.process_packet(_from_server(handshake_packet(), base + 0.011))
+    fingerprinter.process_packet(_to_server(handshake_packet(), base + 0.012))
+
+
+def test_a_repeated_quic_handshake_reports_one_value_pair():
+    """The fingerprinter reads the first handshake and reports no second value pair.
+
+    The reference reports `ja4l_c: 500_64` and `ja4l_s: 5000_56` for this traffic. A
+    restart on the second client Initial packet would report the second handshake as
+    well, and no FoxIO implementation reports it.
+    """
+    fingerprinter = JA4LFingerprinter()
+    _handshake_round(fingerprinter, FIRST_DCID, 1000.0)
+    _handshake_round(fingerprinter, SECOND_DCID, 1001.0)
+
+    values = [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
+    assert values == ["JA4L-S=5000_56", "JA4L-C=500_64"]
+
+
+def test_a_server_initial_packet_before_its_client_initial_packet_gives_no_server_value():
+    """The fingerprinter completes no server value from a server Initial packet that leads.
+
+    The reference reports nothing at all for this traffic, so it holds no server value.
+    A server measurement point taken from the leading packet would report a latency the
+    reference does not report.
+    """
+    fingerprinter = JA4LFingerprinter()
+    fingerprinter.process_packet(
+        _from_server(server_initial(FIRST_DCID, SERVER_HELLO_FRAMES), 2000.000)
+    )
+    fingerprinter.process_packet(_to_server(client_initial(FIRST_DCID), 2000.010))
+    fingerprinter.process_packet(_from_server(handshake_packet(), 2000.011))
+    fingerprinter.process_packet(_to_server(handshake_packet(), 2000.012))
+
+    values = [entry["fingerprint"] for entry in fingerprinter.get_fingerprints()]
+    assert not [value for value in values if value.startswith("JA4L-S=")]


### PR DESCRIPTION
Refs #123.

## Verdict: the reference rejects both changes this issue asks for

#123 asks for two changes to `_quic_ja4l`:

1. Restart the measurement points when a client repeats the handshake over one address
   pair and port pair.
2. Complete the server value when a server Initial packet arrives before its client
   Initial packet.

`CLAUDE.md` rule 1 binds this issue: a fingerprint changes only when a FoxIO vector
requires it. No vector holds either case, which the issue records. So I measured the
reference instead of reading it.

The FoxIO Rust implementation is the only FoxIO implementation that reads a QUIC
handshake, and `.claude/rules/external-apis.md` makes it decide where the Python file
holds no value for a stream. I built it at the pinned commit
`27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8` and ran it on two synthetic captures.

I first confirmed the binary reproduces a committed vector, so the harness is sound:

```
$ ja4 tests/foxio_vectors/chrome-cloudflare-quic-with-secrets.pcapng
  ja4l_c: 113_64
  ja4l_s: 9285_56
```

That matches `tests/foxio_vectors/rust_expected/ja4__insta@chrome-cloudflare-quic-with-secrets.pcapng.snap` exactly.

### Case 1 — a repeated QUIC handshake

The capture holds two complete four-packet handshakes over one address pair and port
pair, 1 second apart, with different connection IDs.

```
$ ja4 quic_repeat.pcap
- stream: 0
  transport: udp
  src: 10.0.0.1
  dst: 10.0.0.2
  src_port: 44444
  dst_port: 443
  ja4s: q000000_0000_000000000000
  ja4l_c: 500_64
  ja4l_s: 5000_56

$ ja4plus   ->  ['JA4L-S=5000_56', 'JA4L-C=500_64']
```

The two readers agree. The reference reports one value pair, and it reads the first
handshake. It does not restart. The restart this issue asks for would make `ja4plus`
report a second value pair that no FoxIO implementation reports.

### Case 2 — a server Initial packet before its client Initial packet

```
$ ja4 quic_mirrored.pcap
[]

$ ja4plus   ->  ['JA4L-C=500_64']
```

The reference reports nothing at all. It discards the leading server Initial packet,
exactly as `ja4plus` does, and it then never reaches its terminal state. Completing the
server value would move `ja4plus` further from the reference, not closer.

`rust/ja4/src/time/udp.rs` states the mechanism, and the measurement confirms it. The
state machine holds a terminal `Done` state that ignores every later packet. Its
`Handshake` state discards a later `ClientInitial`, and its first state discards a
`ServerInitial`.

## What this pull request contains

No fingerprinter changes. No fingerprint moves.

- `tests/test_ja4l_quic_repeated_connection.py` — two tests that hold the measured
  reference behaviour, so a later restart cannot land without a vector.
- `tests/quic_builder.py` — a `handshake_packet` builder the tests need.
- `docs/implementation_notes.md` — the reading, under JA4L.

I proved the first test binds. With the restart the issue describes applied to
`_quic_client_initial`, it fails:

```
E       AssertionError: assert ['JA4L-S=5000...A4L-C=500_64'] == ['JA4L-S=5000...A4L-C=500_64']
E         Left contains 2 more items, first extra item: 'JA4L-S=5000_56'
```

## The open question

Case 2 leaves one real divergence, and it is not the one the issue names. On a capture
whose server Initial packet leads, the reference reports no value, and `ja4plus`
reports `JA4L-C=500_64`. `ja4plus` emits each value as it reads it, and the reference
emits a value pair only when it collects all four points. This pull request does not
change that, because suppressing a partial value is a wider decision than #123 covers.

## Gates

```
pytest tests/ -m "not spec_validation"   919 passed, 8 xfailed, 93 subtests passed
pytest tests/ -m spec_validation         1342 passed, 141 skipped, 103 xfailed
ruff check ja4plus/ tests/               All checks passed!
ruff format --check ja4plus/ tests/      97 files already formatted
mypy ja4plus/                            Success: no issues found in 27 source files
```

The register invariant holds. `pytest tests/ -m spec_validation` reports `103 xfailed`,
and `tests/foxio_deviations.json` holds 103 keys. Neither moved.

Verified against: https://github.com/FoxIO-LLC/ja4/blob/27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8/rust/ja4/src/time/udp.rs (retrieved 2026-08-07)
