### PR TITLE
Guard the one stored JA4L client value per connection

### DIFF
--- a/tests/test_ja4l_connection_state.py
+++ b/tests/test_ja4l_connection_state.py
@@ -92,6 +92,24 @@ def test_a_repeated_syn_that_carries_the_same_number_changes_nothing():
     assert values == ["JA4L-S=1000_64", "JA4L-C=500_128"]
 
 
+def test_a_connection_of_100_bare_acks_stores_one_client_value():
+    """The stored list holds one client value for one connection.
+
+    A bare ACK carries the relative sequence number 1 and the relative acknowledgement
+    number 1, so every one of the 100 ACKs moves the client measurement point. The
+    reference holds one client value for one connection, so the later point replaces the
+    value the fingerprinter already stored.
+    """
+    packets = [_client("S", 0, 0, 0.000), _server("SA", 0, 1, 0.001)]
+    for index in range(100):
+        packets.append(_client("A", 1, 1, 0.002 + index * 0.001))
+    client_values = [value for value in _values(packets) if value.startswith("JA4L-C=")]
+    # The reference measures to the last packet that holds both relative numbers, which
+    # is the 100th ACK at 0.101s. `browsers-x509.pcapng` stream 0 proves the rule: the
+    # reference value 278_128 comes from the Client Hello, and the bare ACK gives 56.
+    assert client_values == ["JA4L-C=50000_128"]
+
+
 def test_a_capture_that_starts_after_the_handshake_reports_nothing():
     """The fingerprinter needs the SYN, so a capture without one gives no value."""
     assert _values([_client("A", 1, 1, 0.000), _client("PA", 1, 1, 0.001, b"hello")]) == []


### PR DESCRIPTION
Refs #34.

**This pull request stops short of the first acceptance criterion, and it needs a
decision.** The measurement below says the criterion reads two ways, and the two readings
lead to opposite outcomes. I built neither one.

## What this pull request holds

One regression test. It asserts that a connection of 100 bare ACKs leaves one `JA4L-C`
value in the stored list.

## What the measurement found

The plan describes a defect that two earlier commits already changed.

1. `_src_is_client` left the file in `03c7c02` ("refactor(ja4l): remove the unused
   _src_is_client helper (#119) (#126)"). The third acceptance criterion is already met.
   `rtk git grep -n "_src_is_client" ja4plus/` reports nothing and exits 1.
2. `1d374e0` (#104) added the `client_entry` mechanism at
   `ja4plus/fingerprinters/ja4l.py:150-163`. A later client point replaces the stored
   value instead of adding a second one.

So the stored list, which `tests/conformance_index.py:225` reads through
`get_fingerprints()`, already holds one value per connection.

**The return value of `process_packet` does not.** Every consumer reads that return value,
not the stored list: `ja4plus/cli.py:204`, `ja4plus/cli.py:260`,
`ja4plus/collector.py:123` and `ja4plus/processor.py:80`. On the committed vectors the two
paths disagree:

| Capture | Values the return path gives | Values the stored list gives |
|---|---|---|
| `browsers-x509.pcapng` | 6 | 3 |
| `ssh2.pcapng` | 15 | 9 |
| `latest.pcapng` | 11 | 6 |
| `socks-https-example.pcap` | 6 | 3 |
| `ssh-r.pcap` | 6 | 3 |

A test of the return path fails against the code as it stands:

```
>       assert len(reported) == 1
E       AssertionError: assert 100 == 1
E        +  where 100 = len(['JA4L-C=500_128', 'JA4L-C=1000_128', 'JA4L-C=1500_128', ...])
```

## Why I did not fix the return path

To report one value the fingerprinter must choose one. `CLAUDE.md` rule 1 binds that
choice to a vector. I measured all three candidate rules across every committed vector, on
the 60 connections that produce a `JA4L-C`.

| Rule | Connections it gets wrong | Connections it drops |
|---|---|---|
| First matching packet | 44 of 60 | 0 |
| First matching packet that carries a payload | 1 of 60 | 13 of 60 |
| Last matching packet, which is the stored rule | 0 of 60 | 0 |

- **First matching packet.** `browsers-x509.pcapng` stream 0 rejects it. The reference is
  `278_128`, from the 517-byte Client Hello. The bare ACK before it gives `56_128`.
- **First matching packet that carries a payload.** `socks4-https.pcap` rejects it: a
  retransmission repeats the relative sequence number 1 with a payload, and the reference
  `119433_126` comes from the retransmission, not the first copy. It also drops 13
  connections that never send a payload, and the reference holds a value for them:
  `latest.pcapng` stream 6 is `32_128`, and `http1-with-cookies.pcapng` is `20_64`.
- **Last matching packet.** This reproduces every reference value, and it is what the
  stored list already does. A reader knows which packet is last only when the connection
  ends, and `process_packet` has no end-of-connection point.

So no rule that a streaming return value can compute reproduces the reference.

## The decision

Read "produces exactly one `JA4L-C` value" against the stored list, and #34 is already
met by #104 and #126, and this test is the whole deliverable.

Read it against the return value, and the fix is to hold a client value back until the
connection ends. That is the mechanism #156 owns, and my brief puts it out of scope.

Which reading governs, and if it is the second one, does #34 absorb the deferral or wait
for #156?

## How I tested

Five gates, in the worktree, on Python 3.14:

```
.venv/bin/pytest tests/ -m "not spec_validation"   968 passed, 8 xfailed, 93 subtests passed
.venv/bin/pytest tests/ -m spec_validation         1375 passed, 146 skipped, 120 xfailed
.venv/bin/ruff check ja4plus/ tests/               All checks passed!
.venv/bin/ruff format --check ja4plus/ tests/      100 files already formatted
.venv/bin/mypy ja4plus/                            Success: no issues found in 27 source files
```

The conformance suite reports `120 xfailed` against the 120 keys in
`tests/foxio_deviations.json`, unchanged. No reference JA4L value moved. The unit suite
rises from 967 to 968 for the one test this pull request adds.

The project manager owns the `docs/specs/spec.md` Changelog round for this batch, so this
pull request writes no round number.

Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata (retrieved 2026-08-07)
