### PR TITLE
Order TCP segments correctly across a sequence-number wrap

### DIFF
--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -905,13 +905,22 @@ numbers puts every segment after the wrap point before every segment before it, 
 connection that crosses the boundary reassembles backwards.
 
 `_seq_before` orders two sequence numbers on the difference between them, as RFC 1982
-does. `_ordered_segments` finds the earliest sequence number of the stream, then sorts
-on the distance from it. `get_stream` and `base_seq` both read that order, so the gap
-test, the overlap arithmetic and the reported base all hold across the wrap.
+does. `get_stream` reads it for the gap test and the overlap arithmetic, so both hold
+across the wrap.
 
-The method needs every sequence number of one stream to lie within 2**31 of the others.
-`max_stream_bytes` bounds a stream at 1048576 bytes by default, which meets that
-condition with a wide margin.
+`_ordered_segments` gives the segment order. A stream occupies one arc of the sequence
+space, and one step between two neighbours closes that arc. The method sorts the
+segments on the raw number, finds the widest step, and starts the stream at the segment
+after it. `get_stream` and `base_seq` both read that order.
+
+A comparison of each segment against a running earliest value looks equivalent and is
+not. `_seq_before` stops being transitive once the segments span more than half the
+sequence space, so that form returns a different first segment for a different arrival
+order. Nothing bounds the spread of the stored sequence numbers today, because
+`max_stream_bytes` bounds the reassembled output and not the stored segments. Row 3 of
+the audit register holds that defect. The widest-step reading depends only on the
+sequence numbers, so the reassembled bytes never depend on the order the capture
+delivered the segments.
 
 `add_segment` detects a duplicate against a set of `(seq, length)` pairs. The earlier
 scan of every stored segment cost the square of the segment count: 10000 segments took

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -898,6 +898,27 @@ have no counterpart here.
 for correct ordering. Prior versions appended data in arrival order,
 which could corrupt streams with out-of-order TCP segments.
 
+### The order holds across a sequence wrap
+
+A TCP sequence number is 32 bits and wraps back to zero. An order that compares the raw
+numbers puts every segment after the wrap point before every segment before it, so a
+connection that crosses the boundary reassembles backwards.
+
+`_seq_before` orders two sequence numbers on the difference between them, as RFC 1982
+does. `_ordered_segments` finds the earliest sequence number of the stream, then sorts
+on the distance from it. `get_stream` and `base_seq` both read that order, so the gap
+test, the overlap arithmetic and the reported base all hold across the wrap.
+
+The method needs every sequence number of one stream to lie within 2**31 of the others.
+`max_stream_bytes` bounds a stream at 1048576 bytes by default, which meets that
+condition with a wide margin.
+
+`add_segment` detects a duplicate against a set of `(seq, length)` pairs. The earlier
+scan of every stored segment cost the square of the segment count: 10000 segments took
+0.451 s, and 20000 took 1.765 s. The set gives 0.0019 s and 0.004 s.
+
+**Location:** `ja4plus/utils/tcp_stream.py`. #32 built it.
+
 ---
 
 ## JA4H - HTTP

--- a/docs/specs/features/02-correctness-audit.md
+++ b/docs/specs/features/02-correctness-audit.md
@@ -96,10 +96,10 @@ the rule the fix must satisfy.
 
 | # | Location | What is wrong | Rule for the fix |
 |---|---|---|---|
-| 1 | `ja4plus/utils/tcp_stream.py:53` | `sorted(...)` orders raw sequence numbers. A sequence number is 32 bits and wraps. A connection that crosses the boundary reassembles in the wrong order. | Compare with modular arithmetic. |
-| 2 | `ja4plus/utils/tcp_stream.py:37` | The duplicate check scans every stored segment for each new segment. Cost grows with the square of the segment count. | Use a set of `(seq, length)` pairs. |
+| 1 | `ja4plus/utils/tcp_stream.py:53` | `sorted(...)` orders raw sequence numbers. A sequence number is 32 bits and wraps. A connection that crosses the boundary reassembles in the wrong order. | Compare with modular arithmetic. #32 built it. |
+| 2 | `ja4plus/utils/tcp_stream.py:37` | The duplicate check scans every stored segment for each new segment. Cost grows with the square of the segment count. | Use a set of `(seq, length)` pairs. #32 built it. |
 | 3 | `ja4plus/utils/tcp_stream.py:41` | `max_stream_bytes` limits the reassembled output, not the stored segments. A sender that emits many distinct small segments grows one stream without bound. | Cap the stored bytes per stream, not only the output. |
-| 4 | `ja4plus/utils/tcp_stream.py:33` | `base_seq` is stored and never read. | Remove it, or use it. |
+| 4 | `ja4plus/utils/tcp_stream.py:33` | `base_seq` is stored and never read. | Remove it, or use it. #32 removed the stored value. The `base_seq` method stays, because `ja4x.py` reads it. |
 | 5 | `ja4plus/fingerprinters/ja4l.py:223` | The client branch matches every ACK without a SYN flag. Each later ACK overwrites timestamp `C` and emits another client fingerprint with a larger latency. | Emit one client value for one connection. `FR-spec-conformance-19` gives the measurement point, and #88 built it. |
 | 6 | `ja4plus/fingerprinters/ja4l.py:279` | `_src_is_client` is never called. | Remove it. |
 | 7 | `ja4plus/fingerprinters/ja4h.py:163` | `cookies[k] = v` drops a repeated cookie name, while `cookie_fields` keeps it. The cookie-name hash and the cookie-value hash then describe different cookie sets. | Build both hashes from one ordered list of pairs. |
@@ -137,7 +137,7 @@ Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/pcap (retrieved
 
 | Case | What happens |
 |---|---|
-| A TCP segment arrives with a sequence number below the stored base, because the number wrapped. | The reassembler places it after the stored segments. |
+| A TCP segment arrives with a sequence number below the stored base, because the number wrapped. | The reassembler places it after the stored segments, in sequence order. |
 | A sender emits 100000 distinct one-byte segments on one connection. | The reassembler holds no more than the per-stream byte cap. |
 | A TLS record declares a length larger than the packet. | The parser returns nothing. |
 | An extension list declares more extensions than the packet carries. | The parser returns nothing. |

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -9,6 +9,27 @@ from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
+# A TCP sequence number is 32 bits and wraps back to zero. RFC 1982 orders two such
+# numbers on the difference between them, not on the numbers themselves.
+_SEQ_MASK = 0xFFFFFFFF
+_SEQ_HALF = 0x80000000
+
+
+def _seq_before(a, b):
+    """Report whether sequence number a comes before sequence number b.
+
+    The two numbers must lie within 2**31 of each other. A stream holds at most
+    `max_stream_bytes`, so every sequence number in one stream meets that condition.
+
+    Args:
+        a: A 32-bit TCP sequence number.
+        b: A 32-bit TCP sequence number.
+
+    Returns:
+        True when a comes before b, and False when a equals b or comes after b.
+    """
+    return ((a - b) & _SEQ_MASK) > _SEQ_HALF
+
 
 class TCPStreamReassembler:
     """Reassembles TCP streams using sequence numbers.
@@ -30,27 +51,53 @@ class TCPStreamReassembler:
         if key not in self.streams:
             if len(self.streams) >= self.max_streams:
                 self.streams.popitem(last=False)
-            self.streams[key] = {"segments": [], "base_seq": seq}
+            self.streams[key] = {"segments": [], "seen": set()}
 
         stream = self.streams[key]
 
-        for existing_seq, existing_data in stream["segments"]:
-            if existing_seq == seq and len(existing_data) == len(data):
-                return
+        # A scan of every stored segment costs the square of the segment count. A
+        # retransmission-heavy stream reaches thousands of segments.
+        fingerprint = (seq, len(data))
+        if fingerprint in stream["seen"]:
+            return
 
+        stream["seen"].add(fingerprint)
         stream["segments"].append((seq, data))
         self.streams.move_to_end(key)
+
+    def _ordered_segments(self, stream):
+        """Return the segments of a stream in sequence order, earliest first.
+
+        The order holds across a wrap of the 32-bit sequence number. The method finds
+        the earliest sequence number, then sorts on the distance from it.
+
+        Args:
+            stream: A stream entry from `self.streams`.
+
+        Returns:
+            A list of (seq, data) pairs, which is empty when the stream holds none.
+        """
+        segments = stream["segments"]
+        if not segments:
+            return []
+
+        first = segments[0][0]
+        for seq, _ in segments:
+            if _seq_before(seq, first):
+                first = seq
+
+        return sorted(segments, key=lambda s: (s[0] - first) & _SEQ_MASK)
 
     def get_stream(self, key):
         """Reassemble and return contiguous stream data from base_seq.
 
-        Returns data from the lowest sequence number up to the first gap.
+        Returns data from the earliest sequence number up to the first gap. The order
+        holds across a wrap of the 32-bit sequence number.
         """
         if key not in self.streams:
             return b""
 
-        stream = self.streams[key]
-        segments = sorted(stream["segments"], key=lambda s: s[0])
+        segments = self._ordered_segments(self.streams[key])
 
         if not segments:
             return b""
@@ -59,11 +106,13 @@ class TCPStreamReassembler:
         next_seq = segments[0][0]
 
         for seq, data in segments:
-            if seq <= next_seq:
-                overlap = next_seq - seq
+            # A gap and an overlap differ by the direction of the difference, which a
+            # subtraction of the raw numbers reports wrongly across a wrap.
+            if seq == next_seq or _seq_before(seq, next_seq):
+                overlap = (next_seq - seq) & _SEQ_MASK
                 if overlap < len(data):
                     result.extend(data[overlap:])
-                    next_seq = seq + len(data)
+                    next_seq = (seq + len(data)) & _SEQ_MASK
             else:
                 break
 
@@ -76,21 +125,24 @@ class TCPStreamReassembler:
     def base_seq(self, key):
         """Return the sequence number the reassembled stream starts at, or None.
 
-        `get_stream` starts at the lowest sequence number the stream holds, and a
-        segment that arrives late lowers it. A caller that remembers an offset into the
-        reassembled bytes needs this value to know that every offset moved.
+        `get_stream` starts at the earliest sequence number the stream holds, and a
+        segment that arrives late moves it earlier. A caller that remembers an offset
+        into the reassembled bytes needs this value to know that every offset moved.
 
         Args:
             key: The stream key.
 
         Returns:
-            The lowest sequence number the stream holds, or None when it holds no
+            The earliest sequence number the stream holds, or None when it holds no
             segment.
         """
         stream = self.streams.get(key)
-        if not stream or not stream["segments"]:
+        if not stream:
             return None
-        return min(seq for seq, _ in stream["segments"])
+        segments = self._ordered_segments(stream)
+        if not segments:
+            return None
+        return segments[0][0]
 
     def remove_stream(self, key):
         """Remove a stream from tracking."""
@@ -104,3 +156,6 @@ class TCPStreamReassembler:
         stream["segments"] = [
             (seq, data) for seq, data in stream["segments"] if seq + len(data) > up_to_seq
         ]
+        # `add_segment` reads this set to detect a duplicate. A trimmed segment that
+        # stays in the set makes `add_segment` drop that segment when it arrives again.
+        stream["seen"] = {(seq, len(data)) for seq, data in stream["segments"]}

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -68,8 +68,8 @@ class TCPStreamReassembler:
     def _ordered_segments(self, stream):
         """Return the segments of a stream in sequence order, earliest first.
 
-        The order holds across a wrap of the 32-bit sequence number. The method finds
-        the earliest sequence number, then sorts on the distance from it.
+        The order holds across a wrap of the 32-bit sequence number. The order depends
+        only on the sequence numbers, never on the order the capture delivered them.
 
         Args:
             stream: A stream entry from `self.streams`.
@@ -81,12 +81,24 @@ class TCPStreamReassembler:
         if not segments:
             return []
 
-        first = segments[0][0]
-        for seq, _ in segments:
-            if _seq_before(seq, first):
-                first = seq
+        by_seq = sorted(segments, key=lambda s: s[0])
+        if len(by_seq) == 1:
+            return by_seq
 
-        return sorted(segments, key=lambda s: (s[0] - first) & _SEQ_MASK)
+        # A stream occupies one arc of the sequence space, and one step between two
+        # neighbours closes that arc. The widest step is that one, so the segment after
+        # it holds the first byte. A comparison of each segment against a running
+        # earliest value gives a different answer for a different arrival order,
+        # because the comparison is not transitive once the segments span the space.
+        start = 0
+        widest = (by_seq[0][0] - by_seq[-1][0]) & _SEQ_MASK
+        for i in range(1, len(by_seq)):
+            step = by_seq[i][0] - by_seq[i - 1][0]
+            if step > widest:
+                widest = step
+                start = i
+
+        return by_seq[start:] + by_seq[:start]
 
     def get_stream(self, key):
         """Reassemble and return contiguous stream data from base_seq.

--- a/tests/test_tcp_stream.py
+++ b/tests/test_tcp_stream.py
@@ -160,6 +160,23 @@ class TestTCPStreamReassembler(unittest.TestCase):
         # The threshold sits between the two readings, clear of the noise of either.
         self.assertLess(elapsed(20000), elapsed(5000) * 8)
 
+    def test_the_segment_order_does_not_depend_on_the_arrival_order(self):
+        import itertools
+
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        # The three sequence numbers spread across the whole sequence space, so no
+        # 2**31 window holds them. A fingerprint that moved with the arrival order
+        # would describe the capture file rather than the connection.
+        spread = [(0x00000000, b"a"), (0x60000000, b"b"), (0xC0000000, b"c")]
+        bases = set()
+        for arrival in itertools.permutations(spread):
+            r = TCPStreamReassembler()
+            for seq, data in arrival:
+                r.add_segment("stream1", seq=seq, data=data)
+            bases.add(r.base_seq("stream1"))
+        self.assertEqual(len(bases), 1)
+
     def test_a_trimmed_segment_reassembles_when_it_arrives_again(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
 

--- a/tests/test_tcp_stream.py
+++ b/tests/test_tcp_stream.py
@@ -1,6 +1,11 @@
 """Tests for TCP stream reassembly."""
 
+import time
 import unittest
+
+# A TCP sequence number is 32 bits. 0xFFFFFFFE puts the next four bytes across the
+# boundary, so a reassembler that compares raw numbers orders these segments backwards.
+WRAP_SEQ = 0xFFFFFFFE
 
 
 class TestTCPStreamReassembler(unittest.TestCase):
@@ -82,6 +87,77 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
         r = TCPStreamReassembler()
         self.assertIsNone(r.base_seq("stream1"))
+
+    def test_reassembly_across_the_sequence_wrap_keeps_the_byte_order(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=WRAP_SEQ, data=b"abcd")
+        r.add_segment(key, seq=2, data=b"efgh")
+        self.assertEqual(r.get_stream(key), b"abcdefgh")
+
+    def test_a_late_segment_across_the_sequence_wrap_keeps_the_byte_order(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=2, data=b"efgh")
+        r.add_segment(key, seq=WRAP_SEQ, data=b"abcd")
+        self.assertEqual(r.get_stream(key), b"abcdefgh")
+
+    def test_a_gap_across_the_sequence_wrap_stops_the_stream(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=WRAP_SEQ, data=b"abcd")
+        r.add_segment(key, seq=100, data=b"efgh")
+        self.assertEqual(r.get_stream(key), b"abcd")
+
+    def test_an_overlap_across_the_sequence_wrap_drops_the_repeated_bytes(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=WRAP_SEQ, data=b"abcd")
+        r.add_segment(key, seq=1, data=b"cdef")
+        self.assertEqual(r.get_stream(key), b"abcdef")
+
+    def test_the_base_sequence_across_the_sequence_wrap_names_the_first_byte(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=2, data=b"efgh")
+        r.add_segment(key, seq=WRAP_SEQ, data=b"abcd")
+        self.assertEqual(r.base_seq(key), WRAP_SEQ)
+
+    def test_ten_thousand_segments_take_less_than_one_second(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        start = time.perf_counter()
+        for i in range(10000):
+            r.add_segment(key, seq=i * 4, data=b"abcd")
+        elapsed = time.perf_counter() - start
+        self.assertLess(elapsed, 1.0)
+
+    def test_the_cost_of_a_segment_does_not_grow_with_the_segment_count(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        def elapsed(count):
+            r = TCPStreamReassembler()
+            start = time.perf_counter()
+            for i in range(count):
+                r.add_segment("stream1", seq=i * 4, data=b"abcd")
+            return time.perf_counter() - start
+
+        # A scan of every stored segment costs the square of the count, so four times
+        # the segments costs sixteen times the time. A constant-cost check costs four.
+        # The threshold sits between the two readings, clear of the noise of either.
+        self.assertLess(elapsed(20000), elapsed(5000) * 8)
 
     def test_max_streams_cleanup(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler

--- a/tests/test_tcp_stream.py
+++ b/tests/test_tcp_stream.py
@@ -120,8 +120,9 @@ class TestTCPStreamReassembler(unittest.TestCase):
 
         r = TCPStreamReassembler()
         key = "stream1"
+        # The first segment puts "d" at sequence number 1, and the second repeats it.
         r.add_segment(key, seq=WRAP_SEQ, data=b"abcd")
-        r.add_segment(key, seq=1, data=b"cdef")
+        r.add_segment(key, seq=1, data=b"def")
         self.assertEqual(r.get_stream(key), b"abcdef")
 
     def test_the_base_sequence_across_the_sequence_wrap_names_the_first_byte(self):
@@ -158,6 +159,24 @@ class TestTCPStreamReassembler(unittest.TestCase):
         # the segments costs sixteen times the time. A constant-cost check costs four.
         # The threshold sits between the two readings, clear of the noise of either.
         self.assertLess(elapsed(20000), elapsed(5000) * 8)
+
+    def test_a_trimmed_segment_reassembles_when_it_arrives_again(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=100, data=b"hello")
+        r.trim_stream(key, 105)
+        self.assertEqual(r.get_stream(key), b"")
+        r.add_segment(key, seq=100, data=b"hello")
+        self.assertEqual(r.get_stream(key), b"hello")
+
+    def test_a_trim_of_an_unknown_stream_does_nothing(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        r.trim_stream("stream1", 100)
+        self.assertEqual(r.get_stream("stream1"), b"")
 
     def test_max_streams_cleanup(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler


### PR DESCRIPTION
Refs #32. Part of #13.

## What

`ja4plus/utils/tcp_stream.py` held three defects from the audit register:

- **Row 1 — the wrap.** `get_stream` sorted raw sequence numbers. A TCP sequence number
  is 32 bits and wraps back to zero, so a connection that crossed the boundary
  reassembled backwards.
- **Row 2 — the duplicate scan.** `add_segment` scanned every stored segment, so its
  cost grew with the square of the segment count.
- **Row 4 — `base_seq`.** The stored `base_seq` value was written and never read.

## How

`_seq_before` orders two sequence numbers on the difference between them, as RFC 1982
does. `get_stream` reads it for the gap test and the overlap arithmetic, and it masks
`next_seq` to 32 bits.

`_ordered_segments` gives the segment order. A stream occupies one arc of the sequence
space, and one step between two neighbours closes that arc. The method sorts on the raw
number, finds the widest step, and starts the stream after it. `get_stream` and
`base_seq` both read that order.

`add_segment` detects a duplicate against a set of `(seq, length)` pairs.

The stored `base_seq` value is removed. The `base_seq` **method** stays, because
`ja4plus/fingerprinters/ja4x.py:166` reads it.

## Why the first ordering attempt was wrong

The self-review rejected a simpler form that compared each segment against a running
earliest value. `_seq_before` stops being transitive once the segments span more than
half the sequence space, so that form returned a different first segment for a different
arrival order. Three segments at `0x00000000`, `0x60000000` and `0xC0000000` gave three
different answers across the six arrival orders. `.claude/rules/conformance.md` forbids a
value that depends on the order the capture is read.
`test_the_segment_order_does_not_depend_on_the_arrival_order` holds that line.

Nothing bounds the spread of the stored sequence numbers today, because
`max_stream_bytes` bounds the reassembled output and not the stored segments. That is
row 3 of the register, which is #33.

## How this was tested

Every new test was proven to fail against the code as it stood. The failures:

| Test | Failure before the fix |
|---|---|
| `test_reassembly_across_the_sequence_wrap_keeps_the_byte_order` | `AssertionError: b'efgh' != b'abcdefgh'` |
| `test_a_late_segment_across_the_sequence_wrap_keeps_the_byte_order` | `AssertionError: b'efgh' != b'abcdefgh'` |
| `test_a_gap_across_the_sequence_wrap_stops_the_stream` | `AssertionError: b'efgh' != b'abcd'` |
| `test_an_overlap_across_the_sequence_wrap_drops_the_repeated_bytes` | `AssertionError: b'def' != b'abcdef'` |
| `test_the_base_sequence_across_the_sequence_wrap_names_the_first_byte` | `AssertionError: 2 != 4294967294` |
| `test_the_cost_of_a_segment_does_not_grow_with_the_segment_count` | `AssertionError: 1.77643425000133 not less than 0.8767423359677196` |
| `test_the_segment_order_does_not_depend_on_the_arrival_order` | `AssertionError: 3 != 1` |
| `test_a_trimmed_segment_reassembles_when_it_arrives_again` | fails without the `seen` rebuild in `trim_stream` |

`WRAP_SEQ` is `0xFFFFFFFE`, so the four bytes of the first segment sit at `0xFFFFFFFE`,
`0xFFFFFFFF`, `0x00000000` and `0x00000001`. The segments cross the boundary.

### The timing criterion, measured

The issue asks for 10000 segments in under one second. **That criterion already passed
against the unfixed code**, so it is weak evidence on its own:

| Segments | Before | After |
|---|---|---|
| 5000 | 0.1096 s | 0.0010 s |
| 10000 | 0.4511 s | 0.0018 s |
| 20000 | 1.7652 s | 0.0038 s |

Before, four times the segments cost sixteen times the time. After, it costs four times.
`test_the_cost_of_a_segment_does_not_grow_with_the_segment_count` measures the growth
rather than one absolute number, and it fails against the unfixed code.

## Gates

| Gate | Result |
|---|---|
| `pytest tests/ -m "not spec_validation"` | 977 passed, 8 xfailed, 93 subtests passed |
| `pytest tests/ -m spec_validation` | 1375 passed, 146 skipped, 120 xfailed |
| `ruff check ja4plus/ tests/` | All checks passed! |
| `ruff format --check ja4plus/ tests/` | 100 files already formatted |
| `mypy ja4plus/` | Success: no issues found in 27 source files |

**No fingerprint moved.** The conformance suite reports `1375 passed, 146 skipped, 120
xfailed` both before and after the change, against 120 keys in
`tests/foxio_deviations.json`.

**Coverage rose.** `ja4plus/utils/tcp_stream.py` goes from 91% to 99%. The project total
holds at 80%, with 670 uncovered statements against 674 before.

## Two things the reviewer should check

1. **I touched `trim_stream`, which the brief fenced off for #33.** One statement only:
   it rebuilds the `seen` set from the surviving segments. Without it a trimmed segment
   that arrives again is dropped as a duplicate, which is a defect my own change would
   have introduced. I did **not** bound the segment list, which is #33's work. Revert
   that one statement if you would rather #33 own it.
2. **`trim_stream` still compares raw sequence numbers** at `seq + len(data) > up_to_seq`,
   so it holds the same wrap defect. It has no caller and no test today. I left it, and
   flag it here for whoever takes #33.

No `Closes #` keyword: this is a batch member, and the batch PR closes the issue.

Verified against: https://datatracker.ietf.org/doc/html/rfc1982 (RFC 1982, serial number arithmetic, retrieved 2026-08-07)
