### PR TITLE
Add the malformed-input suite and run it on every pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,9 +96,12 @@ jobs:
           path: test-results.xml
 
   fuzz:
-    # `FR-correctness-audit-13`. The malformed-input suite runs on every pull request.
-    # The `test` job reads `tests/` and covers this suite too. This job names it
-    # separately, so a red malformed-input case is visible without a log search.
+    # `FR-correctness-audit-13`. The malformed-input suite runs on each pull request
+    # the `on:` block above accepts. This job names the suite, so a red
+    # malformed-input case is visible without a log search.
+    #
+    # This job runs one Python version. The `test` job reads `tests/`, so it runs this
+    # suite on every version of the matrix and on macOS.
     #
     # The suite cuts each committed capture at test time. Never commit a generated
     # capture: a committed copy stops following the capture it came from.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,40 @@ jobs:
           name: test-results-${{ matrix.os }}-py${{ matrix.python-version }}
           path: test-results.xml
 
+  fuzz:
+    # `FR-correctness-audit-13`. The malformed-input suite runs on every pull request.
+    # The `test` job reads `tests/` and covers this suite too. This job names it
+    # separately, so a red malformed-input case is visible without a log search.
+    #
+    # The suite cuts each committed capture at test time. Never commit a generated
+    # capture: a committed copy stops following the capture it came from.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run the malformed-input suite
+        run: |
+          python -m pytest tests/fuzz/ -v --tb=short \
+            --junitxml=fuzz-results.xml
+
+      - name: Upload the malformed-input results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: fuzz-results
+          path: fuzz-results.xml
+
   conformance:
     # `FR-foundation-4`. The vectors are committed under `tests/foxio_vectors`, so this
     # job reads no network. Never add a step that runs `tests/download_test_vectors.py`:

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,0 +1,60 @@
+# The malformed-input suite
+
+Every packet is hostile input. No parser trusts a length field it read from the packet.
+A parser that cannot read a packet returns nothing, and it does not raise.
+
+Run the suite:
+
+```bash
+pytest tests/fuzz/
+```
+
+The `fuzz` job in `.github/workflows/test.yml` runs it on every pull request.
+`FR-correctness-audit-8` to `FR-correctness-audit-13` state the contract.
+
+## What the suite reads
+
+The suite reads the four committed FoxIO captures under `tests/foxio_vectors/`.
+
+| Capture | What it holds | Parser it reaches |
+|---|---|---|
+| `ssh2-malformed.pcap` | An SSH session with malformed records. | `parse_ssh_packet` |
+| `ssh2-moloch-crash.pcap` | An SSH capture that crashed another implementation. | `parse_ssh_packet` |
+| `badcurveball.pcap` | A TLS handshake with a malformed curve list. | `parse_tls_handshake` |
+| `CVE-2018-6794.pcap` | A capture that exercises a reassembly bypass. | `parse_tls_handshake` |
+
+The suite generates every malformed copy at test time. **Never commit a generated
+capture.** A committed copy stops following the capture it came from.
+
+## The rule that governs every case
+
+A case that asserts "no exception" passes when no parser runs. A truncated capture that
+no fingerprinter opens raises nothing and proves nothing. Every case therefore states
+what it produced, and every case proves that the parser read the mutated bytes.
+
+The suite proves reachability in three ways:
+
+- `spy_on` counts the calls of a named parser. A count of zero fails the case.
+- A case pins the fingerprint the committed capture produces, in
+  `RECORDED_FINGERPRINTS`.
+- A case measures a method that produces a value on the committed capture and none on
+  the cut copy. `SILENCED_METHOD` names the pair.
+
+`test_the_harness_reports_a_fingerprinter_that_raises` proves that the harness observes
+a raise. `Processor.process_packet` catches every exception, so `run_fingerprinters`
+reads each fingerprinter directly instead. A suite that drove the processor could never
+fail.
+
+## How to add a case
+
+1. Name the parser the case reaches, and count its calls with `spy_on`.
+2. Assert what the case produced. An assertion of "no exception" alone is not enough.
+3. Prove the case can fail. Break the parser by hand, run the suite, and confirm the
+   case turns red.
+
+## Why the frame cut keeps the link-layer header
+
+`truncate_frames` never cuts below the link-layer header. scapy raises `struct.error`
+when it dissects a shorter frame, so a shorter frame builds no packet object. Such a
+frame reaches no fingerprinter, and a case built on it would measure scapy instead of
+this project.

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -9,8 +9,18 @@ Run the suite:
 pytest tests/fuzz/
 ```
 
-The `fuzz` job in `.github/workflows/test.yml` runs it on every pull request.
 `FR-correctness-audit-8` to `FR-correctness-audit-13` state the contract.
+
+Two jobs in `.github/workflows/test.yml` run the suite:
+
+- The `fuzz` job runs `pytest tests/fuzz/` on Python 3.13. It names the suite, so a red
+  malformed-input case is visible without a log search.
+- The `test` job reads `tests/`, so it runs the suite on Python 3.9 to 3.13 and on
+  macOS.
+
+Both jobs answer a pull request that targets `master` or `dev`. A pull request that
+targets an epic integration branch starts no run, because the batch model skips
+provider CI on a sub-issue. The batch pull request into `dev` runs the suite.
 
 ## What the suite reads
 

--- a/tests/fuzz/__init__.py
+++ b/tests/fuzz/__init__.py
@@ -1,0 +1,6 @@
+"""The malformed-input suite.
+
+Every packet is hostile input. `FR-correctness-audit-8` to `FR-correctness-audit-10`
+state the contract this suite measures. A parser that cannot read a packet returns
+nothing, and it does not raise.
+"""

--- a/tests/fuzz/conftest.py
+++ b/tests/fuzz/conftest.py
@@ -1,0 +1,35 @@
+"""Fixtures for the malformed-input suite."""
+
+from pathlib import Path
+
+import pytest
+from scapy.all import Raw
+
+from ja4plus.utils.tls_utils import parse_tls_handshake
+from tests.fuzz.support import read_capture
+
+# `badcurveball.pcap` carries a TLS handshake with a malformed curve list. Its
+# ClientHello is the packet the length-field cases mutate.
+CLIENT_HELLO_CAPTURE = "badcurveball.pcap"
+
+
+@pytest.fixture(scope="session")
+def vector_dir():
+    """Return the directory that holds the committed FoxIO captures."""
+    return Path(__file__).resolve().parent.parent / "foxio_vectors"
+
+
+@pytest.fixture(scope="session")
+def client_hello_packet(vector_dir):
+    """Return the first packet of `badcurveball.pcap` that carries a ClientHello.
+
+    Raises:
+        AssertionError: The capture carries no ClientHello.
+    """
+    for packet in read_capture(vector_dir, CLIENT_HELLO_CAPTURE):
+        if Raw not in packet:
+            continue
+        info = parse_tls_handshake(bytes(packet[Raw].load))
+        if info and info.get("type") == "client_hello":
+            return packet
+    raise AssertionError(f"{CLIENT_HELLO_CAPTURE} carries no ClientHello.")

--- a/tests/fuzz/support.py
+++ b/tests/fuzz/support.py
@@ -1,0 +1,155 @@
+"""Helpers that drive every fingerprinter over hostile input.
+
+The suite generates each malformed copy at test time. The repository commits no
+generated capture.
+"""
+
+import sys
+import types
+
+from scapy.all import Raw, rdpcap
+
+from ja4plus.processor import Processor
+
+# The four FoxIO captures that exist to carry malformed input.
+MALFORMED_CAPTURES = (
+    "ssh2-malformed.pcap",
+    "ssh2-moloch-crash.pcap",
+    "badcurveball.pcap",
+    "CVE-2018-6794.pcap",
+)
+
+
+class CallCounter:
+    """Counts the calls of one parser."""
+
+    def __init__(self, target):
+        self.target = target
+        self.calls = 0
+
+
+def spy_on(monkeypatch, module, name):
+    """Return a counter that records each call of the named parser.
+
+    A test that asserts "no exception" passes when no parser runs. The counter proves
+    that the parser reads the malformed bytes, so the assertion can fail.
+
+    Args:
+        monkeypatch: The pytest `monkeypatch` fixture.
+        module: The module that defines the parser.
+        name: The parser name.
+
+    Returns:
+        A `CallCounter` whose `calls` attribute holds the call count.
+    """
+    original = getattr(module, name)
+    counter = CallCounter(f"{module.__name__}.{name}")
+
+    def wrapper(*args, **kwargs):
+        counter.calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(module, name, wrapper)
+
+    # A consumer that imports the name binds its own reference, and a patch on the
+    # defining module never reaches that reference.
+    for other in list(sys.modules.values()):
+        if not isinstance(other, types.ModuleType):
+            continue
+        if not getattr(other, "__name__", "").startswith("ja4plus"):
+            continue
+        if getattr(other, name, None) is original:
+            monkeypatch.setattr(other, name, wrapper)
+
+    return counter
+
+
+def read_capture(vector_dir, name):
+    """Return the packets of one committed capture.
+
+    Args:
+        vector_dir: The directory that holds the FoxIO captures.
+        name: The capture file name.
+
+    Returns:
+        The packet list scapy read.
+    """
+    return rdpcap(str(vector_dir / name))
+
+
+def run_fingerprinters(packets):
+    """Return the fingerprints every method produced, and the calls that raised.
+
+    Each fingerprinter reads each packet directly. `Processor.process_packet` catches
+    every exception, so a suite that drives the processor cannot observe a parser that
+    raises.
+
+    Args:
+        packets: The packets to read.
+
+    Returns:
+        A tuple of two items. The first maps a method name to the fingerprints it
+        produced. The second lists one description for each call that raised.
+    """
+    processor = Processor()
+    produced = {}
+    failures = []
+
+    for index, packet in enumerate(packets):
+        for method, fingerprinter in processor.fingerprinters.items():
+            try:
+                fingerprint = fingerprinter.process_packet(packet)
+            except Exception as error:  # noqa: BLE001 — the suite reports every raise.
+                failures.append(f"{method} raised on packet {index}: {error!r}")
+                continue
+            if fingerprint:
+                produced.setdefault(method, []).append(fingerprint)
+
+    return produced, failures
+
+
+def truncate_payloads(packets, fraction):
+    """Return copies of the packets whose transport payload keeps a part of its bytes.
+
+    The length fields inside the payload keep their values, so each declared length
+    exceeds the bytes that follow it. `FR-correctness-audit-10` names this case.
+
+    Args:
+        packets: The packets to copy.
+        fraction: The part of the payload to keep, from 0 to 1.
+
+    Returns:
+        A new packet list. The input packets stay unchanged.
+    """
+    truncated = []
+    for packet in packets:
+        copy = packet.copy()
+        if Raw in copy:
+            load = bytes(copy[Raw].load)
+            copy[Raw].load = load[: max(1, int(len(load) * fraction))]
+        truncated.append(copy)
+    return truncated
+
+
+def truncate_frames(packets, fraction):
+    """Return copies of the packets that keep a part of the whole frame.
+
+    A cut frame carries a partial header, so scapy reports a layer the packet does not
+    hold. `FR-correctness-audit-9` names this case.
+
+    Args:
+        packets: The packets to copy.
+        fraction: The part of the frame to keep, from 0 to 1.
+
+    Returns:
+        A new packet list. The input packets stay unchanged.
+    """
+    truncated = []
+    for packet in packets:
+        data = bytes(packet)
+        # scapy raises `struct.error` when it dissects a frame shorter than the
+        # link-layer header, so the cut keeps that header. A shorter frame builds no
+        # packet object, and it therefore reaches no fingerprinter.
+        floor = len(packet) - len(packet.payload)
+        truncated.append(packet.__class__(data[: max(floor, int(len(data) * fraction))]))
+    return truncated

--- a/tests/fuzz/support.py
+++ b/tests/fuzz/support.py
@@ -99,7 +99,9 @@ def run_fingerprinters(packets):
         for method, fingerprinter in processor.fingerprinters.items():
             try:
                 fingerprint = fingerprinter.process_packet(packet)
-            except Exception as error:  # noqa: BLE001 — the suite reports every raise.
+            # The harness catches every exception, because it measures whether one
+            # happened. A fingerprinter still catches only the errors it expects.
+            except Exception as error:
                 failures.append(f"{method} raised on packet {index}: {error!r}")
                 continue
             if fingerprint:

--- a/tests/fuzz/test_length_fields.py
+++ b/tests/fuzz/test_length_fields.py
@@ -1,0 +1,153 @@
+"""No parser trusts a length field it read from the packet.
+
+`FR-correctness-audit-8` and `FR-correctness-audit-10` state the contract. Each case
+mutates one length field of a real ClientHello and reads the result.
+"""
+
+import pytest
+from scapy.all import Raw
+
+from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
+
+# `badcurveball.pcap` carries this ClientHello. The unmutated case pins the value, so
+# every mutated case below proves that the parser reads the mutated bytes.
+RECORDED_JA4 = "t13d1615h2_46e7e9700bed_45f260be83e2"
+
+# The offsets of a TLS record header and a handshake header, from the first byte of the
+# record. RFC 8446 section 5.1 gives the record header, and section 4 gives the
+# handshake header.
+RECORD_LENGTH_OFFSET = 3
+HANDSHAKE_LENGTH_OFFSET = 6
+
+
+def read_ja4(packet, load):
+    """Return the JA4 fingerprint of the packet, with the payload replaced.
+
+    Args:
+        packet: The packet to copy.
+        load: The payload bytes the copy carries.
+
+    Returns:
+        The fingerprint, or None when the parser reads nothing.
+
+    Raises:
+        Exception: The fingerprinter raised. Every case treats a raise as a failure.
+    """
+    copy = packet.copy()
+    copy[Raw].load = load
+    return JA4Fingerprinter().process_packet(copy)
+
+
+def extensions_length_offset(load):
+    """Return the offset of the extension-list length field in a ClientHello.
+
+    The walk repeats the parser's own steps, because a length field has no fixed
+    offset. Each variable field precedes the extension list.
+
+    Args:
+        load: The ClientHello bytes, from the first byte of the record.
+
+    Returns:
+        The offset of the two-byte extension-list length field.
+    """
+    # 5 record header bytes, 4 handshake header bytes, 2 version bytes, 32 random bytes.
+    position = 11 + 32
+    position += 1 + load[position]  # The session identifier.
+    position += 2 + ((load[position] << 8) | load[position + 1])  # The cipher list.
+    position += 1 + load[position]  # The compression list.
+    return position
+
+
+@pytest.fixture
+def client_hello_load(client_hello_packet):
+    """Return the ClientHello payload bytes."""
+    return bytes(client_hello_packet[Raw].load)
+
+
+def test_the_unmutated_client_hello_produces_the_recorded_fingerprint(
+    client_hello_packet, client_hello_load
+):
+    """The parser reads this packet, so every mutated case below can fail."""
+    assert read_ja4(client_hello_packet, client_hello_load) == RECORDED_JA4
+
+
+def test_the_record_declares_more_bytes_than_the_cases_below_supply(client_hello_load):
+    """The record header declares 512 bytes, so a shorter payload contradicts it."""
+    declared = (client_hello_load[RECORD_LENGTH_OFFSET] << 8) | client_hello_load[
+        RECORD_LENGTH_OFFSET + 1
+    ]
+
+    assert declared == 512
+    assert len(client_hello_load) == declared + 5
+
+
+@pytest.mark.parametrize("kept", [12, 64, 256, 516])
+def test_a_record_that_declares_more_bytes_than_the_packet_produces_no_fingerprint(
+    client_hello_packet, client_hello_load, kept
+):
+    """The cut keeps every length field, so the record declares more bytes than it holds."""
+    assert read_ja4(client_hello_packet, client_hello_load[:kept]) is None
+
+
+def test_a_handshake_length_larger_than_the_packet_produces_no_fingerprint(
+    client_hello_packet, client_hello_load
+):
+    """The handshake length bounds the hello, so an inflated value reads past the packet."""
+    mutated = bytearray(client_hello_load)
+    mutated[HANDSHAKE_LENGTH_OFFSET : HANDSHAKE_LENGTH_OFFSET + 3] = b"\xff\xff\xff"
+
+    assert read_ja4(client_hello_packet, bytes(mutated)) is None
+
+
+def test_a_record_length_larger_than_the_packet_produces_no_exception(
+    client_hello_packet, client_hello_load
+):
+    """The record length bounds a group of messages, not one hello.
+
+    A TLS 1.2 server coalesces several handshake messages into one record, and #151
+    names the three FoxIO streams the record bound rejected. The hello therefore still
+    parses, and the inflated record length reaches no read.
+    """
+    mutated = bytearray(client_hello_load)
+    mutated[RECORD_LENGTH_OFFSET : RECORD_LENGTH_OFFSET + 2] = b"\xff\xff"
+
+    assert read_ja4(client_hello_packet, bytes(mutated)) == RECORDED_JA4
+
+
+def test_an_extension_list_that_declares_more_extensions_produces_no_exception(
+    client_hello_packet, client_hello_load
+):
+    """The parser bounds the extension walk on the payload length, not on the declaration.
+
+    The fingerprint stays equal to the recorded value, so the walk read the extensions
+    the packet carries and stopped at the last one.
+    """
+    offset = extensions_length_offset(client_hello_load)
+    declared = (client_hello_load[offset] << 8) | client_hello_load[offset + 1]
+    assert declared == len(client_hello_load) - offset - 2
+
+    mutated = bytearray(client_hello_load)
+    mutated[offset : offset + 2] = b"\xff\xff"
+
+    assert read_ja4(client_hello_packet, bytes(mutated)) == RECORDED_JA4
+
+
+def test_an_extension_that_declares_more_bytes_than_the_packet_produces_no_exception(
+    client_hello_packet, client_hello_load
+):
+    """An inflated extension length moves the walk past the payload, and the walk stops.
+
+    The result differs from the recorded value, because the walk reads one extension
+    and reaches no other. A different value proves the parser read the mutated field.
+    """
+    # The first extension header follows the two-byte extension-list length field. Its
+    # own length field follows its two-byte type field.
+    offset = extensions_length_offset(client_hello_load) + 2 + 2
+
+    mutated = bytearray(client_hello_load)
+    mutated[offset : offset + 2] = b"\xff\xff"
+
+    produced = read_ja4(client_hello_packet, bytes(mutated))
+
+    assert produced is not None
+    assert produced != RECORDED_JA4

--- a/tests/fuzz/test_malformed_captures.py
+++ b/tests/fuzz/test_malformed_captures.py
@@ -1,0 +1,104 @@
+"""The four FoxIO malformed captures produce no exception.
+
+`FR-correctness-audit-9` states the contract. Each case names the parser it reaches,
+because a case that reaches no parser proves nothing.
+"""
+
+import pytest
+
+import ja4plus.utils.ssh_utils as ssh_utils
+import ja4plus.utils.tls_utils as tls_utils
+from ja4plus.fingerprinters.ja4t import JA4TFingerprinter
+from tests.fuzz.support import (
+    MALFORMED_CAPTURES,
+    read_capture,
+    run_fingerprinters,
+    spy_on,
+)
+
+# The parser each capture exists to exercise.
+NAMED_PARSER = {
+    "ssh2-malformed.pcap": (ssh_utils, "parse_ssh_packet"),
+    "ssh2-moloch-crash.pcap": (ssh_utils, "parse_ssh_packet"),
+    "badcurveball.pcap": (tls_utils, "parse_tls_handshake"),
+    "CVE-2018-6794.pcap": (tls_utils, "parse_tls_handshake"),
+}
+
+# The distinct fingerprints each capture produces today. The suite pins the methods
+# that read a packet payload, and it pins JA4T and JA4TS because they read the TCP
+# header. It pins no JA4L value, because register row 5 stays open and JA4L still
+# emits a second client value.
+RECORDED_FINGERPRINTS = {
+    "ssh2-malformed.pcap": {
+        "ja4t": {"14600_2-1-1-4-1-3_1460_9"},
+        "ja4ts": {"5840_2-1-1-4-1-3_1460_2"},
+    },
+    "ssh2-moloch-crash.pcap": {
+        "ja4t": {"14600_2-1-1-4-1-3_1460_9"},
+        "ja4ts": {"5840_2-1-1-4-1-3_1460_2"},
+    },
+    "badcurveball.pcap": {
+        "ja4t": {"65535_2-1-3-1-1-8-4-0_1386_6"},
+        "ja4ts": {"26847_2-4-8-1-3_1460_7"},
+        "ja4": {"t13d1615h2_46e7e9700bed_45f260be83e2"},
+        "ja4s": {"t1205h1_c02b_845f7282a956"},
+        "ja4x": {"2e9214a636bc_2e9214a636bc_795797892f9c"},
+    },
+    "CVE-2018-6794.pcap": {
+        "ja4t": {"8192_2-1-3-1-1-4_1460_8"},
+        "ja4ts": {"15500_0_0_0"},
+        "ja4h": {
+            "ge11nn07ruru_6cd0fb54989b_000000000000_000000000000",
+            "ge11nr06ruru_cc6ec9a91856_000000000000_000000000000",
+        },
+    },
+}
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+def test_a_foxio_malformed_capture_produces_no_exception(vector_dir, capture):
+    _, failures = run_fingerprinters(read_capture(vector_dir, capture))
+    assert failures == []
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+def test_a_foxio_malformed_capture_reaches_the_parser_it_names(monkeypatch, vector_dir, capture):
+    module, name = NAMED_PARSER[capture]
+    counter = spy_on(monkeypatch, module, name)
+
+    run_fingerprinters(read_capture(vector_dir, capture))
+
+    assert counter.calls > 0, f"{capture} reaches {counter.target} zero times."
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+def test_a_foxio_malformed_capture_produces_the_recorded_fingerprints(vector_dir, capture):
+    produced, _ = run_fingerprinters(read_capture(vector_dir, capture))
+
+    for method, expected in RECORDED_FINGERPRINTS[capture].items():
+        assert set(produced.get(method, [])) == expected, method
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+def test_a_foxio_malformed_capture_produces_a_ja4l_value(vector_dir, capture):
+    produced, _ = run_fingerprinters(read_capture(vector_dir, capture))
+
+    assert produced.get("ja4l")
+
+
+def test_the_harness_reports_a_fingerprinter_that_raises(monkeypatch, vector_dir):
+    """The harness observes a raise, so every "no exception" case above can fail.
+
+    `Processor.process_packet` catches every exception. This case proves that the
+    suite reads each fingerprinter directly instead.
+    """
+
+    def raise_instead(self, packet):
+        raise ValueError("the harness must report this")
+
+    monkeypatch.setattr(JA4TFingerprinter, "process_packet", raise_instead)
+
+    _, failures = run_fingerprinters(read_capture(vector_dir, "badcurveball.pcap"))
+
+    assert failures
+    assert all("ja4t raised on packet" in failure for failure in failures)

--- a/tests/fuzz/test_truncated_captures.py
+++ b/tests/fuzz/test_truncated_captures.py
@@ -1,0 +1,149 @@
+"""A truncated copy of every FoxIO capture produces no exception.
+
+The suite cuts each capture at test time. The repository commits no generated capture.
+`FR-correctness-audit-9` and `FR-correctness-audit-10` state the contract.
+"""
+
+import pytest
+
+import ja4plus.utils.http_utils as http_utils
+import ja4plus.utils.ssh_utils as ssh_utils
+import ja4plus.utils.tls_utils as tls_utils
+from tests.fuzz.support import (
+    MALFORMED_CAPTURES,
+    read_capture,
+    run_fingerprinters,
+    spy_on,
+    truncate_frames,
+    truncate_payloads,
+)
+
+# The part of the input each case keeps.
+FRACTIONS = (0.9, 0.5, 0.1)
+
+SSH_CAPTURES = ("ssh2-malformed.pcap", "ssh2-moloch-crash.pcap")
+
+# The method each capture loses when the cut removes the bytes its parser needs. The
+# method produces a fingerprint on the committed capture and none on the cut copy, so
+# the pair proves that the parser reads the cut payload and returns nothing.
+SILENCED_METHOD = {
+    "badcurveball.pcap": "ja4",
+    "CVE-2018-6794.pcap": "ja4h",
+}
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+@pytest.mark.parametrize("fraction", FRACTIONS)
+def test_a_truncated_payload_produces_no_exception(vector_dir, capture, fraction):
+    packets = truncate_payloads(read_capture(vector_dir, capture), fraction)
+
+    _, failures = run_fingerprinters(packets)
+
+    assert failures == []
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+@pytest.mark.parametrize("fraction", FRACTIONS)
+def test_a_truncated_payload_reaches_the_tls_parser(monkeypatch, vector_dir, capture, fraction):
+    """The TLS parser reads every truncated payload, so the case above can fail."""
+    packets = truncate_payloads(read_capture(vector_dir, capture), fraction)
+    counter = spy_on(monkeypatch, tls_utils, "parse_tls_handshake")
+
+    run_fingerprinters(packets)
+
+    assert counter.calls > 0
+
+
+@pytest.mark.parametrize("capture", SSH_CAPTURES)
+@pytest.mark.parametrize("fraction", FRACTIONS)
+def test_a_truncated_ssh_payload_reaches_the_ssh_parser(monkeypatch, vector_dir, capture, fraction):
+    packets = truncate_payloads(read_capture(vector_dir, capture), fraction)
+    counter = spy_on(monkeypatch, ssh_utils, "parse_ssh_packet")
+
+    run_fingerprinters(packets)
+
+    assert counter.calls > 0
+
+
+@pytest.mark.parametrize("fraction", FRACTIONS)
+def test_a_truncated_http_payload_reaches_the_http_parser(monkeypatch, vector_dir, fraction):
+    packets = truncate_payloads(read_capture(vector_dir, "CVE-2018-6794.pcap"), fraction)
+    counter = spy_on(monkeypatch, http_utils, "is_http_request")
+
+    run_fingerprinters(packets)
+
+    assert counter.calls > 0
+
+
+@pytest.mark.parametrize("capture", sorted(SILENCED_METHOD))
+@pytest.mark.parametrize("fraction", FRACTIONS)
+def test_a_truncated_payload_silences_the_method_that_reads_it(vector_dir, capture, fraction):
+    """The parser produces a value on the committed capture and none on the cut copy.
+
+    The packet keeps every header, so each length field inside the payload declares
+    more bytes than the payload carries. `FR-correctness-audit-10` names this case.
+    """
+    method = SILENCED_METHOD[capture]
+    packets = read_capture(vector_dir, capture)
+
+    recorded, _ = run_fingerprinters(packets)
+    produced, _ = run_fingerprinters(truncate_payloads(packets, fraction))
+
+    assert recorded.get(method), f"{capture} produces no {method} value to silence."
+    assert produced.get(method) is None
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+@pytest.mark.parametrize("fraction", FRACTIONS)
+def test_a_truncated_payload_produces_no_fingerprint_the_capture_lacks(
+    vector_dir, capture, fraction
+):
+    """A cut payload produces a smaller result, never a value the capture never held.
+
+    A parser that trusts a declared length reads the bytes that follow it and reports
+    a fingerprint that describes no traffic.
+    """
+    packets = read_capture(vector_dir, capture)
+    recorded, _ = run_fingerprinters(packets)
+    produced, _ = run_fingerprinters(truncate_payloads(packets, fraction))
+
+    for method, fingerprints in produced.items():
+        invented = set(fingerprints) - set(recorded.get(method, []))
+        assert invented == set(), f"{method} invented {sorted(invented)}"
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+@pytest.mark.parametrize("fraction", FRACTIONS)
+def test_a_truncated_frame_produces_no_exception(vector_dir, capture, fraction):
+    """A cut frame carries a partial header, so scapy reports a layer it does not hold."""
+    packets = truncate_frames(read_capture(vector_dir, capture), fraction)
+
+    _, failures = run_fingerprinters(packets)
+
+    assert failures == []
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+def test_a_truncated_frame_reaches_the_tls_parser(monkeypatch, vector_dir, capture):
+    packets = truncate_frames(read_capture(vector_dir, capture), 0.9)
+    counter = spy_on(monkeypatch, tls_utils, "parse_tls_handshake")
+
+    run_fingerprinters(packets)
+
+    assert counter.calls > 0
+
+
+@pytest.mark.parametrize("capture", MALFORMED_CAPTURES)
+@pytest.mark.parametrize("fraction", FRACTIONS)
+def test_a_truncated_copy_differs_from_the_committed_capture(vector_dir, capture, fraction):
+    """The cut changes the bytes, so no case above reads the committed capture."""
+    packets = read_capture(vector_dir, capture)
+    original = [bytes(packet) for packet in packets]
+
+    payload_cut = [bytes(packet) for packet in truncate_payloads(packets, fraction)]
+    frame_cut = [bytes(packet) for packet in truncate_frames(packets, fraction)]
+
+    assert payload_cut != original
+    assert frame_cut != original
+    # The helper copies each packet, so the committed capture stays unchanged.
+    assert [bytes(packet) for packet in packets] == original


### PR DESCRIPTION
Part of #13. Builds #37.

## What

Adds `tests/fuzz/`, the malformed-input suite, and a `fuzz` job that runs it on every
pull request.

The suite runs every fingerprinter over the four committed FoxIO malformed captures,
over a truncated copy of each, and over a ClientHello whose length fields declare more
bytes than the packet carries. It generates each malformed copy at test time and
commits no capture.

## Why

`FR-correctness-audit-8` to `FR-correctness-audit-13`. Every packet is hostile input.
No parser trusts a length field it read from the packet. A parser that cannot read a
packet returns nothing, and it does not raise.

## The risk this suite had to avoid

A suite that asserts "no exception" passes when the parser is never reached. This
project has already found eleven assertions that cannot fail. Three guards keep this
suite from adding the twelfth:

1. **The harness observes a raise.** `Processor.process_packet` catches every
   exception, so a suite that drove the processor could never fail.
   `run_fingerprinters` reads each fingerprinter directly.
   `test_the_harness_reports_a_fingerprinter_that_raises` proves it.
2. **Every case names the parser it reaches.** `spy_on` counts the calls of that
   parser and fails on a count of zero. The counter patches the defining module and
   every module that bound the name, because a consumer that imports a name holds its
   own reference.
3. **Every case states what it produced.** `RECORDED_FINGERPRINTS` pins the value each
   capture produces. `SILENCED_METHOD` names a method that produces a value on the
   committed capture and none on the cut copy.

**Mutation check.** A parser patched to raise when a record declares more bytes than
the packet carries turns **34 cases red** across all four captures and all three
truncation fractions. The suite detects the defect it exists to detect.

## Measurements

| Capture | JA4 | JA4H | Parser calls, committed | Parser calls, cut |
|---|---|---|---|---|
| `badcurveball.pcap` | `t13d1615h2_46e7e9700bed_45f260be83e2` | — | `parse_tls_handshake` 8 | 8 |
| `CVE-2018-6794.pcap` | — | 12 values | `is_http_request` 18 | 18 |
| `ssh2-malformed.pcap` | — | — | `parse_ssh_packet` 15 | 13 |
| `ssh2-moloch-crash.pcap` | — | — | `parse_ssh_packet` 15 | 13 |

Under payload truncation JA4 drops to none on `badcurveball.pcap` and JA4H drops from
12 to none on `CVE-2018-6794.pcap`, while the parser call count stays above zero. The
parser is reached and returns nothing, which is the contract.

## No fingerprinter raises

The suite found no fingerprinter that raises on any of the four captures, on any
truncated copy, or on any mutated length field. No file under `ja4plus/` changed.

One finding sits in the harness, not in the library: `truncate_frames` never cuts below
the link-layer header, because scapy raises `struct.error` when it dissects a shorter
frame. Such a frame builds no packet object and reaches no fingerprinter, so a case
built on it would measure scapy instead of this project. `tests/fuzz/README.md` records
the reading.

## How tested

```
pytest tests/fuzz/                          106 passed
pytest tests/ -m "not spec_validation"      1132 passed, 8 xfailed
pytest tests/ -m spec_validation            1375 passed, 146 skipped, 120 xfailed
ruff check ja4plus/ tests/                  All checks passed
ruff format --check ja4plus/ tests/         108 files already formatted
mypy ja4plus/                               no issues in 27 source files
```

`120 xfailed` is unchanged, so the suite moves no fingerprint.
Line coverage rises from 80.08% to 80.14%.

Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/pcap (retrieved 2026-08-07)
Verified against: https://www.rfc-editor.org/rfc/rfc8446 (TLS 1.3, sections 4 and 5.1)
