### PR TITLE
Keep the stored register entry when the baseline generator runs

### DIFF
--- a/tests/foxio_manifest.py
+++ b/tests/foxio_manifest.py
@@ -15,10 +15,11 @@ today, so a deleted vector that passes leaves nothing behind to notice.
 ## How to add a vector
 
 1. Put the capture and its expected-output file under `tests/foxio_vectors/`.
-2. Run `python tests/generate_foxio_baseline.py`. It rewrites the manifest and the
-   register from the vectors it finds.
+2. Run `python tests/generate_foxio_baseline.py`. It rewrites the manifest from the
+   vectors it finds, and it merges the measurement into the register.
 3. Read the difference. The manifest gains one line, and the register gains one entry
-   for each case the new vector fails.
+   for each case the new vector fails. An entry the register already holds keeps every
+   field, so the `decided` field of a settled deviation survives the run.
 
 A vector is a two-file change on purpose. A capture that arrives without a manifest
 line, or leaves without one, fails the suite.

--- a/tests/generate_foxio_baseline.py
+++ b/tests/generate_foxio_baseline.py
@@ -24,10 +24,10 @@ is not allowed.
 
 The register run merges. A key the committed register already holds keeps its stored
 entry, with every field and in the field order the file holds. A cause this program
-reads from a failure message states the symptom, and a person states the mechanism, and
-the `decided` field records that a person settled the deviation. This program writes a
-new entry only for a deviation the register does not hold. A key that stops failing
-still disappears.
+reads from a failure message states the symptom, and a person states the mechanism. The
+`decided` field records that a person settled the deviation. This program writes a new
+entry only for a deviation the register does not hold. A key that stops failing still
+disappears.
 
 A run that measures the deviations the register already holds therefore changes no byte
 of `tests/foxio_deviations.json`.
@@ -290,7 +290,7 @@ def _register(collector, committed):
     cause this program reads from a failure message states the symptom, and a person
     states the mechanism. #78, #96, #97 and #105 hold mechanisms no failure message
     carries, and a mechanical rewrite would destroy them. The `decided` field records
-    that a person settled the deviation, and this program measures no such field, so a
+    that a person settled the deviation. This program measures no such field, so a
     rewrite of a stored entry would delete it. A key that stops failing still disappears.
 
     Args:

--- a/tests/generate_foxio_baseline.py
+++ b/tests/generate_foxio_baseline.py
@@ -22,9 +22,15 @@ It overwrites both files. Read the difference before you commit it. A method thi
 program does not know an issue for stops the run, because an entry with no issue number
 is not allowed.
 
-A key the committed register already holds keeps its committed entry. A cause this
-program reads from a failure message states the symptom, and a person states the
-mechanism. A key that stops failing still disappears.
+The register run merges. A key the committed register already holds keeps its stored
+entry, with every field and in the field order the file holds. A cause this program
+reads from a failure message states the symptom, and a person states the mechanism, and
+the `decided` field records that a person settled the deviation. This program writes a
+new entry only for a deviation the register does not hold. A key that stops failing
+still disappears.
+
+A run that measures the deviations the register already holds therefore changes no byte
+of `tests/foxio_deviations.json`.
 """
 
 import json
@@ -250,20 +256,46 @@ def _manifest(collector):
     return {vector: counts[vector] for vector in sorted(counts)}
 
 
+def _committed(path=REGISTER_PATH):
+    """Return the committed register as the file writes it.
+
+    A key that still fails keeps its stored entry, so the entry must arrive with every
+    field and in the field order the file holds. A parsed entry carries neither: the
+    Deviation class names three fields, and it states no order.
+
+    Args:
+        path: The path of the register file. Defaults to the committed register.
+
+    Returns:
+        A map of key to the stored entry. An absent file gives an empty map.
+
+    Raises:
+        ValueError: An entry names no issue, or states no cause, or is not a table.
+    """
+    # The reader rejects a malformed entry, and this program refuses to write over one.
+    load_register(path)
+    if not Path(path).exists():
+        return {}
+    with open(path) as handle:
+        return json.load(handle)
+
+
 def _register(collector, committed):
     """Return the register entries and the failures that are not conformance cases.
 
     A structural test, such as the manifest check, carries no method parameter. It is
     not a registrable case, so this program reports it instead of recording it.
 
-    A key the committed register already holds keeps its committed entry. A cause this
-    program reads from a failure message states the symptom, and a person states the
-    mechanism. #78, #96, #97 and #105 hold mechanisms no failure message carries, and a
-    mechanical rewrite would destroy them. A key that stops failing still disappears.
+    A key the committed register already holds keeps its stored entry, byte for byte. A
+    cause this program reads from a failure message states the symptom, and a person
+    states the mechanism. #78, #96, #97 and #105 hold mechanisms no failure message
+    carries, and a mechanical rewrite would destroy them. The `decided` field records
+    that a person settled the deviation, and this program measures no such field, so a
+    rewrite of a stored entry would delete it. A key that stops failing still disappears.
 
     Args:
         collector: The collector that ran the suite.
-        committed: The register the repository holds today.
+        committed: The stored register, as `_committed` returns it.
 
     Returns:
         A (register, other) pair. The register maps each key to its entry, sorted by
@@ -288,16 +320,13 @@ def _register(collector, committed):
             key = occurrence_key(vector, method)
             occurrence_form = True
         held = committed.get(key)
-        if held is None:
-            register[key] = _entry(method, message, occurrence_form)
-        else:
-            register[key] = {"issue": held.issue, "cause": held.cause}
+        register[key] = _entry(method, message, occurrence_form) if held is None else held
     return {key: register[key] for key in sorted(register)}, other
 
 
 def main():
     # Read the committed register before the run overwrites it.
-    committed = load_register()
+    committed = _committed()
     os.environ[IGNORE_VARIABLE] = "1"
     collector = _CaseCollector()
     pytest.main([SUITE, "-m", "spec_validation", "-q", "-p", "no:randomly"], plugins=[collector])

--- a/tests/test_generate_foxio_baseline.py
+++ b/tests/test_generate_foxio_baseline.py
@@ -259,8 +259,8 @@ def _collector_for(keys):
 class TestTheCommittedRegisterAfterARun:
     """Check that a run which finds the same deviations changes no committed byte.
 
-    The generator is the documented way to add a vector. A run that rewrites an entry
-    it did not measure destroys the `decided` field a person set, and it buries the one
+    The generator is the documented way to add a vector. A run that rewrites an entry it
+    did not measure destroys the `decided` field a person set. It also buries the one
     real change under a diff of every entry.
     """
 

--- a/tests/test_generate_foxio_baseline.py
+++ b/tests/test_generate_foxio_baseline.py
@@ -5,9 +5,10 @@ the owning issue from the failure message, so a defect in that reading puts a fa
 cause and a false owner on hundreds of entries. These tests check the reading.
 """
 
+import json
 from types import SimpleNamespace
 
-from tests.foxio_deviations import Deviation
+from tests.foxio_deviations import REGISTER_PATH
 from tests.generate_foxio_baseline import (
     JA4_O_EMPTY_EXTENSION_ISSUE,
     JA4H_RAW_ISSUE,
@@ -17,6 +18,7 @@ from tests.generate_foxio_baseline import (
     _entry,
     _failure_line,
     _register,
+    _write,
 )
 
 # pytest prints the source of the test above the failure line. The source holds the
@@ -186,7 +188,7 @@ class TestTheCommittedEntry:
         )
 
     def test_a_committed_entry_survives_the_regeneration(self):
-        committed = {"v.pcap/0:443/JA4X.1": Deviation(issue=78, cause="The reference decrypts.")}
+        committed = {"v.pcap/0:443/JA4X.1": {"issue": 78, "cause": "The reference decrypts."}}
         register, _ = _register(self._collector(), committed)
         assert register["v.pcap/0:443/JA4X.1"] == {
             "issue": 78,
@@ -199,3 +201,79 @@ class TestTheCommittedEntry:
             "issue": 78,
             "cause": "The produced JA4X value differs from the reference.",
         }
+
+    def test_a_committed_entry_keeps_the_decided_field(self):
+        entry = {"cause": "The reference decrypts.", "decided": True, "issue": 78}
+        register, _ = _register(self._collector(), {"v.pcap/0:443/JA4X.1": entry})
+        assert register["v.pcap/0:443/JA4X.1"] == entry
+
+    def test_a_committed_entry_keeps_the_order_of_its_fields(self):
+        entry = {"cause": "The reference decrypts.", "decided": True, "issue": 78}
+        register, _ = _register(self._collector(), {"v.pcap/0:443/JA4X.1": entry})
+        assert list(register["v.pcap/0:443/JA4X.1"]) == ["cause", "decided", "issue"]
+
+    def test_a_key_that_stops_failing_leaves_the_register(self):
+        committed = {
+            "v.pcap/0:443/JA4X.1": {"issue": 78, "cause": "The reference decrypts."},
+            "gone.pcap/0:443/JA4X.1": {"issue": 78, "cause": "A fix landed."},
+        }
+        register, _ = _register(self._collector(), committed)
+        assert "gone.pcap/0:443/JA4X.1" not in register
+
+
+def _collector_for(keys):
+    """Return a collector that reports one failed case for each register key.
+
+    The generator reads the parameters of a case, not its key, so a test that starts
+    from a key must rebuild the parameters that produce it.
+
+    Args:
+        keys: The register keys, in either of the two key forms.
+
+    Returns:
+        A collector that carries one failure for each key.
+    """
+    failures = []
+    params = {}
+    for key in keys:
+        parts = key.split("/")
+        if len(parts) == 3:
+            vector, stream, tail = parts
+            index, port = stream.split(":")
+            method, occurrence = tail.rsplit(".", 1)
+            case = {
+                "method": method,
+                "pcap_path": SimpleNamespace(name=vector),
+                "stream": SimpleNamespace(index=index, src_port=port),
+                "occurrence": int(occurrence),
+            }
+        else:
+            vector, method = parts
+            case = {"method": method, "pcap_path": SimpleNamespace(name=vector)}
+        nodeid = "tests/test_spec_validation.py::test_case[{}]".format(key)
+        params[nodeid] = SimpleNamespace(params=case)
+        failures.append((nodeid, "E           Failed: {}".format(key)))
+    return SimpleNamespace(failures=failures, params=params)
+
+
+class TestTheCommittedRegisterAfterARun:
+    """Check that a run which finds the same deviations changes no committed byte.
+
+    The generator is the documented way to add a vector. A run that rewrites an entry
+    it did not measure destroys the `decided` field a person set, and it buries the one
+    real change under a diff of every entry.
+    """
+
+    def test_a_run_that_finds_the_same_deviations_writes_the_same_bytes(self, tmp_path):
+        committed = json.loads(REGISTER_PATH.read_text())
+        register, other = _register(_collector_for(committed), committed)
+        written = tmp_path / "foxio_deviations.json"
+        _write(written, register)
+        assert written.read_text() == REGISTER_PATH.read_text()
+        assert other == []
+
+    def test_the_run_keeps_every_decided_entry(self, tmp_path):
+        committed = json.loads(REGISTER_PATH.read_text())
+        decided = [key for key, entry in committed.items() if entry.get("decided")]
+        register, _ = _register(_collector_for(committed), committed)
+        assert [key for key, entry in register.items() if entry.get("decided")] == decided


### PR DESCRIPTION
Fixes the defect #161 records. Part of Epic 1 batch 11.

## What

`tests/generate_foxio_baseline.py` rebuilt each register entry as
`{"issue": held.issue, "cause": held.cause}`. That form drops every field the
`Deviation` class does not name, and it states its own field order. A run therefore
deleted the `decided` field of 49 entries and rewrote the field order of all 104, which
turned a one-line change into a diff of about 370 lines.

The register run now merges:

- A key the register already holds keeps its stored entry, byte for byte.
- The generator writes a new entry only for a deviation the register does not hold.
- A key that stops failing still disappears.

`_committed` reads the raw JSON, because a parsed entry carries neither the extra fields
nor the field order. It still calls `load_register` first, so a malformed register stops
the run as it did before.

## Why

`decided` records that a person settled a deviation. The generator is the documented way
to add a vector, so the next person who added one deleted 49 such decisions silently.
The entry count stayed at 104, so no count invariant caught the loss. #141 met this and
worked around it with `git checkout`.

## How tested

The tests came first, and they failed against the generator as it stood:

```
FAILED tests/test_generate_foxio_baseline.py::TestTheCommittedEntry::test_a_committed_entry_keeps_the_decided_field
FAILED tests/test_generate_foxio_baseline.py::TestTheCommittedEntry::test_a_committed_entry_keeps_the_order_of_its_fields
FAILED tests/test_generate_foxio_baseline.py::TestTheCommittedRegisterAfterARun::test_a_run_that_finds_the_same_deviations_writes_the_same_bytes
FAILED tests/test_generate_foxio_baseline.py::TestTheCommittedRegisterAfterARun::test_the_run_keeps_every_decided_entry
6 failed, 16 passed in 0.05s
```

A direct measurement against the generator as it stood reported the loss:

```
committed keys 104 decided 49
rewritten keys 104 decided 0
field order of first rewritten entry ['issue', 'cause']
```

`test_a_run_that_finds_the_same_deviations_writes_the_same_bytes` drives every one of the
104 committed keys through `_register` and `_write`, then compares the written text
against the committed file. It is a whole-file comparison, not a sample.

The generator itself also ran end to end. The MD5 of both written files is the same
before and after, and `git status` reports neither file as changed:

```
93c8cd5d6800c994c2b5421ac5aa2a91  tests/foxio_deviations.json
720586af8ddd29e7728e6912a7540b3c  tests/foxio_vector_manifest.json
wrote 38 vectors to tests/foxio_vector_manifest.json
wrote 104 entries to tests/foxio_deviations.json
93c8cd5d6800c994c2b5421ac5aa2a91  tests/foxio_deviations.json
720586af8ddd29e7728e6912a7540b3c  tests/foxio_vector_manifest.json
```

The five gates:

```
pytest tests/ -m "not spec_validation"  950 passed, 8 xfailed, 93 subtests passed
pytest tests/ -m spec_validation        1371 passed, 146 skipped, 104 xfailed
ruff check ja4plus/ tests/              All checks passed!
ruff format --check ja4plus/ tests/     100 files already formatted
mypy ja4plus/                           Success: no issues found in 27 source files
```

The register still holds 104 keys and 49 entries that carry `decided`.

Coverage of `tests/generate_foxio_baseline.py` rises from 64% to 65%. Coverage of
`ja4plus/` stays at 80%, because this change touches no file under `ja4plus/`.

## Scope

No fingerprinter changes. No register content changes. No new vector, which is #162.

`tests/foxio_manifest.py` states the procedure that this change alters, so its step 2 and
step 3 change in the same commit.

## Notes for the reviewer

- I chose no `docs/specs/spec.md` Changelog round number. The project manager owns the
  round for this batch.
- Out of scope, and not fixed here: the `## How to measure a new baseline` section of
  `tests/foxio_deviations.py` names `tests/generate_foxio_deviations.py`, and the file is
  `tests/generate_foxio_baseline.py`. The same section says the program "writes a
  register from that measurement", which now reads as a merge. Both are stale prose in a
  file this issue does not own.

Verified against: repository code only. This change calls no external interface.
