### PR TITLE
Bound a TLS hello on its own length field, not on the record length

### DIFF
--- a/.claude/rules/external-apis.md
+++ b/.claude/rules/external-apis.md
@@ -61,11 +61,12 @@ streams and omits six, and the Rust snapshot holds all thirteen. Where the Pytho
 holds no value for a stream and the Rust snapshot holds one, the Rust snapshot decides.
 Where both carry a value for one method on one stream, `python/test/testdata/` decides.
 
-The FoxIO Python implementation reads no QUIC handshake, and it reads no TLS on a port it
-does not know. Those two gaps produce every case. `tests/foxio_vectors/rust_expected/`
-holds a copy of the eight snapshots that cover them, and
-`tests/test_foxio_rust_parity.py` measures the match. #138 records the reading, and
-`docs/implementation_notes.md` holds the table.
+The FoxIO Python implementation has three gaps. It reads no QUIC handshake, it reads no
+TLS on a port it does not know, and it reads no ServerHello whose handshake record spans
+several TCP segments. Those three gaps produce every case.
+`tests/foxio_vectors/rust_expected/` holds a copy of the ten snapshots that cover them,
+and `tests/test_foxio_rust_parity.py` measures the match. #138 records the first two
+readings, #151 records the third, and `docs/implementation_notes.md` holds both tables.
 
 Read this rule at stream granularity. An earlier form read "only where the Python file
 holds an empty array", and that form covered one capture of the eight.

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -859,3 +859,79 @@ all other non-zero versions use the v1 salt.
 
 **Integration:** `extract_tls_info` checks for QUIC on UDP packets
 before falling through to standard TLS parsing.
+
+---
+
+## A hello is bounded on its own length field, not on the record length
+
+Issue #151 asked why `ja4plus` read no ServerHello on three streams for which the FoxIO
+Rust snapshot holds a JA4S value. The three share one cause, and the cause was a defect
+in this project.
+
+### The mechanism
+
+A TLS handshake record carries one or more handshake messages. A TLS 1.2 server puts the
+ServerHello, the Certificate, the ServerKeyExchange and the ServerHelloDone in one
+record. That record is longer than one TCP segment, so the first segment holds the whole
+ServerHello and only part of the record.
+
+`parse_tls_handshake` bounded the hello on the record length field. It returned nothing
+whenever the segment held less than the record declared, so it never read a ServerHello
+that a coalesced record carries. The bound now reads the three-byte length field of the
+handshake message at offset 6, and the reader slices the buffer at the end of that
+message. The slice keeps the reader inside the hello, because the bytes that follow
+belong to the Certificate message.
+
+### The measurement
+
+The first server data packet of each stream, read with `scapy`:
+
+| Capture | Stream | Packet | Segment bytes | Record needs | ServerHello ends at byte |
+|---|---|---|---|---|---|
+| `ssh2.pcapng` | `57374 <-> 52.178.17.3:443` | 232 | 1452 | 6296 | 94 |
+| `ssh2.pcapng` | `57375 <-> 204.79.197.220:443` | 254 | 1452 | 7036 | 107 |
+| `tls-handshake.pcapng` | `50167 <-> 40.126.24.84:443` | 148 | 1460 | 3955 | 98 |
+| `browsers-x509.pcapng` | `54524 <-> 13.107.21.239:443` | 5 | 1458 | 5947 | 111 |
+| `latest.pcapng` | `52940 <-> 52.249.29.248:443` | 158 | 1452 | 7141 | 94 |
+| `latest.pcapng` | `52941 <-> 52.249.29.248:443` | 192 | 1452 | 7141 | 94 |
+| `socks4-https.pcap` | `50606 <-> 10.0.0.2:9901` | 8 | 1360 | 6776 | 90 |
+
+Every row reads the same way. The record needs more bytes than the segment carries, and
+the ServerHello ends inside the segment.
+
+### The third gap in the FoxIO Python implementation
+
+`.claude/rules/external-apis.md` named two gaps before this issue: the FoxIO Python
+implementation reads no QUIC handshake, and it reads no TLS on a port it does not know.
+This is a third gap. The FoxIO Python expected-output file omits the JA4S value of every
+stream in the table, and the FoxIO Rust snapshot holds it for six of the seven.
+
+`tls-handshake.pcapng` proves the gap on one capture. Stream `50167` runs on port 443, so
+neither of the first two gaps explains the omission, and the Rust snapshot holds
+`t120400_c030_4e8089b08790` for it.
+
+The six streams the Rust snapshot covers each produce the Rust value.
+`tests/test_foxio_rust_parity.py` holds the measurement in
+`TestTheStreamsThatCoalesceTheServerHelloRecord`. The snapshots of
+`browsers-x509.pcapng` and `latest.pcapng` join the vector set for that measurement.
+
+### The seventh stream
+
+`socks4-https.pcap` stream `50606 <-> 10.0.0.2:9901` is the one exception. The FoxIO Rust
+snapshot holds `ja4t`, `ja4l_c` and `ja4l_s` for it, and no `ja4s` and no `ja4`. No FoxIO
+implementation holds a JA4S value for the stream.
+
+`ja4plus` reads the record layer without regard to the tunnel protocol that carries it,
+which is the behaviour #138 decided to keep for the three JA4X values on the same stream.
+The register records the JA4S value under the same decision.
+
+### The register
+
+The register rises from 99 keys to 104, and the conformance suite reports 104 xfailed.
+The five new keys are `browsers-x509.pcapng/JA4S`, `browsers-x509.pcapng/JA4S_r`,
+`latest.pcapng/JA4S`, `latest.pcapng/JA4S_r` and `socks4-https.pcap/JA4S`. The existing
+`ssh2.pcapng` and `tls-handshake.pcapng` JA4S keys hold the capture, so they absorb the
+three streams #151 names, and their cause text now records the second reason.
+
+Verified against: https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1 (TLS 1.2, retrieved 2026-08-07)
+Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/rust/ja4/src/snapshots (commit 27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8)

--- a/ja4plus/utils/tls_utils.py
+++ b/ja4plus/utils/tls_utils.py
@@ -66,15 +66,25 @@ def parse_tls_handshake(raw_data):
         record_type = raw_data[offset]
         record_length = (raw_data[offset + 3] << 8) | raw_data[offset + 4]
 
-        if record_type == 0x16 and offset + 6 <= len(raw_data):  # 0x16 = Handshake
+        if record_type == 0x16 and offset + 9 <= len(raw_data):  # 0x16 = Handshake
             handshake_type = raw_data[offset + 5]
 
             if handshake_type in (1, 2):
-                # A truncated record holds no complete hello.
-                if offset + 5 + record_length > len(raw_data):
+                # A handshake record carries one or more handshake messages, so the
+                # record length bounds the group and not the hello. A TLS 1.2 server
+                # coalesces the ServerHello, the Certificate and the ServerHelloDone
+                # into one record that spans several TCP segments, and issue #151 names
+                # the three FoxIO streams the record bound rejected.
+                handshake_length = int.from_bytes(raw_data[offset + 6 : offset + 9], "big")
+                end = offset + 9 + handshake_length
+                # A hello the segment cuts holds no cipher and no extension list.
+                if end > len(raw_data):
                     return None
 
-                record = raw_data[offset:]
+                # The slice stops at the end of the hello, because the bytes that follow
+                # belong to the next handshake message. A reader that walks into them
+                # reports an extension the peer never sent.
+                record = raw_data[offset:end]
                 if handshake_type == 1:
                     return _parse_client_hello(record)
                 return _parse_server_hello(record)

--- a/tests/download_test_vectors.py
+++ b/tests/download_test_vectors.py
@@ -78,13 +78,17 @@ WIRESHARK_CAPTURES = [
     "dhcpv6.pcap",
 ]
 
-# The FoxIO Python implementation reads no QUIC handshake, and it reads no TLS on a port
-# it does not know. The FoxIO Rust implementation reads both, so its snapshot holds a
-# stream that the expected-output file of the same capture omits. Issue #138 settles
-# those streams, and `tests/test_foxio_rust_parity.py` holds the measurement.
+# The FoxIO Python implementation reads no QUIC handshake, it reads no TLS on a port it
+# does not know, and it reads no ServerHello whose handshake record spans several TCP
+# segments. The FoxIO Rust implementation reads all three, so its snapshot holds a
+# stream that the expected-output file of the same capture omits. Issue #138 settles the
+# first two, issue #151 settles the third, and `tests/test_foxio_rust_parity.py` holds
+# the measurement.
 RUST_CAPTURES = [
+    "browsers-x509.pcapng",
     "chrome-cloudflare-quic-with-secrets.pcapng",
     "https-connect.pcap",
+    "latest.pcapng",
     "quic-tls-handshake.pcapng",
     "quic-with-several-tls-frames.pcapng",
     "ssh2.pcapng",
@@ -136,10 +140,12 @@ for each of these captures:
 
 {rust_captures}
 
-The FoxIO Python implementation reads no QUIC handshake, and it reads no TLS on a
-port it does not know. The FoxIO Rust implementation reads both, so each snapshot
-above holds a stream that `{expected_dir}/<capture>.json` omits. Issue #138 settles
-those streams, and `tests/test_foxio_rust_parity.py` holds the measurement.
+The FoxIO Python implementation reads no QUIC handshake, it reads no TLS on a port
+it does not know, and it reads no ServerHello whose handshake record spans several
+TCP segments. The FoxIO Rust implementation reads all three, so each snapshot above
+holds a stream that `{expected_dir}/<capture>.json` omits. Issue #138 settles the
+first two gaps, issue #151 settles the third, and `tests/test_foxio_rust_parity.py`
+holds the measurement.
 
 The conformance suite reads only the top level of this directory, so neither
 subdirectory adds a case to it.

--- a/tests/foxio_deviation_owners.json
+++ b/tests/foxio_deviation_owners.json
@@ -30,6 +30,11 @@
       "state": "open",
       "title": "Settle whether ja4plus emits a fingerprint on a stream the FoxIO reference ignores"
     },
+    "151": {
+      "epic": false,
+      "state": "open",
+      "title": "Read the JA4S ServerHello on three streams the FoxIO Rust implementation holds a value for"
+    },
     "34": {
       "epic": false,
       "state": "open",

--- a/tests/foxio_deviations.json
+++ b/tests/foxio_deviations.json
@@ -15,6 +15,16 @@
     "cause": "ja4plus emits more JA4L-S values than the reference holds.",
     "issue": 34
   },
+  "browsers-x509.pcapng/JA4S": {
+    "cause": "The FoxIO Rust snapshot holds the exact JA4S value ja4plus produces. The server coalesces the ServerHello, the Certificate and the ServerHelloDone into one handshake record that spans several TCP segments, and the FoxIO Python implementation reads no such ServerHello, so its expected-output file omits the stream. tests/test_foxio_rust_parity.py measures the match.",
+    "issue": 151,
+    "decided": true
+  },
+  "browsers-x509.pcapng/JA4S_r": {
+    "cause": "ja4plus produces a JA4S_r value on a stream the FoxIO Python expected-output file omits. The server coalesces the ServerHello, the Certificate and the ServerHelloDone into one handshake record that spans several TCP segments, and the FoxIO Python implementation reads no such ServerHello. The FoxIO Rust snapshot holds the hashed form of the same stream, and it equals the value ja4plus produces. The reference publishes no raw form for the stream.",
+    "issue": 151,
+    "decided": true
+  },
   "chrome-cloudflare-quic-with-secrets.pcapng/0:57098/JA4H.1": {
     "cause": "The reference decrypts the QUIC traffic with the secrets the capture carries, and ja4plus reads no encrypted request.",
     "issue": 129
@@ -261,6 +271,16 @@
     "issue": 138,
     "decided": true
   },
+  "latest.pcapng/JA4S": {
+    "cause": "The FoxIO Rust snapshot holds the exact JA4S value ja4plus produces. The server coalesces the ServerHello, the Certificate and the ServerHelloDone into one handshake record that spans several TCP segments, and the FoxIO Python implementation reads no such ServerHello, so its expected-output file omits the stream. tests/test_foxio_rust_parity.py measures the match.",
+    "issue": 151,
+    "decided": true
+  },
+  "latest.pcapng/JA4S_r": {
+    "cause": "ja4plus produces a JA4S_r value on a stream the FoxIO Python expected-output file omits. The server coalesces the ServerHello, the Certificate and the ServerHelloDone into one handshake record that spans several TCP segments, and the FoxIO Python implementation reads no such ServerHello. The FoxIO Rust snapshot holds the hashed form of the same stream, and it equals the value ja4plus produces. The reference publishes no raw form for the stream.",
+    "issue": 151,
+    "decided": true
+  },
   "quic-tls-handshake.pcapng/JA4": {
     "cause": "The FoxIO Rust snapshot holds the exact JA4 value ja4plus produces. The FoxIO Python implementation reads no QUIC handshake, so its expected-output file omits the stream. tests/test_foxio_rust_parity.py measures the match.",
     "issue": 138,
@@ -269,6 +289,11 @@
   "quic-with-several-tls-frames.pcapng/JA4": {
     "cause": "The FoxIO Rust snapshot holds the exact JA4 value ja4plus produces. The FoxIO Python implementation reads no QUIC handshake, so its expected-output file omits the stream. tests/test_foxio_rust_parity.py measures the match.",
     "issue": 138,
+    "decided": true
+  },
+  "socks4-https.pcap/JA4S": {
+    "cause": "ja4plus produces a JA4S value on the SOCKS4 tunnel on port 9901, and no FoxIO implementation holds one. ja4plus reads the record layer without regard to the tunnel protocol that carries it, which is the behaviour #138 decided to keep for the three JA4X values on the same stream. #151 made the value reachable by bounding a hello on its own length field rather than on the length of the record that carries it.",
+    "issue": 151,
     "decided": true
   },
   "socks4-https.pcap/JA4X": {
@@ -316,7 +341,7 @@
     "issue": 34
   },
   "ssh2.pcapng/JA4S": {
-    "cause": "The FoxIO Rust snapshot holds the exact JA4S value ja4plus produces. The FoxIO Python implementation reads no QUIC handshake, so its expected-output file omits the stream. tests/test_foxio_rust_parity.py measures the match.",
+    "cause": "The FoxIO Rust snapshot holds the exact JA4S value ja4plus produces. The FoxIO Python implementation reads no QUIC handshake, so its expected-output file omits the stream. It also reads no ServerHello whose handshake record spans several TCP segments, which omits the two streams #151 names. tests/test_foxio_rust_parity.py measures the match.",
     "issue": 138,
     "decided": true
   },
@@ -326,7 +351,7 @@
     "issue": 97
   },
   "ssh2.pcapng/JA4S_r": {
-    "cause": "ja4plus produces a JA4S_r value on a stream the FoxIO Python expected-output file omits. The FoxIO Python implementation reads no QUIC handshake. The FoxIO Rust snapshot holds the hashed form of the same stream, and it equals the value ja4plus produces. The reference publishes no raw form for the stream.",
+    "cause": "ja4plus produces a JA4S_r value on a stream the FoxIO Python expected-output file omits. The FoxIO Python implementation reads no QUIC handshake, and it reads no ServerHello whose handshake record spans several TCP segments. The FoxIO Rust snapshot holds the hashed form of the same stream, and it equals the value ja4plus produces. The reference publishes no raw form for the stream.",
     "issue": 138,
     "decided": true
   },
@@ -360,12 +385,12 @@
     "issue": 34
   },
   "tls-handshake.pcapng/JA4S": {
-    "cause": "The FoxIO Rust snapshot holds the exact JA4S value ja4plus produces. The FoxIO Python implementation reads no QUIC handshake, so its expected-output file omits the stream. tests/test_foxio_rust_parity.py measures the match.",
+    "cause": "The FoxIO Rust snapshot holds the exact JA4S value ja4plus produces. The FoxIO Python implementation reads no QUIC handshake, so its expected-output file omits the stream. It also reads no ServerHello whose handshake record spans several TCP segments, which omits the stream #151 names. tests/test_foxio_rust_parity.py measures the match.",
     "issue": 138,
     "decided": true
   },
   "tls-handshake.pcapng/JA4S_r": {
-    "cause": "ja4plus produces a JA4S_r value on a stream the FoxIO Python expected-output file omits. The FoxIO Python implementation reads no QUIC handshake. The FoxIO Rust snapshot holds the hashed form of the same stream, and it equals the value ja4plus produces. The reference publishes no raw form for the stream.",
+    "cause": "ja4plus produces a JA4S_r value on a stream the FoxIO Python expected-output file omits. The FoxIO Python implementation reads no QUIC handshake, and it reads no ServerHello whose handshake record spans several TCP segments. The FoxIO Rust snapshot holds the hashed form of the same stream, and it equals the value ja4plus produces. The reference publishes no raw form for the stream.",
     "issue": 138,
     "decided": true
   },

--- a/tests/foxio_vectors/NOTICE
+++ b/tests/foxio_vectors/NOTICE
@@ -28,15 +28,17 @@ The FoxIO Python implementation emits no JA4D and no JA4D6, so the two files und
 implementation that writes a reference value for the two methods.
 `docs/implementation_notes.md` records the reading.
 
-The subdirectory `rust_expected/` holds 8 more expected-output files:
+The subdirectory `rust_expected/` holds 10 more expected-output files:
 
     rust/ja4/src/snapshots/ja4__insta@<capture>.snap
         ->  tests/foxio_vectors/rust_expected/ja4__insta@<capture>.snap
 
 for each of these captures:
 
+    browsers-x509.pcapng
     chrome-cloudflare-quic-with-secrets.pcapng
     https-connect.pcap
+    latest.pcapng
     quic-tls-handshake.pcapng
     quic-with-several-tls-frames.pcapng
     ssh2.pcapng
@@ -44,10 +46,12 @@ for each of these captures:
     tls-sni.pcapng
     tls3.pcapng
 
-The FoxIO Python implementation reads no QUIC handshake, and it reads no TLS on a
-port it does not know. The FoxIO Rust implementation reads both, so each snapshot
-above holds a stream that `python/test/testdata/<capture>.json` omits. Issue #138 settles
-those streams, and `tests/test_foxio_rust_parity.py` holds the measurement.
+The FoxIO Python implementation reads no QUIC handshake, it reads no TLS on a port
+it does not know, and it reads no ServerHello whose handshake record spans several
+TCP segments. The FoxIO Rust implementation reads all three, so each snapshot above
+holds a stream that `python/test/testdata/<capture>.json` omits. Issue #138 settles the
+first two gaps, issue #151 settles the third, and `tests/test_foxio_rust_parity.py`
+holds the measurement.
 
 The conformance suite reads only the top level of this directory, so neither
 subdirectory adds a case to it.

--- a/tests/foxio_vectors/rust_expected/ja4__insta@browsers-x509.pcapng.snap
+++ b/tests/foxio_vectors/rust_expected/ja4__insta@browsers-x509.pcapng.snap
@@ -1,0 +1,115 @@
+---
+source: ja4/src/lib.rs
+expression: output
+---
+- stream: 0
+  transport: tcp
+  src: 172.27.7.31
+  dst: 13.107.21.239
+  src_port: 54524
+  dst_port: 443
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  tls_server_name: edge.microsoft.com
+  ja4: t13d1516h2_8daaf6152771_e5627efa2ab1
+  ja4s: t1206h2_c030_044dc9b3196d
+  tls_certs:
+  - x509:
+    - ja4x: a373a9f83c6b_2bab15409345_0f2217ba412e
+      issuerCountryName: US
+      issuerOrganizationName: Microsoft Corporation
+      issuerCommonName: Microsoft Azure TLS Issuing CA 05
+      subjectCountryName: US
+      subjectStateOrProvinceName: WA
+      subjectLocalityName: Redmond
+      subjectOrganizationName: Microsoft Corporation
+      subjectCommonName: edge.microsoft.com
+    - ja4x: 7d5dbb3783b4_a373a9f83c6b_c34b04c10969
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerOrganizationalUnit: www.digicert.com
+      issuerCommonName: DigiCert Global Root G2
+      subjectCountryName: US
+      subjectOrganizationName: Microsoft Corporation
+      subjectCommonName: Microsoft Azure TLS Issuing CA 05
+  ja4l_c: 56_128
+  ja4l_s: 1907_112
+- stream: 1
+  transport: tcp
+  src: 172.27.7.31
+  dst: 68.67.160.117
+  src_port: 54525
+  dst_port: 443
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  tls_server_name: nym1-ib.adnxs.com
+  ja4: t13d1516h2_8daaf6152771_e5627efa2ab1
+  ja4s: t1207h2_c02b_cf25e267ce22
+  tls_certs:
+  - x509:
+    - ja4x: 7d5dbb3783b4_2bab15409345_7bf9a7bf7029
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerOrganizationalUnit: www.digicert.com
+      issuerCommonName: GeoTrust ECC CA 2018
+      subjectCountryName: US
+      subjectStateOrProvinceName: New York
+      subjectLocalityName: New York
+      subjectOrganizationName: Xandr Inc.
+      subjectCommonName: '*.adnxs.com'
+    - ja4x: 7d5dbb3783b4_7d5dbb3783b4_44440d41940c
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerOrganizationalUnit: www.digicert.com
+      issuerCommonName: DigiCert Global Root CA
+      subjectCountryName: US
+      subjectOrganizationName: DigiCert Inc
+      subjectOrganizationalUnit: www.digicert.com
+      subjectCommonName: GeoTrust ECC CA 2018
+  ja4l_c: 73_128
+  ja4l_s: 7166_41
+- stream: 2
+  transport: tcp
+  src: 172.27.7.31
+  dst: 103.42.133.15
+  src_port: 54603
+  dst_port: 443
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  tls_server_name: lptag.liveperson.net
+  ja4: t13d1516h2_8daaf6152771_e5627efa2ab1
+  ja4s: t1205h2_c02f_845f7282a956
+  tls_certs:
+  - x509:
+    - ja4x: 2bab15409345_2e9214a636bc_b891c0ad6f32
+      issuerCountryName: GB
+      issuerStateOrProvinceName: Greater Manchester
+      issuerLocalityName: Salford
+      issuerOrganizationName: Sectigo Limited
+      issuerCommonName: Sectigo RSA Organization Validation Secure Server CA
+      subjectCountryName: US
+      subjectStateOrProvinceName: New York
+      subjectOrganizationName: LivePerson, Inc
+      subjectCommonName: '*.liveperson.net'
+    - ja4x: 2bab15409345_2bab15409345_2367ce7fbc5b
+      issuerCountryName: US
+      issuerStateOrProvinceName: New Jersey
+      issuerLocalityName: Jersey City
+      issuerOrganizationName: The USERTRUST Network
+      issuerCommonName: USERTrust RSA Certification Authority
+      subjectCountryName: GB
+      subjectStateOrProvinceName: Greater Manchester
+      subjectLocalityName: Salford
+      subjectOrganizationName: Sectigo Limited
+      subjectCommonName: Sectigo RSA Organization Validation Secure Server CA
+    - ja4x: 2bab15409345_2bab15409345_2030e37f3421
+      issuerCountryName: GB
+      issuerStateOrProvinceName: Greater Manchester
+      issuerLocalityName: Salford
+      issuerOrganizationName: Comodo CA Limited
+      issuerCommonName: AAA Certificate Services
+      subjectCountryName: US
+      subjectStateOrProvinceName: New Jersey
+      subjectLocalityName: Jersey City
+      subjectOrganizationName: The USERTRUST Network
+      subjectCommonName: USERTrust RSA Certification Authority
+  ja4l_c: 78_128
+  ja4l_s: 2948_229
+

--- a/tests/foxio_vectors/rust_expected/ja4__insta@latest.pcapng.snap
+++ b/tests/foxio_vectors/rust_expected/ja4__insta@latest.pcapng.snap
@@ -1,0 +1,151 @@
+---
+source: ja4/src/lib.rs
+expression: output
+---
+- stream: 1
+  transport: tcp
+  src: 172.16.225.48
+  dst: 34.212.93.65
+  src_port: 52936
+  dst_port: 443
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  tls_server_name: pdx-col.eum-appdynamics.com
+  ja4: t13d1516h2_8daaf6152771_e5627efa2ab1
+  ja4s: t1206h2_c02f_3603f09c43ba
+  tls_certs:
+  - x509:
+    - ja4x: a373a9f83c6b_2bab15409345_7bf9a7bf7029
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerCommonName: DigiCert Global G2 TLS RSA SHA256 2020 CA1
+      subjectCountryName: US
+      subjectStateOrProvinceName: California
+      subjectLocalityName: San Francisco
+      subjectOrganizationName: AppDynamics LLC
+      subjectCommonName: '*.eum-appdynamics.com'
+    - ja4x: 7d5dbb3783b4_a373a9f83c6b_a83ffcd6e6c2
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerOrganizationalUnit: www.digicert.com
+      issuerCommonName: DigiCert Global Root G2
+      subjectCountryName: US
+      subjectOrganizationName: DigiCert Inc
+      subjectCommonName: DigiCert Global G2 TLS RSA SHA256 2020 CA1
+  ja4l_c: 62_128
+  ja4l_s: 33804_227
+- stream: 3
+  transport: tcp
+  src: 172.16.225.48
+  dst: 13.33.165.101
+  src_port: 52937
+  dst_port: 443
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  tls_server_name: discovery.cem.cloud.us
+  ja4: t12d190800_d83cc789557e_7af1ed941c26
+  ja4s: t120600_c02f_51ad275821ba
+  tls_certs:
+  - x509:
+    - ja4x: a373a9f83c6b_2bab15409345_7bf9a7bf7029
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerCommonName: DigiCert TLS RSA SHA256 2020 CA1
+      subjectCountryName: US
+      subjectStateOrProvinceName: Florida
+      subjectLocalityName: Fort Lauderdale
+      subjectOrganizationName: Citrix Systems, Inc.
+      subjectCommonName: '*.cem.cloud.us'
+    - ja4x: 7d5dbb3783b4_a373a9f83c6b_a83ffcd6e6c2
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerOrganizationalUnit: www.digicert.com
+      issuerCommonName: DigiCert Global Root CA
+      subjectCountryName: US
+      subjectOrganizationName: DigiCert Inc
+      subjectCommonName: DigiCert TLS RSA SHA256 2020 CA1
+  ja4l_c: 57_128
+  ja4l_s: 7096_245
+- stream: 5
+  transport: tcp
+  src: 172.16.225.48
+  dst: 34.205.195.66
+  src_port: 52938
+  dst_port: 443
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  tls_server_name: app.slack.com
+  ja4: t13d1516h2_8daaf6152771_9b887d9acb53
+  ja4s: t130300_1301_6bbbaf601ed8
+  ja4l_c: 47_128
+  ja4l_s: 14207_43
+- stream: 6
+  transport: tcp
+  src: 172.16.225.48
+  dst: 23.43.242.57
+  src_port: 52939
+  dst_port: 80
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  ja4l_c: 32_128
+  ja4l_s: 3915_57
+  http:
+  - ja4h: ge11nn07enus_3e3b55d61660_000000000000_000000000000
+- stream: 9
+  transport: tcp
+  src: 172.16.225.48
+  dst: 52.249.29.248
+  src_port: 52940
+  dst_port: 443
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  tls_server_name: ping-edge.smartscreen.microsoft.com
+  ja4: t13d1516h2_8daaf6152771_e5627efa2ab1
+  ja4s: t120300_c030_09f674154ab3
+  tls_certs:
+  - x509:
+    - ja4x: a373a9f83c6b_2bab15409345_0f2217ba412e
+      issuerCountryName: US
+      issuerOrganizationName: Microsoft Corporation
+      issuerCommonName: Microsoft Azure TLS Issuing CA 05
+      subjectCountryName: US
+      subjectStateOrProvinceName: WA
+      subjectLocalityName: Redmond
+      subjectOrganizationName: Microsoft Corporation
+      subjectCommonName: smartscreen.microsoft.com
+    - ja4x: 7d5dbb3783b4_a373a9f83c6b_c34b04c10969
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerOrganizationalUnit: www.digicert.com
+      issuerCommonName: DigiCert Global Root G2
+      subjectCountryName: US
+      subjectOrganizationName: Microsoft Corporation
+      subjectCommonName: Microsoft Azure TLS Issuing CA 05
+  ja4l_c: 40_128
+  ja4l_s: 42103_109
+- stream: 10
+  transport: tcp
+  src: 172.16.225.48
+  dst: 52.249.29.248
+  src_port: 52941
+  dst_port: 443
+  ja4t: 64240_2-1-3-1-1-4_1460_8
+  tls_server_name: data-edge.smartscreen.microsoft.com
+  ja4: t13d1516h2_8daaf6152771_e5627efa2ab1
+  ja4s: t120300_c030_09f674154ab3
+  tls_certs:
+  - x509:
+    - ja4x: a373a9f83c6b_2bab15409345_0f2217ba412e
+      issuerCountryName: US
+      issuerOrganizationName: Microsoft Corporation
+      issuerCommonName: Microsoft Azure TLS Issuing CA 05
+      subjectCountryName: US
+      subjectStateOrProvinceName: WA
+      subjectLocalityName: Redmond
+      subjectOrganizationName: Microsoft Corporation
+      subjectCommonName: smartscreen.microsoft.com
+    - ja4x: 7d5dbb3783b4_a373a9f83c6b_c34b04c10969
+      issuerCountryName: US
+      issuerOrganizationName: DigiCert Inc
+      issuerOrganizationalUnit: www.digicert.com
+      issuerCommonName: DigiCert Global Root G2
+      subjectCountryName: US
+      subjectOrganizationName: Microsoft Corporation
+      subjectCommonName: Microsoft Azure TLS Issuing CA 05
+  ja4l_c: 61_128
+  ja4l_s: 53595_109

--- a/tests/test_foxio_rust_parity.py
+++ b/tests/test_foxio_rust_parity.py
@@ -31,14 +31,41 @@ RUST_SNAPSHOT_NAME = "ja4__insta@{capture}.snap"
 # Each one holds at least one stream that the FoxIO Python file omits and the FoxIO Rust
 # snapshot holds.
 DIVERGENT_CAPTURES = (
+    "browsers-x509.pcapng",
     "chrome-cloudflare-quic-with-secrets.pcapng",
     "https-connect.pcap",
+    "latest.pcapng",
     "quic-tls-handshake.pcapng",
     "quic-with-several-tls-frames.pcapng",
     "ssh2.pcapng",
     "tls-handshake.pcapng",
     "tls-sni.pcapng",
     "tls3.pcapng",
+)
+
+# The streams on which the server coalesces the ServerHello, the Certificate and the
+# ServerHelloDone into one handshake record that spans several TCP segments. The FoxIO
+# Python file omits the JA4S value of every one, and the FoxIO Rust snapshot holds it.
+# Issue #151 names the first three, and the one reader change settles all six.
+COALESCED_RECORD_STREAMS = (
+    ("ssh2.pcapng", "172.16.225.48", "57374", "52.178.17.3", "t120300_c030_09f674154ab3"),
+    ("ssh2.pcapng", "172.16.225.48", "57375", "204.79.197.220", "t1205h2_c030_015e35fdd027"),
+    (
+        "tls-handshake.pcapng",
+        "192.168.1.168",
+        "50167",
+        "40.126.24.84",
+        "t120400_c030_4e8089b08790",
+    ),
+    (
+        "browsers-x509.pcapng",
+        "172.27.7.31",
+        "54524",
+        "13.107.21.239",
+        "t1206h2_c030_044dc9b3196d",
+    ),
+    ("latest.pcapng", "172.16.225.48", "52940", "52.249.29.248", "t120300_c030_09f674154ab3"),
+    ("latest.pcapng", "172.16.225.48", "52941", "52.249.29.248", "t120300_c030_09f674154ab3"),
 )
 
 # The method name the reference uses, beside the field name the Rust snapshot writes.
@@ -210,6 +237,53 @@ class TestTheRustImplementationHoldsWhatJa4plusProduces:
                 )
         assert not mismatches, "\n".join(mismatches)
         assert matched, "the vectors hold no QUIC stream the FoxIO Python file omits"
+
+
+@pytest.mark.spec_validation
+class TestTheStreamsThatCoalesceTheServerHelloRecord:
+    """Measure each JA4S stream whose ServerHello record spans several TCP segments.
+
+    The class above lets a stream on which ja4plus emits nothing pass, so it reports a
+    pass on a comparison it never makes. These streams were exactly that case. Each
+    check here names one stream and one value, so a later regression names itself.
+    """
+
+    @pytest.mark.parametrize(
+        "capture,client,client_port,server,rust_value",
+        COALESCED_RECORD_STREAMS,
+        ids=[
+            "{}:{}".format(capture, client_port)
+            for capture, _, client_port, _, _ in COALESCED_RECORD_STREAMS
+        ],
+    )
+    def test_the_stream_produces_the_foxio_rust_ja4s_value(
+        self, capture, client, client_port, server, rust_value
+    ):
+        """ja4plus produces the JA4S value the FoxIO Rust snapshot holds."""
+        identity = stream_identity(client, client_port, server, "443")
+        produced = index_produced(VECTORS_DIR / capture)
+        assert produced.get(identity, {}).get("JA4S", ()) == (rust_value,)
+
+    @pytest.mark.parametrize(
+        "capture,client,client_port,server,rust_value",
+        COALESCED_RECORD_STREAMS,
+        ids=[
+            "{}:{}".format(capture, client_port)
+            for capture, _, client_port, _, _ in COALESCED_RECORD_STREAMS
+        ],
+    )
+    def test_the_foxio_python_file_omits_the_stream(
+        self, capture, client, client_port, server, rust_value
+    ):
+        """The stream earns its place here only while the FoxIO Python file omits it.
+
+        A vector refresh that adds a JA4S value for the stream makes the Rust snapshot
+        the second reference, not the first. This check fails then, and it names the
+        stream that changed.
+        """
+        identity = stream_identity(client, client_port, server, "443")
+        python = read_python_methods(VECTORS_DIR / "{}.json".format(capture))
+        assert "JA4S" not in python.get(identity, set())
 
 
 @pytest.mark.spec_validation

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -264,6 +264,77 @@ class TestTLSParsing(unittest.TestCase):
         self.assertEqual(result["handshake_type"], "server_hello")
         self.assertEqual(result["cipher"], 0xC02F)
 
+    def test_parse_server_hello_reads_a_record_the_segment_truncates(self):
+        """The reader returns the ServerHello of a record longer than the segment.
+
+        A TLS 1.2 server puts the ServerHello, the Certificate and the ServerHelloDone
+        in one handshake record. That record spans several TCP segments, and the first
+        segment holds the whole ServerHello. Issue #151 names the three FoxIO streams
+        the earlier record-length bound rejected.
+        """
+        sh = bytearray()
+        sh += (0x0303).to_bytes(2, "big")
+        sh += b"\x00" * 32
+        sh += b"\x00"  # Session ID len
+        sh += (0xC02F).to_bytes(2, "big")  # Cipher
+        sh += b"\x00"  # Compression
+
+        handshake = b"\x02" + len(sh).to_bytes(3, "big") + bytes(sh)
+        # The record declares the coalesced length, and the segment carries the
+        # ServerHello alone.
+        record = b"\x16\x03\x03" + (6291).to_bytes(2, "big") + handshake
+
+        result = parse_tls_handshake(record)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["handshake_type"], "server_hello")
+        self.assertEqual(result["cipher"], 0xC02F)
+
+    def test_parse_server_hello_rejects_a_truncated_hello_message(self):
+        """The reader returns None when the segment cuts the ServerHello itself.
+
+        The bound moves from the record length to the handshake message length. A
+        message the segment cuts holds no cipher and no extension list, so the reader
+        returns nothing rather than a value it guessed.
+        """
+        sh = bytearray()
+        sh += (0x0303).to_bytes(2, "big")
+        sh += b"\x00" * 32
+        sh += b"\x00"
+        sh += (0xC02F).to_bytes(2, "big")
+        sh += b"\x00"
+
+        handshake = b"\x02" + len(sh).to_bytes(3, "big") + bytes(sh)
+        record = b"\x16\x03\x03" + (6291).to_bytes(2, "big") + handshake[:-10]
+
+        self.assertIsNone(parse_tls_handshake(record))
+
+    def test_parse_server_hello_reads_no_byte_after_the_hello_message(self):
+        """The reader bounds the ServerHello on its own length field.
+
+        The extension list of the ServerHello declares more bytes than the message
+        holds. The bytes that follow belong to the Certificate message, and a reader
+        that walks into them reports an extension the server never sent.
+        """
+        sh = bytearray()
+        sh += (0x0303).to_bytes(2, "big")
+        sh += b"\x00" * 32
+        sh += b"\x00"
+        sh += (0xC02F).to_bytes(2, "big")
+        sh += b"\x00"
+        # One extension, 0x0000 bytes long, followed by a declared length that runs
+        # past the end of the message.
+        sh += (8).to_bytes(2, "big")
+        sh += b"\x00\x2b\x00\x02\x03\x04"
+        sh += b"\x00\x10"
+
+        handshake = b"\x02" + len(sh).to_bytes(3, "big") + bytes(sh)
+        # The Certificate message follows in the same record, and the segment holds it.
+        record = b"\x16\x03\x03" + (6291).to_bytes(2, "big") + handshake + b"\x0b" + b"\x11" * 64
+
+        result = parse_tls_handshake(record)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["extensions"], [0x002B])
+
     def test_extract_tls_info_from_packet(self):
         """extract_tls_info should work with scapy packets."""
         raw = self._build_client_hello(sni="test.com", ciphers=[0x1301])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -292,44 +292,49 @@ class TestTLSParsing(unittest.TestCase):
     def test_parse_server_hello_rejects_a_truncated_hello_message(self):
         """The reader returns None when the segment cuts the ServerHello itself.
 
-        The bound moves from the record length to the handshake message length. A
-        message the segment cuts holds no cipher and no extension list, so the reader
-        returns nothing rather than a value it guessed.
+        The record here holds every byte it declares, so a bound on the record length
+        reads the message and reports the fields it found before the cut. The message
+        declares 38 bytes and the record carries 28, so the reader returns nothing.
         """
         sh = bytearray()
         sh += (0x0303).to_bytes(2, "big")
         sh += b"\x00" * 32
-        sh += b"\x00"
-        sh += (0xC02F).to_bytes(2, "big")
-        sh += b"\x00"
+        sh += b"\x00"  # Session ID len
+        sh += (0xC02F).to_bytes(2, "big")  # Cipher
+        sh += b"\x00"  # Compression
 
-        handshake = b"\x02" + len(sh).to_bytes(3, "big") + bytes(sh)
-        record = b"\x16\x03\x03" + (6291).to_bytes(2, "big") + handshake[:-10]
+        # The message names its full length, and the record carries 10 bytes fewer.
+        handshake = b"\x02" + len(sh).to_bytes(3, "big") + bytes(sh)[:-10]
+        record = b"\x16\x03\x03" + len(handshake).to_bytes(2, "big") + handshake
 
         self.assertIsNone(parse_tls_handshake(record))
 
-    def test_parse_server_hello_reads_no_byte_after_the_hello_message(self):
-        """The reader bounds the ServerHello on its own length field.
+    def test_parse_server_hello_reads_no_extension_after_the_hello_message(self):
+        """The reader bounds the extension list on the length of the hello.
 
-        The extension list of the ServerHello declares more bytes than the message
-        holds. The bytes that follow belong to the Certificate message, and a reader
-        that walks into them reports an extension the server never sent.
+        The extension list declares 16 bytes and the ServerHello carries 8. The bytes
+        that follow belong to the next handshake message of the same record, and a
+        reader that walks into them reports an extension the server never sent.
         """
         sh = bytearray()
         sh += (0x0303).to_bytes(2, "big")
         sh += b"\x00" * 32
-        sh += b"\x00"
-        sh += (0xC02F).to_bytes(2, "big")
-        sh += b"\x00"
-        # One extension, 0x0000 bytes long, followed by a declared length that runs
-        # past the end of the message.
-        sh += (8).to_bytes(2, "big")
-        sh += b"\x00\x2b\x00\x02\x03\x04"
-        sh += b"\x00\x10"
+        sh += b"\x00"  # Session ID len
+        sh += (0xC02F).to_bytes(2, "big")  # Cipher
+        sh += b"\x00"  # Compression
+        sh += (16).to_bytes(2, "big")  # The declared extension-list length.
+        sh += b"\x00\x2b\x00\x04\x03\x04\x03\x03"  # The one extension it carries.
 
         handshake = b"\x02" + len(sh).to_bytes(3, "big") + bytes(sh)
-        # The Certificate message follows in the same record, and the segment holds it.
-        record = b"\x16\x03\x03" + (6291).to_bytes(2, "big") + handshake + b"\x0b" + b"\x11" * 64
+        # The next handshake message of the record reads as extension 0x0010 to a
+        # reader that passes the end of the hello.
+        trailer = b"\x00\x10\x00\x02\x68\x32\x00\x00"
+        record = (
+            b"\x16\x03\x03"
+            + (len(handshake) + len(trailer)).to_bytes(2, "big")
+            + handshake
+            + trailer
+        )
 
         result = parse_tls_handshake(record)
         self.assertIsNotNone(result)


### PR DESCRIPTION
Refs #151.

## What

`parse_tls_handshake` bounded a ClientHello or a ServerHello on the length field of the
TLS record that carries it. The bound now reads the three-byte length field of the
handshake message, and the reader slices the buffer at the end of that message.

## Why

A TLS handshake record carries one or more handshake messages. A TLS 1.2 server puts the
ServerHello, the Certificate, the ServerKeyExchange and the ServerHelloDone in one
record, and that record is longer than one TCP segment. The record bound rejected the
first segment, so the reader never looked at the ServerHello inside it.

The first server data packet of each affected stream, read with `scapy`:

| Capture | Stream | Packet | Segment bytes | Record needs | ServerHello ends at byte |
|---|---|---|---|---|---|
| `ssh2.pcapng` | `57374 <-> 52.178.17.3:443` | 232 | 1452 | 6296 | 94 |
| `ssh2.pcapng` | `57375 <-> 204.79.197.220:443` | 254 | 1452 | 7036 | 107 |
| `tls-handshake.pcapng` | `50167 <-> 40.126.24.84:443` | 148 | 1460 | 3955 | 98 |
| `browsers-x509.pcapng` | `54524 <-> 13.107.21.239:443` | 5 | 1458 | 5947 | 111 |
| `latest.pcapng` | `52940 <-> 52.249.29.248:443` | 158 | 1452 | 7141 | 94 |
| `latest.pcapng` | `52941 <-> 52.249.29.248:443` | 192 | 1452 | 7141 | 94 |
| `socks4-https.pcap` | `50606 <-> 10.0.0.2:9901` | 8 | 1360 | 6776 | 90 |

Every row reads the same way. The record needs more bytes than the segment carries, and
the ServerHello ends inside the segment.

The three streams #151 names are the first three rows. The other four are the same cause,
and one reader change settles all seven.

## The vector that proves it

`.claude/rules/external-apis.md` reads the Rust snapshot tie-break at stream granularity.
Six of the seven streams now produce the exact JA4S value the FoxIO Rust snapshot holds:

| Stream | FoxIO Rust JA4S | ja4plus |
|---|---|---|
| `ssh2.pcapng` `57374` | `t120300_c030_09f674154ab3` | same |
| `ssh2.pcapng` `57375` | `t1205h2_c030_015e35fdd027` | same |
| `tls-handshake.pcapng` `50167` | `t120400_c030_4e8089b08790` | same |
| `browsers-x509.pcapng` `54524` | `t1206h2_c030_044dc9b3196d` | same |
| `latest.pcapng` `52940` | `t120300_c030_09f674154ab3` | same |
| `latest.pcapng` `52941` | `t120300_c030_09f674154ab3` | same |

`tls-handshake.pcapng` stream `50167` proves the FoxIO Python gap on one capture. It runs
on port 443, so neither of the two gaps #138 names explains the omission.

The snapshots of `browsers-x509.pcapng` and `latest.pcapng` join
`tests/foxio_vectors/rust_expected/`, taken without change from the pinned upstream
commit. `tests/download_test_vectors.py` and the `NOTICE` list them, so the copy stays
reproducible.

## The seventh stream

`socks4-https.pcap` stream `50606 <-> 10.0.0.2:9901` is the exception. Its Rust snapshot
holds `ja4t`, `ja4l_c` and `ja4l_s`, and no `ja4s` and no `ja4`. `ja4plus` reads the
record layer without regard to the tunnel protocol that carries it, which is the
behaviour #138 decided to keep for the three JA4X values on the same stream. The register
records the JA4S value under that decision.

## The register

99 keys to 104 keys, and the conformance suite moves from 99 xfailed to 104 xfailed. The
two counts stay equal. The five new keys are `browsers-x509.pcapng/JA4S`,
`browsers-x509.pcapng/JA4S_r`, `latest.pcapng/JA4S`, `latest.pcapng/JA4S_r` and
`socks4-https.pcap/JA4S`. The existing `ssh2.pcapng` and `tls-handshake.pcapng` JA4S keys
hold the capture, so they absorb the three streams #151 names, and their cause text now
records the second reason.

## How tested

Written test-first. Three unit tests in `tests/test_utils.py` fix the reader contract, and
`TestTheStreamsThatCoalesceTheServerHelloRecord` in `tests/test_foxio_rust_parity.py`
names each of the six streams and its value. All five gates run in the worktree:

```
.venv/bin/pytest tests/ -m "not spec_validation"   926 passed, 8 xfailed
.venv/bin/pytest tests/ -m spec_validation         1358 passed, 104 xfailed
.venv/bin/ruff check ja4plus/ tests/               All checks passed!
.venv/bin/ruff format --check ja4plus/ tests/      98 files already formatted
.venv/bin/mypy ja4plus/                            Success: no issues found in 27 source files
```

Coverage did not fall: 650 missed of 3299 statements on the base, 650 missed of 3301 on
this branch.

## Note for the merge gate

`docs/specs/spec.md` gains no changelog round here. #141 is live on the same integration
branch, and a numbered row would conflict. The full reading sits in
`docs/implementation_notes.md`, appended as a new section.

Verified against: https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1 (TLS 1.2, retrieved 2026-08-07)
Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/rust/ja4/src/snapshots (commit 27f0cbf9fd3000c072f82a0f7d0361dc99acf6c8)
