### PR TITLE
Bound the bytes and the segments one TCP stream holds

### DIFF
--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -916,9 +916,8 @@ after it. `get_stream` and `base_seq` both read that order.
 A comparison of each segment against a running earliest value looks equivalent and is
 not. `_seq_before` stops being transitive once the segments span more than half the
 sequence space, so that form returns a different first segment for a different arrival
-order. Nothing bounds the spread of the stored sequence numbers today, because
-`max_stream_bytes` bounds the reassembled output and not the stored segments. Row 3 of
-the audit register holds that defect. The widest-step reading depends only on the
+order. `max_stream_bytes` now bounds the stored segments, so the spread of the stored
+sequence numbers stays inside one arc. The widest-step reading depends only on the
 sequence numbers, so the reassembled bytes never depend on the order the capture
 delivered the segments.
 
@@ -927,6 +926,54 @@ scan of every stored segment cost the square of the segment count: 10000 segment
 0.451 s, and 20000 took 1.765 s. The set gives 0.0019 s and 0.004 s.
 
 **Location:** `ja4plus/utils/tcp_stream.py`. #32 built it.
+
+### One stream holds a bounded number of bytes and segments
+
+`max_stream_bytes` bounded the bytes `get_stream` returns, and nothing bounded the bytes
+the stream stores. A sender of many distinct small segments grew one stream without a
+limit. `add_segment` now refuses a segment once the stream holds `max_stream_bytes`
+bytes, and once it holds `max_stream_segments` segments. A refused segment enters no
+state, so the stream accepts it again after a trim frees the room.
+
+The byte cap alone leaves a sender of one-byte segments a million entries in the segment
+list, so the segment cap carries the second bound. The default is 4096. The largest
+stream of the FoxIO vectors holds 1336 segments and 1853328 bytes, both in
+`http2-with-cookies.pcapng`. The measurement runs `Processor` over every capture under
+`tests/foxio_vectors/` and reads the stored segments after each call to `add_segment`.
+
+The byte cap cuts that one vector stream at 1048576 bytes, and no reference value moves.
+`get_stream` already truncated its result at `max_stream_bytes`, so no fingerprinter ever
+read the bytes beyond the cap. The conformance suite reports 1375 passed, 146 skipped and
+120 xfailed before the change and after it.
+
+`get_stream` no longer truncates its result. The stream stores no more than
+`max_stream_bytes`, and the result never holds more than the stream stores.
+
+`trim_stream` compared raw sequence numbers, which holds the defect #32 removed from
+`get_stream`. It now reads `_seq_before`. It takes an absolute sequence number, never a
+byte offset. #78 removed its one call site, because that call passed a byte offset and
+removed no segment for a realistic initial sequence number.
+
+`ja4h.py` left a buffer that is not an HTTP request in the reassembler for the life of
+the capture. It now removes the stream when no later byte can make the buffer an HTTP
+request. `can_become_http_request` reads the buffer against the HTTP method tokens and
+keeps a buffer that is a prefix of one, because a request line spans two segments.
+
+The removal waits one packet. A segment that arrives out of order puts the middle of a
+request at the start of the buffer, and that buffer starts no HTTP request. A removal on
+that packet drops the segment, and the request never reassembles when the head arrives.
+The head lowers the base sequence number, so `_drop_an_unusable_stream` removes the
+stream only on a packet that leaves the base sequence number where the previous packet
+left it. The measurement: the tail of `GET /index.html HTTP/1.1` arrives at sequence
+number 126 and the head at 100. A removal on the first packet gives `None` for both
+packets. The one-packet wait gives a fingerprint on the second.
+
+`self.unusable_base` holds one base sequence number for each stream that waits. It drops
+the keys the reassembler no longer holds once it passes `max_streams` entries, the way
+`ja4x.py` prunes `scan_offsets`.
+
+**Location:** `ja4plus/utils/tcp_stream.py`, `ja4plus/utils/http_utils.py`,
+`ja4plus/fingerprinters/ja4h.py`. #33 built it, and it absorbed #103.
 
 ---
 

--- a/docs/specs/features/02-correctness-audit.md
+++ b/docs/specs/features/02-correctness-audit.md
@@ -98,13 +98,13 @@ the rule the fix must satisfy.
 |---|---|---|---|
 | 1 | `ja4plus/utils/tcp_stream.py:53` | `sorted(...)` orders raw sequence numbers. A sequence number is 32 bits and wraps. A connection that crosses the boundary reassembles in the wrong order. | Compare with modular arithmetic. #32 built it. |
 | 2 | `ja4plus/utils/tcp_stream.py:37` | The duplicate check scans every stored segment for each new segment. Cost grows with the square of the segment count. | Use a set of `(seq, length)` pairs. #32 built it. |
-| 3 | `ja4plus/utils/tcp_stream.py:41` | `max_stream_bytes` limits the reassembled output, not the stored segments. A sender that emits many distinct small segments grows one stream without bound. | Cap the stored bytes per stream, not only the output. |
+| 3 | `ja4plus/utils/tcp_stream.py:41` | `max_stream_bytes` limits the reassembled output, not the stored segments. A sender that emits many distinct small segments grows one stream without bound. | Cap the stored bytes per stream, not only the output. #33 built it, with a segment cap beside the byte cap. |
 | 4 | `ja4plus/utils/tcp_stream.py:33` | `base_seq` is stored and never read. | Remove it, or use it. #32 removed the stored value. The `base_seq` method stays, because `ja4x.py` reads it. |
 | 5 | `ja4plus/fingerprinters/ja4l.py:223` | The client branch matches every ACK without a SYN flag. Each later ACK overwrites timestamp `C` and emits another client fingerprint with a larger latency. | Emit one client value for one connection. `FR-spec-conformance-19` gives the measurement point, and #88 built it. |
 | 6 | `ja4plus/fingerprinters/ja4l.py:279` | `_src_is_client` is never called. | Remove it. |
 | 7 | `ja4plus/fingerprinters/ja4h.py:163` | `cookies[k] = v` drops a repeated cookie name, while `cookie_fields` keeps it. The cookie-name hash and the cookie-value hash then describe different cookie sets. | Build both hashes from one ordered list of pairs. |
 | 8 | `ja4plus/fingerprinters/ja4h.py:131` | The request-line pattern requires `HTTP/<digit>.<digit>`. A request line that reads `HTTP/2` never matches, although `_http_version_to_str` handles `2`. | Accept an optional minor version. |
-| 9 | `ja4plus/fingerprinters/ja4h.py:82` | When the buffer is not an HTTP request, the segment stays in the reassembler forever. | Remove the stream when the buffer cannot become an HTTP request. |
+| 9 | `ja4plus/fingerprinters/ja4h.py:82` | When the buffer is not an HTTP request, the segment stays in the reassembler forever. | Remove the stream when the buffer cannot become an HTTP request. #33 built it. |
 | 10 | `ja4plus/fingerprinters/ja4.py:292` | The `if original_order:` branch and its `else:` branch build the same string. | Remove the branch, or make the two differ. |
 | 11 | `ja4plus/fingerprinters/base.py:38` | `add_fingerprint` stores the packet object. A monitor holds every packet it ever fingerprinted. | Store what the result needs. Never store the packet. |
 | 12 | `ja4plus/fingerprinters/ja4ssh.py:80` | On a non-standard port, the lower port number decides which side is the server. Two ephemeral ports make this arbitrary. | Decide from the first SSH banner, and fall back to the port. |
@@ -138,7 +138,8 @@ Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/pcap (retrieved
 | Case | What happens |
 |---|---|
 | A TCP segment arrives with a sequence number below the stored base, because the number wrapped. | The reassembler places it after the stored segments, in sequence order. |
-| A sender emits 100000 distinct one-byte segments on one connection. | The reassembler holds no more than the per-stream byte cap. |
+| A sender emits 100000 distinct one-byte segments on one connection. | The reassembler holds no more than the per-stream byte cap, and no more than the per-stream segment cap. |
+| A buffer holds bytes that no HTTP request line starts with. | JA4H removes the stream from the reassembler. |
 | A TLS record declares a length larger than the packet. | The parser returns nothing. |
 | An extension list declares more extensions than the packet carries. | The parser returns nothing. |
 | An HTTP request repeats a cookie name with two values. | Both hashes describe both occurrences. |

--- a/ja4plus/fingerprinters/ja4h.py
+++ b/ja4plus/fingerprinters/ja4h.py
@@ -12,7 +12,12 @@ import hashlib
 import logging
 from scapy.all import IP, IPv6, TCP, Raw
 
-from ja4plus.utils.http_utils import extract_http_info, is_http_request, parse_http_request
+from ja4plus.utils.http_utils import (
+    can_become_http_request,
+    extract_http_info,
+    is_http_request,
+    parse_http_request,
+)
 from ja4plus.utils.tcp_stream import TCPStreamReassembler
 from ja4plus.utils.packet_utils import get_ip_layer
 from ja4plus.fingerprinters.base import BaseFingerprinter
@@ -61,6 +66,7 @@ class JA4HFingerprinter(BaseFingerprinter):
         super().__init__()
         self.reassembler = TCPStreamReassembler(max_streams=100)
         self.last_raw_original_order = None
+        self.unusable_base = {}
 
     def process_packet(self, packet):
         """
@@ -87,6 +93,7 @@ class JA4HFingerprinter(BaseFingerprinter):
 
         # Try to parse HTTP from reassembled stream
         if not is_http_request(stream_data):
+            self._drop_an_unusable_stream(stream_key, stream_data)
             # Also try the single packet (backward compat)
             http_info = extract_http_info(packet)
             if not http_info:
@@ -113,6 +120,44 @@ class JA4HFingerprinter(BaseFingerprinter):
 
         return None
 
+    def _drop_an_unusable_stream(self, stream_key, stream_data):
+        """Remove a stream whose buffer no later segment turns into an HTTP request.
+
+        A segment that arrives out of order puts the middle of a request at the start of
+        the buffer, and that buffer starts no HTTP request. The missing head lowers the
+        base sequence number when it arrives, so the removal waits for one further packet
+        that leaves the base sequence number where it was.
+
+        Args:
+            stream_key: The key of the stream in the reassembler.
+            stream_data: The contiguous bytes of the stream.
+        """
+        if stream_key not in self.reassembler.streams:
+            return
+
+        if can_become_http_request(stream_data):
+            self.unusable_base.pop(stream_key, None)
+            return
+
+        base = self.reassembler.base_seq(stream_key)
+        if stream_key in self.unusable_base and self.unusable_base[stream_key] == base:
+            # Nothing else reads this buffer. A buffer that stays holds memory for the
+            # life of the capture.
+            self.reassembler.remove_stream(stream_key)
+            self.unusable_base.pop(stream_key, None)
+            return
+
+        self.unusable_base[stream_key] = base
+        if len(self.unusable_base) > self.reassembler.max_streams:
+            # The reassembler evicts a stream on its own. A base sequence number that
+            # names an evicted stream is state that nothing reads again, and a flood of
+            # streams would otherwise grow the table without a limit.
+            self.unusable_base = {
+                key: value
+                for key, value in self.unusable_base.items()
+                if key in self.reassembler.streams
+            }
+
     def _record(self, fingerprint, http_info, packet):
         """Append one JA4H result, with the raw original-order form beside the hash."""
         raw_original_order = _generate_ja4h_raw_from_info(http_info)
@@ -129,6 +174,7 @@ class JA4HFingerprinter(BaseFingerprinter):
         super().reset()
         self.reassembler = TCPStreamReassembler(max_streams=100)
         self.last_raw_original_order = None
+        self.unusable_base = {}
 
     def cleanup_connection(self, src_ip, src_port, dst_ip, dst_port, proto):
         """Remove TCP stream buffer for the given connection."""
@@ -137,6 +183,8 @@ class JA4HFingerprinter(BaseFingerprinter):
         # Also try reverse direction
         rev_key = f"{dst_ip}:{dst_port}-{src_ip}:{src_port}"
         self.reassembler.remove_stream(rev_key)
+        self.unusable_base.pop(stream_key, None)
+        self.unusable_base.pop(rev_key, None)
 
 
 def _extract_http_info_from_bytes(data):

--- a/ja4plus/utils/http_utils.py
+++ b/ja4plus/utils/http_utils.py
@@ -103,6 +103,19 @@ def parse_http_request(data):
         return None
 
 
+HTTP_METHOD_TOKENS = (
+    b"GET ",
+    b"POST ",
+    b"PUT ",
+    b"DELETE ",
+    b"HEAD ",
+    b"OPTIONS ",
+    b"PATCH ",
+    b"CONNECT ",
+    b"TRACE ",
+)
+
+
 def is_http_request(data):
     """
     Check if the data appears to be an HTTP request.
@@ -113,23 +126,37 @@ def is_http_request(data):
     Returns:
         True if the data appears to be an HTTP request, False otherwise
     """
-    http_methods = [
-        b"GET ",
-        b"POST ",
-        b"PUT ",
-        b"DELETE ",
-        b"HEAD ",
-        b"OPTIONS ",
-        b"PATCH ",
-        b"CONNECT ",
-        b"TRACE ",
-    ]
-
     if isinstance(data, str):
         data = data.encode("utf-8", errors="ignore")
 
-    for method in http_methods:
+    for method in HTTP_METHOD_TOKENS:
         if data.startswith(method):
+            return True
+
+    return False
+
+
+def can_become_http_request(data):
+    """Report whether a later byte can make the buffer an HTTP request.
+
+    A caller holds a buffer that grows one TCP segment at a time. The buffer is the
+    start of an HTTP request while it is a prefix of a method token.
+
+    Args:
+        data: The bytes the buffer holds, or the same text as a string.
+
+    Returns:
+        True when the buffer is an HTTP request, or when it is the start of one. False
+        when no later byte can make it one.
+    """
+    if isinstance(data, str):
+        data = data.encode("utf-8", errors="ignore")
+
+    if not data:
+        return True
+
+    for method in HTTP_METHOD_TOKENS:
+        if data.startswith(method) or method.startswith(data):
             return True
 
     return False

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -31,6 +31,13 @@ def _seq_before(a, b):
     return ((a - b) & _SEQ_MASK) > _SEQ_HALF
 
 
+# The largest stream of the FoxIO vectors holds 1336 segments without a byte cap, and
+# 788 with one, both in `http2-with-cookies.pcapng`. This cap sits three times above the
+# larger reading, so no vector reaches it. The byte cap alone leaves a sender of one-byte
+# segments a million entries in the segment list, so this cap carries the second bound.
+DEFAULT_MAX_STREAM_SEGMENTS = 4096
+
+
 class TCPStreamReassembler:
     """Reassembles TCP streams using sequence numbers.
 
@@ -38,20 +45,36 @@ class TCPStreamReassembler:
     Evicts oldest streams when max_streams is exceeded.
     """
 
-    def __init__(self, max_streams=100, max_stream_bytes=1048576):
+    def __init__(
+        self,
+        max_streams=100,
+        max_stream_bytes=1048576,
+        max_stream_segments=DEFAULT_MAX_STREAM_SEGMENTS,
+    ):
         self.streams = OrderedDict()
         self.max_streams = max_streams
         self.max_stream_bytes = max_stream_bytes
+        self.max_stream_segments = max_stream_segments
 
     def add_segment(self, key, seq, data):
-        """Add a TCP segment to a stream."""
+        """Add a TCP segment to a stream.
+
+        The stream refuses the segment once it holds `max_stream_bytes` bytes, or
+        `max_stream_segments` segments. A refused segment leaves no trace, so the stream
+        accepts it again after a trim frees the room.
+
+        Args:
+            key: The stream key.
+            seq: The 32-bit TCP sequence number of the first byte of the segment.
+            data: The payload bytes of the segment.
+        """
         if not data:
             return
 
         if key not in self.streams:
             if len(self.streams) >= self.max_streams:
                 self.streams.popitem(last=False)
-            self.streams[key] = {"segments": [], "seen": set()}
+            self.streams[key] = {"segments": [], "seen": set(), "bytes": 0}
 
         stream = self.streams[key]
 
@@ -61,8 +84,18 @@ class TCPStreamReassembler:
         if fingerprint in stream["seen"]:
             return
 
+        # `get_stream` bounds the bytes it returns, and nothing bounded the bytes the
+        # stream stores. A sender of many small segments then grows one stream without a
+        # limit. The stream keeps the bytes it holds, because `get_stream` reads the
+        # earliest of them and a fingerprinter reads the earliest of those.
+        if stream["bytes"] + len(data) > self.max_stream_bytes:
+            return
+        if len(stream["segments"]) >= self.max_stream_segments:
+            return
+
         stream["seen"].add(fingerprint)
         stream["segments"].append((seq, data))
+        stream["bytes"] += len(data)
         self.streams.move_to_end(key)
 
     def _ordered_segments(self, stream):
@@ -128,10 +161,8 @@ class TCPStreamReassembler:
             else:
                 break
 
-            if len(result) > self.max_stream_bytes:
-                result = result[: self.max_stream_bytes]
-                break
-
+        # `add_segment` bounds the bytes the stream stores, and the result never holds
+        # more than the stream stores, so this method needs no bound of its own.
         return bytes(result)
 
     def base_seq(self, key):
@@ -161,13 +192,27 @@ class TCPStreamReassembler:
         self.streams.pop(key, None)
 
     def trim_stream(self, key, up_to_seq):
-        """Remove segments before up_to_seq to free memory."""
+        """Remove the segments that end at or before up_to_seq, to free memory.
+
+        The comparison holds across a wrap of the 32-bit sequence number, the way
+        `get_stream` orders its segments.
+
+        Args:
+            key: The stream key.
+            up_to_seq: An absolute 32-bit sequence number, never a byte offset. A byte
+                offset removes no segment for a realistic initial sequence number.
+        """
         if key not in self.streams:
             return
         stream = self.streams[key]
         stream["segments"] = [
-            (seq, data) for seq, data in stream["segments"] if seq + len(data) > up_to_seq
+            (seq, data)
+            for seq, data in stream["segments"]
+            if _seq_before(up_to_seq, (seq + len(data)) & _SEQ_MASK)
         ]
         # `add_segment` reads this set to detect a duplicate. A trimmed segment that
         # stays in the set makes `add_segment` drop that segment when it arrives again.
         stream["seen"] = {(seq, len(data)) for seq, data in stream["segments"]}
+        # `add_segment` reads this count against the byte cap. A count that the trim
+        # leaves high refuses a later segment for room the stream no longer uses.
+        stream["bytes"] = sum(len(data) for _, data in stream["segments"])

--- a/tests/test_ja4h_reassembly.py
+++ b/tests/test_ja4h_reassembly.py
@@ -39,6 +39,76 @@ class TestJA4HReassembly(unittest.TestCase):
             "Multi-segment HTTP should produce fingerprint",
         )
 
+    def test_a_buffer_that_cannot_become_an_http_request_leaves_the_reassembler(self):
+        fp = JA4HFingerprinter()
+        # A TLS record starts with 0x16, which no HTTP request line starts with.
+        first = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=443, seq=100)
+            / Raw(load=b"\x16\x03\x01\x00\x2c" + b"\x00" * 44)
+        )
+        second = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=443, seq=149)
+            / Raw(load=b"\x00" * 20)
+        )
+        fp.process_packet(first)
+        fp.process_packet(second)
+        self.assertEqual(fp.reassembler.streams, {})
+
+    def test_a_reordered_request_head_still_produces_a_fingerprint(self):
+        fp = JA4HFingerprinter()
+        head = b"GET /index.html HTTP/1.1\r\n"
+        tail = b"Host: example.com\r\nAccept: text/html\r\n\r\n"
+        # The tail arrives first, so the buffer starts in the middle of the request line
+        # and no HTTP request line starts with those bytes.
+        tail_packet = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=80, seq=100 + len(head))
+            / Raw(load=tail)
+        )
+        head_packet = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=80, seq=100)
+            / Raw(load=head)
+        )
+        self.assertIsNone(fp.process_packet(tail_packet))
+        self.assertIsNotNone(fp.process_packet(head_packet))
+
+    def test_the_table_of_waiting_streams_stays_inside_the_stream_cap(self):
+        fp = JA4HFingerprinter()
+        # Each connection sends one segment that starts no HTTP request, so each one
+        # makes an entry that waits for a second packet that never arrives.
+        for port in range(1024, 1024 + 300):
+            pkt = (
+                IP(src="10.0.0.1", dst="10.0.0.2")
+                / TCP(sport=port, dport=443, seq=100)
+                / Raw(load=b"\x16\x03\x01\x00\x2c")
+            )
+            fp.process_packet(pkt)
+        self.assertLessEqual(len(fp.unusable_base), fp.reassembler.max_streams)
+
+    def test_a_partial_method_name_stays_in_the_reassembler(self):
+        fp = JA4HFingerprinter()
+        pkt = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=80, seq=100)
+            / Raw(load=b"GE")
+        )
+        fp.process_packet(pkt)
+        self.assertIn("10.0.0.1:12345-10.0.0.2:80", fp.reassembler.streams)
+
+    def test_a_request_that_spans_two_segments_stays_in_the_reassembler(self):
+        fp = JA4HFingerprinter()
+        part1 = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n"
+        pkt = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=12345, dport=80, seq=100)
+            / Raw(load=part1)
+        )
+        fp.process_packet(pkt)
+        self.assertIn("10.0.0.1:12345-10.0.0.2:80", fp.reassembler.streams)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tcp_stream.py
+++ b/tests/test_tcp_stream.py
@@ -195,6 +195,71 @@ class TestTCPStreamReassembler(unittest.TestCase):
         r.trim_stream("stream1", 100)
         self.assertEqual(r.get_stream("stream1"), b"")
 
+    def test_a_stream_holds_no_more_than_the_byte_cap(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_bytes=100)
+        key = "stream1"
+        for i in range(200):
+            r.add_segment(key, seq=i * 10, data=b"a" * 10)
+        stored = sum(len(data) for _, data in r.streams[key]["segments"])
+        self.assertLessEqual(stored, 100)
+
+    def test_a_stream_holds_no_more_than_the_segment_cap(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_segments=8)
+        key = "stream1"
+        for i in range(200):
+            r.add_segment(key, seq=i, data=b"a")
+        self.assertLessEqual(len(r.streams[key]["segments"]), 8)
+
+    def test_one_hundred_thousand_one_byte_segments_stay_inside_the_segment_cap(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        for i in range(100000):
+            r.add_segment(key, seq=i, data=b"a")
+        self.assertLessEqual(len(r.streams[key]["segments"]), r.max_stream_segments)
+
+    def test_a_refused_segment_reassembles_when_the_stream_has_room_again(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_segments=2)
+        key = "stream1"
+        r.add_segment(key, seq=100, data=b"he")
+        r.add_segment(key, seq=102, data=b"ll")
+        # The cap refuses this segment, so the set of seen segments must not hold it.
+        r.add_segment(key, seq=104, data=b"o!")
+        r.trim_stream(key, 102)
+        r.add_segment(key, seq=104, data=b"o!")
+        self.assertEqual(r.get_stream(key), b"llo!")
+
+    def test_a_trim_across_the_sequence_wrap_removes_the_earlier_segment(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=WRAP_SEQ, data=b"abcd")
+        r.add_segment(key, seq=2, data=b"efgh")
+        # The first segment ends at sequence number 2, so the trim removes it and keeps
+        # the second. A comparison of the raw numbers keeps both.
+        r.trim_stream(key, 2)
+        self.assertEqual(r.get_stream(key), b"efgh")
+
+    def test_a_trim_lowers_the_stored_byte_count_of_the_stream(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler()
+        key = "stream1"
+        r.add_segment(key, seq=100, data=b"hello")
+        self.assertEqual(r.streams[key]["bytes"], 5)
+        # A stored byte count that a trim leaves high refuses a later segment for room
+        # the stream no longer uses.
+        r.trim_stream(key, 105)
+        self.assertEqual(r.streams[key]["bytes"], 0)
+
     def test_max_streams_cleanup(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
 
@@ -212,7 +277,9 @@ class TestTCPStreamReassembler(unittest.TestCase):
         key = "stream1"
         r.add_segment(key, seq=0, data=b"a" * 20)
         result = r.get_stream(key)
-        self.assertLessEqual(len(result), 20)
+        # An earlier form of this test compared against 20, which the reassembler met
+        # before the cap existed. The cap is 10, so the comparison names 10.
+        self.assertLessEqual(len(result), 10)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from ja4plus.utils.tls_utils import (
     parse_tls_handshake,
 )
 from ja4plus.utils.http_utils import (
+    can_become_http_request,
     parse_http_request,
     is_http_request,
     extract_http_info,
@@ -429,6 +430,23 @@ class TestHTTPParsing(unittest.TestCase):
         """is_http_request should handle string input."""
         self.assertTrue(is_http_request("GET / HTTP/1.1"))
         self.assertFalse(is_http_request("not http"))
+
+    def test_a_partial_method_name_can_become_an_http_request(self):
+        self.assertTrue(can_become_http_request(b"GE"))
+        self.assertTrue(can_become_http_request(b"OPTION"))
+
+    def test_an_empty_buffer_can_become_an_http_request(self):
+        self.assertTrue(can_become_http_request(b""))
+
+    def test_a_complete_http_request_can_become_an_http_request(self):
+        self.assertTrue(can_become_http_request(b"GET / HTTP/1.1\r\n"))
+
+    def test_a_tls_record_cannot_become_an_http_request(self):
+        self.assertFalse(can_become_http_request(b"\x16\x03\x03"))
+
+    def test_a_string_buffer_can_become_an_http_request(self):
+        self.assertTrue(can_become_http_request("GET"))
+        self.assertFalse(can_become_http_request("not http"))
 
     def test_parse_empty_data(self):
         """Empty data should return None."""


### PR DESCRIPTION
Refs #33. This issue absorbed #103, which named the same defect.

## What is wrong

`max_stream_bytes` bounded the bytes `get_stream` returns, and nothing bounded the bytes
one stream stores. `max_streams` bounded the count of streams only. A sender of many
distinct small segments therefore grew one stream without a limit. `ja4h.py` left a
buffer that is not an HTTP request in the reassembler for the life of the capture.
`trim_stream` compared raw sequence numbers, which is the defect #32 removed from
`get_stream`.

## What this builds

1. `add_segment` refuses a segment once the stream holds `max_stream_bytes` bytes, or
   `max_stream_segments` segments. The default segment cap is 4096.
2. A refused segment enters neither the segment list nor the set of seen segments, so the
   stream accepts it again after a trim frees the room.
3. `trim_stream` reads `_seq_before`, so it orders the way `get_stream` does. It
   recomputes the stored byte count beside the set of seen segments. Its docstring states
   that it takes an absolute sequence number, never a byte offset, because #78 removed
   its one call site over that mistake. This change gives it no new caller.
4. `get_stream` no longer truncates its result. The stream stores no more than
   `max_stream_bytes`, and the result never holds more than the stream stores, so the
   truncation is unreachable.
5. JA4H removes a stream whose buffer no later byte turns into an HTTP request.
   `can_become_http_request` keeps a buffer that is a prefix of a method token, because a
   request line spans two segments.

## The measurement of the vectors

The largest stream of the FoxIO vectors holds **1853328 bytes and 1336 segments**, both
on key `142.250.187.206:443-192.168.2.200:58847` of `http2-with-cookies.pcapng`. The
measurement runs `Processor` over every capture under `tests/foxio_vectors/` and reads
the stored segments after each call to `add_segment`.

The byte cap of 1048576 cuts that one stream, and no reference value moves, because
`get_stream` already truncated its result at the same number. After the change the peak
readings are 1048554 bytes and 788 segments. The segment cap of 4096 sits three times
above the larger segment reading, so no vector reaches it.

## The out-of-order defect this pull request found in itself

The first form of the JA4H removal dropped the stream on the first packet whose buffer
cannot become an HTTP request. Two review passes found the same defect: a segment that
arrives out of order puts the middle of a request at the start of the buffer, and that
buffer starts no HTTP request. The removal then dropped a segment the request needs, and
the request never reassembled when the head arrived.

The measurement, with the removal on the first packet:

```
tail first  -> None
head second -> None
```

The head lowers the base sequence number when it arrives, so `_drop_an_unusable_stream`
removes the stream only on a packet that leaves the base sequence number where the
previous packet left it. `tests/test_ja4h_reassembly.py` holds both cases:
`test_a_reordered_request_head_still_produces_a_fingerprint` and
`test_a_buffer_that_cannot_become_an_http_request_leaves_the_reassembler`.

`self.unusable_base` holds one base sequence number for each waiting stream, and it drops
the keys the reassembler no longer holds once it passes `max_streams` entries, the way
`ja4x.py` prunes `scan_offsets`.
`test_the_table_of_waiting_streams_stays_inside_the_stream_cap` measures that bound over
300 connections.

## Every new test fails against the code as it stands

```
TypeError: TCPStreamReassembler.__init__() got an unexpected keyword argument 'max_stream_segments'. Did you mean 'max_stream_bytes'?
AssertionError: 2000 not less than or equal to 100
AttributeError: 'TCPStreamReassembler' object has no attribute 'max_stream_segments'. Did you mean: 'max_stream_bytes'?
KeyError: 'bytes'
AssertionError: b'abcdefgh' != b'efgh'
AssertionError: OrderedDict({'10.0.0.1:12345-10.0.0.2:443[240 chars])}}}) != {}
```

`test_max_stream_size` already read `assertLessEqual(len(result), 20)` against a cap of
10, so it passed whatever the reassembler did. It now names 10.

## How this was tested

```
.venv/bin/pytest tests/ -m "not spec_validation"   994 passed, 8 xfailed, 93 subtests passed
.venv/bin/pytest tests/ -m spec_validation         1375 passed, 146 skipped, 120 xfailed
.venv/bin/ruff check ja4plus/ tests/               All checks passed!
.venv/bin/ruff format --check ja4plus/ tests/      100 files already formatted
.venv/bin/mypy ja4plus/                            Success: no issues found in 27 source files
```

The conformance suite reports 120 xfailed against the 120 keys of
`tests/foxio_deviations.json`, unchanged from the base commit `c4fec95`.

Coverage holds: `tcp_stream.py` 99 percent before and after, `http_utils.py` 89 to 90,
`ja4h.py` 84 to 86, and the project total 80 percent with 670 missed statements before
and after.

## What this does not build

- **The reassembler still has no maximum age.** The project state rule names a maximum
  entry count and a maximum age. This change bounds the count, the bytes and the
  segments. A connection that never closes holds its slot until `max_streams` evicts it.
  That gap is outside this issue, and #170 records it.
- **JA4X inherits the segment cap of 4096 and overrides no value.** A certificate scan
  reads at most `MAX_SCAN_BYTES`, which is 200000 bytes, so the cap bites only when the
  stored segments average under about 49 bytes. That is the hostile case the bound exists
  for. The largest vector stream holds 788 segments.

Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata
(retrieved 2026-08-07)
