### PR TITLE
Give a TCP reassembler stream a maximum age

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -185,8 +185,8 @@ result = generate_ja4(packet)
 
 | Class/Function | Description |
 |----------------|-------------|
-| `TCPStreamReassembler(max_streams, max_stream_bytes)` | Sequence-aware TCP stream reassembly |
-| `.add_segment(key, seq, data)` | Add a TCP segment |
+| `TCPStreamReassembler(max_streams, max_stream_bytes, max_stream_segments, max_stream_age)` | Sequence-aware TCP stream reassembly |
+| `.add_segment(key, seq, data, timestamp)` | Add a TCP segment. `timestamp` is the packet time in seconds, and it ages the stream |
 | `.get_stream(key)` | Get reassembled contiguous bytes |
 | `.remove_stream(key)` | Remove a tracked stream |
 
@@ -196,6 +196,7 @@ result = generate_ja4(packet)
 |----------|-------------|
 | `get_ip_layer(packet)` | Return IP or IPv6 layer, or None |
 | `get_ttl(packet)` | Return TTL (IPv4) or Hop Limit (IPv6), or None |
+| `packet_seconds(packet)` | Return the capture timestamp in seconds, or None |
 
 ## CLI Module
 

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -1058,6 +1058,56 @@ the keys the reassembler no longer holds once it passes `max_streams` entries, t
 **Location:** `ja4plus/utils/tcp_stream.py`, `ja4plus/utils/http_utils.py`,
 `ja4plus/fingerprinters/ja4h.py`. #33 built it, and it absorbed #103.
 
+### One stream holds a maximum age
+
+`CLAUDE.md` states that a state table has a maximum entry count and a maximum age. #33
+built the entry count and the two per-stream caps. No field held a timestamp, so a
+connection that sent one segment and then stopped held its slot until 100 further
+connections pushed it out.
+
+A stream entry now carries `last_seen`, the packet timestamp of its most recent segment.
+`add_segment` removes every stream that receives no segment for `max_stream_age` seconds.
+The removal drops the whole entry, so the segment list, the set of seen segments and the
+stored byte count leave together. A partial removal would leave a `(seq, length)` pair in
+the set, and `add_segment` would then drop that segment as a duplicate when the sender
+re-sends it.
+
+The age reads the packet timestamp, never the wall clock. `ja4plus/utils/tcp_stream.py`
+imports no clock, and the caller states the timestamp. `packet_seconds` in
+`ja4plus/utils/packet_utils.py` reads `packet.time` and returns None when the packet
+carries none. A stream whose `last_seen` is None never ages out, so a mixed clock evicts
+nothing.
+
+The age follows every segment the stream receives, not the segments the reassembler
+stores. A stream at its byte cap still sends, and an age that ignored a refused segment
+would evict a stream that is busy.
+
+**The default is 600 seconds, and the vectors measure the bound.** The longest gap
+between two segments of one stream across `tests/foxio_vectors/` is 320.714503 seconds,
+on `ssh-r.pcap`, stream `192.168.1.169:64980-192.168.1.197:22`. The measurement reads
+every capture with `rdpcap`, keys each TCP segment the way `ja4h.py` keys a stream, and
+records the widest gap between two packet timestamps of one key. The second reading is
+`http1.pcapng` at 60.042404 seconds. The default sits above the widest gap.
+
+No reference value moves. The conformance suite reports 1375 passed, 146 skipped and 120
+xfailed before the change and after it. A 300-second age gives the same three counts,
+because the one stream above 300 seconds is SSH traffic that JA4H and JA4X read nothing
+from.
+
+**The bound is safe because of what today's fingerprinters read, not because the bound is
+inherently safe.** JA4H and JA4X read the head of a stream, the way the #33 byte cap is
+safe. A later issue that reads further into a stream, or that adds a vector with a wider
+gap, must measure this age again.
+
+`docs/specs/features/03-concurrency-safety.md` states a 300-second default maximum age
+for a state table. That feature set is not built, and its other defaults do not describe
+this reassembler: it states 10000 entries where `max_streams` is 100 for JA4H and 50 for
+JA4X. #170 records the divergence and leaves the feature file for the issue that builds
+it.
+
+**Location:** `ja4plus/utils/tcp_stream.py`, `ja4plus/utils/packet_utils.py`,
+`ja4plus/fingerprinters/ja4h.py`, `ja4plus/fingerprinters/ja4x.py`. #170 built it.
+
 ---
 
 ## JA4H - HTTP

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -1089,6 +1089,11 @@ every capture with `rdpcap`, keys each TCP segment the way `ja4h.py` keys a stre
 records the widest gap between two packet timestamps of one key. The second reading is
 `http1.pcapng` at 60.042404 seconds. The default sits above the widest gap.
 
+`test_the_default_maximum_age_passes_the_longest_gap_of_the_vectors` runs that scan. It
+reads the captures rather than a stored number, so a vector with a wider gap fails it.
+An earlier form compared 600 against the literal 320.714503, and that form passes
+whatever the vectors hold. The scan costs 1.1 seconds.
+
 No reference value moves. The conformance suite reports 1375 passed, 146 skipped and 120
 xfailed before the change and after it. A 300-second age gives the same three counts,
 because the one stream above 300 seconds is SSH traffic that JA4H and JA4X read nothing

--- a/ja4plus/fingerprinters/ja4h.py
+++ b/ja4plus/fingerprinters/ja4h.py
@@ -20,7 +20,7 @@ from ja4plus.utils.http_utils import (
     parse_http_request,
 )
 from ja4plus.utils.tcp_stream import TCPStreamReassembler
-from ja4plus.utils.packet_utils import get_ip_layer
+from ja4plus.utils.packet_utils import get_ip_layer, packet_seconds
 from ja4plus.fingerprinters.base import BaseFingerprinter
 
 logger = logging.getLogger(__name__)
@@ -89,7 +89,7 @@ class JA4HFingerprinter(BaseFingerprinter):
         stream_key = f"{ip_layer.src}:{tcp.sport}-{ip_layer.dst}:{tcp.dport}"
         seq = tcp.seq if hasattr(tcp, "seq") else 0
 
-        self.reassembler.add_segment(stream_key, seq, raw_data)
+        self.reassembler.add_segment(stream_key, seq, raw_data, packet_seconds(packet))
         stream_data = self.reassembler.get_stream(stream_key)
 
         # Try to parse HTTP from reassembled stream

--- a/ja4plus/fingerprinters/ja4x.py
+++ b/ja4plus/fingerprinters/ja4x.py
@@ -111,7 +111,7 @@ class JA4XFingerprinter(BaseFingerprinter):
             return None
 
         try:
-            from ja4plus.utils.packet_utils import get_ip_layer
+            from ja4plus.utils.packet_utils import get_ip_layer, packet_seconds
 
             ip_layer = get_ip_layer(packet)
             if ip_layer is None:
@@ -127,7 +127,7 @@ class JA4XFingerprinter(BaseFingerprinter):
         raw_data = bytes(packet[Raw])
         seq = packet[TCP].seq if hasattr(packet[TCP], "seq") else 0
 
-        self.reassembler.add_segment(stream_id, seq, raw_data)
+        self.reassembler.add_segment(stream_id, seq, raw_data, packet_seconds(packet))
         stream_data = self.reassembler.get_stream(stream_id)
 
         fingerprint = self._find_certificates_in_stream_data(stream_id, stream_data, packet)

--- a/ja4plus/utils/packet_utils.py
+++ b/ja4plus/utils/packet_utils.py
@@ -15,6 +15,24 @@ def get_ip_layer(packet):
     return None
 
 
+def packet_seconds(packet):
+    """Return the capture timestamp of one packet, in seconds, or None.
+
+    A caller ages a state table on this value. It reads no wall clock, because a
+    capture file replays faster than real time, and a wall clock would evict state the
+    capture still needs.
+
+    Args:
+        packet: A network packet.
+
+    Returns:
+        The capture timestamp in seconds, or None when the packet carries none.
+    """
+    if not hasattr(packet, "time"):
+        return None
+    return float(packet.time)
+
+
 def get_ttl(packet):
     """Return TTL (IPv4) or Hop Limit (IPv6), or None."""
     if IP in packet:

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -69,7 +69,7 @@ class TCPStreamReassembler:
         self.max_stream_age = max_stream_age
 
     def _evict_aged_streams(self, now):
-        """Remove every stream that received no segment for `max_stream_age` seconds.
+        """Remove every stream that receives no segment for `max_stream_age` seconds.
 
         The removal drops the whole entry, so the segment list, the set of seen
         segments and the stored byte count leave together. A partial removal would make

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -37,12 +37,22 @@ def _seq_before(a, b):
 # segments a million entries in the segment list, so this cap carries the second bound.
 DEFAULT_MAX_STREAM_SEGMENTS = 4096
 
+# The maximum age of one stream, in seconds. `ssh-r.pcap` holds the longest gap between
+# two segments of one stream across `tests/foxio_vectors/`, at 320.714503 seconds. This
+# age sits above that gap, so no eviction reaches a vector stream.
+DEFAULT_MAX_STREAM_AGE = 600
+
 
 class TCPStreamReassembler:
     """Reassembles TCP streams using sequence numbers.
 
     Handles out-of-order segments, duplicates, and overlaps.
     Evicts oldest streams when max_streams is exceeded.
+
+    A stream also leaves the reassembler once it receives no segment for
+    `max_stream_age` seconds. The age reads the packet timestamp the caller states, and
+    this module imports no clock. A capture file replays faster than real time, so a
+    wall clock would evict state the capture still needs.
     """
 
     def __init__(
@@ -50,13 +60,31 @@ class TCPStreamReassembler:
         max_streams=100,
         max_stream_bytes=1048576,
         max_stream_segments=DEFAULT_MAX_STREAM_SEGMENTS,
+        max_stream_age=DEFAULT_MAX_STREAM_AGE,
     ):
         self.streams = OrderedDict()
         self.max_streams = max_streams
         self.max_stream_bytes = max_stream_bytes
         self.max_stream_segments = max_stream_segments
+        self.max_stream_age = max_stream_age
 
-    def add_segment(self, key, seq, data):
+    def _evict_aged_streams(self, now):
+        """Remove every stream that received no segment for `max_stream_age` seconds.
+
+        The removal drops the whole entry, so the segment list, the set of seen
+        segments and the stored byte count leave together. A partial removal would make
+        `add_segment` drop a later segment as a duplicate.
+
+        Args:
+            now: The packet timestamp of the current segment, in seconds.
+        """
+        # `max_streams` bounds this scan at 100 entries, so the cost per packet is flat.
+        for key, stream in list(self.streams.items()):
+            last_seen = stream["last_seen"]
+            if last_seen is not None and now - last_seen > self.max_stream_age:
+                del self.streams[key]
+
+    def add_segment(self, key, seq, data, timestamp=None):
         """Add a TCP segment to a stream.
 
         The stream refuses the segment once it holds `max_stream_bytes` bytes, or
@@ -67,16 +95,27 @@ class TCPStreamReassembler:
             key: The stream key.
             seq: The 32-bit TCP sequence number of the first byte of the segment.
             data: The payload bytes of the segment.
+            timestamp: The packet timestamp of the segment, in seconds. A caller that
+                states None gives the reassembler no age to read, and the age evicts no
+                stream of that reassembler.
         """
         if not data:
             return
 
+        if timestamp is not None:
+            self._evict_aged_streams(timestamp)
+
         if key not in self.streams:
             if len(self.streams) >= self.max_streams:
                 self.streams.popitem(last=False)
-            self.streams[key] = {"segments": [], "seen": set(), "bytes": 0}
+            self.streams[key] = {"segments": [], "seen": set(), "bytes": 0, "last_seen": None}
 
         stream = self.streams[key]
+
+        # The stream still sends while a cap refuses its segments, so the age follows
+        # every segment the stream receives, not the segments the reassembler stores.
+        if timestamp is not None:
+            stream["last_seen"] = timestamp
 
         # A scan of every stored segment costs the square of the segment count. A
         # retransmission-heavy stream reaches thousands of segments.

--- a/tests/test_ja4h_reassembly.py
+++ b/tests/test_ja4h_reassembly.py
@@ -110,5 +110,36 @@ class TestJA4HReassembly(unittest.TestCase):
         self.assertIn("10.0.0.1:12345-10.0.0.2:80", fp.reassembler.streams)
 
 
+class TestJA4HStreamAge(unittest.TestCase):
+    """Tests that JA4H states the packet time to the reassembler."""
+
+    # A capture time from 2001, far from the wall clock.
+    OLD_CAPTURE_TIME = 1000000000.0
+
+    def _partial_request(self, sport, seconds):
+        """Return one packet that starts an HTTP request and completes no header."""
+        packet = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=sport, dport=80, seq=100)
+            / Raw(load=b"GET /index.html HTTP/1.1\r\nHost: exam")
+        )
+        packet.time = seconds
+        return packet
+
+    def test_the_stream_holds_the_packet_time_of_its_most_recent_segment(self):
+        fp = JA4HFingerprinter()
+        fp.process_packet(self._partial_request(12345, self.OLD_CAPTURE_TIME))
+        key = "10.0.0.1:12345-10.0.0.2:80"
+        self.assertEqual(fp.reassembler.streams[key]["last_seen"], self.OLD_CAPTURE_TIME)
+
+    def test_a_stream_that_passes_the_maximum_age_leaves_the_reassembler(self):
+        fp = JA4HFingerprinter()
+        fp.reassembler.max_stream_age = 100
+        fp.process_packet(self._partial_request(12345, self.OLD_CAPTURE_TIME))
+        fp.process_packet(self._partial_request(12346, self.OLD_CAPTURE_TIME + 101))
+        self.assertNotIn("10.0.0.1:12345-10.0.0.2:80", fp.reassembler.streams)
+        self.assertIn("10.0.0.1:12346-10.0.0.2:80", fp.reassembler.streams)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ja4x_reassembly.py
+++ b/tests/test_ja4x_reassembly.py
@@ -39,5 +39,36 @@ class TestJA4XReassembly(unittest.TestCase):
         # Should not crash; reassembly should handle ordering
 
 
+class TestJA4XStreamAge(unittest.TestCase):
+    """Tests that JA4X states the packet time to the reassembler."""
+
+    # A capture time from 2001, far from the wall clock.
+    OLD_CAPTURE_TIME = 1000000000.0
+
+    def _partial_record(self, sport, seconds):
+        """Return one packet that starts a TLS record and completes no handshake."""
+        packet = (
+            IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=sport, dport=12345, seq=100)
+            / Raw(load=b"\x16\x03\x01\x00\x05\x0b\x00\x00\x01\x00")
+        )
+        packet.time = seconds
+        return packet
+
+    def test_the_stream_holds_the_packet_time_of_its_most_recent_segment(self):
+        fp = JA4XFingerprinter()
+        fp.process_packet(self._partial_record(443, self.OLD_CAPTURE_TIME))
+        key = "10.0.0.1:443-10.0.0.2:12345"
+        self.assertEqual(fp.reassembler.streams[key]["last_seen"], self.OLD_CAPTURE_TIME)
+
+    def test_a_stream_that_passes_the_maximum_age_leaves_the_reassembler(self):
+        fp = JA4XFingerprinter()
+        fp.reassembler.max_stream_age = 100
+        fp.process_packet(self._partial_record(443, self.OLD_CAPTURE_TIME))
+        fp.process_packet(self._partial_record(444, self.OLD_CAPTURE_TIME + 101))
+        self.assertNotIn("10.0.0.1:443-10.0.0.2:12345", fp.reassembler.streams)
+        self.assertIn("10.0.0.1:444-10.0.0.2:12345", fp.reassembler.streams)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_packet_utils.py
+++ b/tests/test_packet_utils.py
@@ -56,5 +56,22 @@ class TestGetTTL(unittest.TestCase):
         self.assertIsNone(get_ttl(pkt))
 
 
+class TestPacketSeconds(unittest.TestCase):
+    def test_returns_the_capture_timestamp_in_seconds(self):
+        from ja4plus.utils.packet_utils import packet_seconds
+
+        pkt = IP() / TCP() / Raw(load=b"a")
+        # A capture time from 2001, far from the wall clock.
+        pkt.time = 1000000000.0
+        self.assertEqual(packet_seconds(pkt), 1000000000.0)
+
+    def test_returns_none_when_the_packet_carries_no_time(self):
+        from ja4plus.utils.packet_utils import packet_seconds
+
+        # A caller that receives None ages no state table, so a missing packet time
+        # never falls back to the wall clock.
+        self.assertIsNone(packet_seconds(object()))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tcp_stream.py
+++ b/tests/test_tcp_stream.py
@@ -2,6 +2,9 @@
 
 import time
 import unittest
+from pathlib import Path
+
+VECTORS_DIR = Path(__file__).parent / "foxio_vectors"
 
 # A TCP sequence number is 32 bits. 0xFFFFFFFE puts the next four bytes across the
 # boundary, so a reassembler that compares raw numbers orders these segments backwards.
@@ -319,15 +322,15 @@ class TestTCPStreamMaximumAge(unittest.TestCase):
         self.assertFalse(hasattr(tcp_stream, "time"))
         self.assertFalse(hasattr(tcp_stream, "datetime"))
 
-    def test_the_packet_clock_alone_ages_a_stream(self):
+    def test_the_stream_holds_the_stated_packet_time(self):
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
 
         r = TCPStreamReassembler(max_stream_age=100)
-        # Both packets carry a capture time from 2001. The wall clock passes it by
-        # decades, so a reassembler that reads the wall clock removes this stream.
         r.add_segment("s1", seq=0, data=b"a", timestamp=OLD_CAPTURE_TIME)
         r.add_segment("s1", seq=1, data=b"b", timestamp=OLD_CAPTURE_TIME + 1)
-        self.assertIn("s1", r.streams)
+        # The stored value is the time the caller states. A reassembler that reads the
+        # wall clock stores a time from this year, which this comparison rejects.
+        self.assertEqual(r.streams["s1"]["last_seen"], OLD_CAPTURE_TIME + 1)
         self.assertEqual(r.get_stream("s1"), b"ab")
 
     def test_an_age_eviction_accepts_the_same_segment_again(self):
@@ -365,13 +368,43 @@ class TestTCPStreamMaximumAge(unittest.TestCase):
         self.assertIn("s1", r.streams)
 
     def test_the_default_maximum_age_passes_the_longest_gap_of_the_vectors(self):
+        from scapy.all import TCP, Raw, rdpcap
+
+        from ja4plus.utils.packet_utils import get_ip_layer
         from ja4plus.utils.tcp_stream import TCPStreamReassembler
 
-        # `ssh-r.pcap` holds the longest gap between two segments of one stream across
-        # `tests/foxio_vectors/`, at 320.714503 seconds. The default sits above it, so
-        # no eviction reaches a stream a fingerprinter still reads.
+        captures = sorted(VECTORS_DIR.glob("*.pcap")) + sorted(VECTORS_DIR.glob("*.pcapng"))
+        if not captures:
+            self.skipTest("tests/foxio_vectors/ holds no capture")
+
+        # The measurement reads every capture and keys each TCP segment the way
+        # `ja4h.py` keys a stream. A hardcoded reading passes whatever the vectors hold,
+        # so this test reads them. It fails when a new vector holds a wider gap.
+        widest = 0.0
+        widest_capture = None
+        for path in captures:
+            last = {}
+            for packet in rdpcap(str(path)):
+                if not (packet.haslayer(TCP) and packet.haslayer(Raw)):
+                    continue
+                ip_layer = get_ip_layer(packet)
+                if ip_layer is None:
+                    continue
+                tcp = packet[TCP]
+                key = f"{ip_layer.src}:{tcp.sport}-{ip_layer.dst}:{tcp.dport}"
+                seconds = float(packet.time)
+                if key in last and seconds - last[key] > widest:
+                    widest = seconds - last[key]
+                    widest_capture = path.name
+                last[key] = seconds
+
+        self.assertGreater(widest, 0.0, "the scan measured no gap")
+        self.assertEqual(widest_capture, "ssh-r.pcap")
+        self.assertAlmostEqual(widest, 320.714503, places=5)
+        # An eviction that reaches a stream a fingerprinter still reads moves a
+        # fingerprint. The default sits above the widest gap the vectors hold.
         r = TCPStreamReassembler()
-        self.assertGreater(r.max_stream_age, 320.714503)
+        self.assertGreater(r.max_stream_age, widest)
 
 
 if __name__ == "__main__":

--- a/tests/test_tcp_stream.py
+++ b/tests/test_tcp_stream.py
@@ -282,5 +282,97 @@ class TestTCPStreamReassembler(unittest.TestCase):
         self.assertLessEqual(len(result), 10)
 
 
+# The reassembler holds no clock of its own, so a test states the packet time itself.
+# This value is the capture time of a packet from 2001, far from the wall clock. A
+# reassembler that reads the wall clock therefore gives a different answer.
+OLD_CAPTURE_TIME = 1000000000.0
+
+
+class TestTCPStreamMaximumAge(unittest.TestCase):
+    """Tests for the maximum age of one stream of the reassembler."""
+
+    def test_removes_a_stream_that_receives_no_segment_for_the_maximum_age(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_age=100)
+        r.add_segment("s1", seq=0, data=b"a", timestamp=OLD_CAPTURE_TIME)
+        # The second packet arrives 101 packet seconds later, which passes the age.
+        r.add_segment("s2", seq=0, data=b"b", timestamp=OLD_CAPTURE_TIME + 101)
+        self.assertNotIn("s1", r.streams)
+        self.assertIn("s2", r.streams)
+
+    def test_keeps_a_stream_that_receives_a_segment_inside_the_maximum_age(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_age=100)
+        r.add_segment("s1", seq=0, data=b"a", timestamp=OLD_CAPTURE_TIME)
+        r.add_segment("s1", seq=1, data=b"b", timestamp=OLD_CAPTURE_TIME + 99)
+        r.add_segment("s2", seq=0, data=b"c", timestamp=OLD_CAPTURE_TIME + 100)
+        self.assertIn("s1", r.streams)
+        self.assertEqual(r.get_stream("s1"), b"ab")
+
+    def test_the_module_reads_no_wall_clock(self):
+        import ja4plus.utils.tcp_stream as tcp_stream
+
+        # A capture file replays faster than real time. A wall clock would evict state
+        # the capture still needs, so the module imports no clock to read.
+        self.assertFalse(hasattr(tcp_stream, "time"))
+        self.assertFalse(hasattr(tcp_stream, "datetime"))
+
+    def test_the_packet_clock_alone_ages_a_stream(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_age=100)
+        # Both packets carry a capture time from 2001. The wall clock passes it by
+        # decades, so a reassembler that reads the wall clock removes this stream.
+        r.add_segment("s1", seq=0, data=b"a", timestamp=OLD_CAPTURE_TIME)
+        r.add_segment("s1", seq=1, data=b"b", timestamp=OLD_CAPTURE_TIME + 1)
+        self.assertIn("s1", r.streams)
+        self.assertEqual(r.get_stream("s1"), b"ab")
+
+    def test_an_age_eviction_accepts_the_same_segment_again(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_age=100)
+        r.add_segment("s1", seq=100, data=b"hello", timestamp=OLD_CAPTURE_TIME)
+        r.add_segment("s2", seq=0, data=b"x", timestamp=OLD_CAPTURE_TIME + 101)
+        # The set of seen segments leaves with the stream. A set that stays makes the
+        # reassembler drop this segment as a duplicate.
+        r.add_segment("s1", seq=100, data=b"hello", timestamp=OLD_CAPTURE_TIME + 102)
+        self.assertEqual(r.get_stream("s1"), b"hello")
+        self.assertEqual(r.streams["s1"]["bytes"], 5)
+        self.assertEqual(len(r.streams["s1"]["segments"]), 1)
+
+    def test_a_refused_segment_holds_the_stream_against_the_maximum_age(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_age=100, max_stream_bytes=1)
+        r.add_segment("s1", seq=0, data=b"a", timestamp=OLD_CAPTURE_TIME)
+        # The byte cap refuses this segment. The stream still sends, so the age of the
+        # stream follows the segment the reassembler refused.
+        r.add_segment("s1", seq=1, data=b"bb", timestamp=OLD_CAPTURE_TIME + 90)
+        r.add_segment("s2", seq=0, data=b"c", timestamp=OLD_CAPTURE_TIME + 150)
+        self.assertIn("s1", r.streams)
+
+    def test_a_stream_without_a_packet_time_stays(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        r = TCPStreamReassembler(max_stream_age=100)
+        # A caller that states no packet time gives the reassembler no age to read.
+        r.add_segment("s1", seq=0, data=b"a")
+        r.add_segment("s2", seq=0, data=b"b", timestamp=OLD_CAPTURE_TIME)
+        r.add_segment("s3", seq=0, data=b"c", timestamp=OLD_CAPTURE_TIME + 10000)
+        self.assertIn("s1", r.streams)
+
+    def test_the_default_maximum_age_passes_the_longest_gap_of_the_vectors(self):
+        from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+        # `ssh-r.pcap` holds the longest gap between two segments of one stream across
+        # `tests/foxio_vectors/`, at 320.714503 seconds. The default sits above it, so
+        # no eviction reaches a stream a fingerprinter still reads.
+        r = TCPStreamReassembler()
+        self.assertGreater(r.max_stream_age, 320.714503)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Builds #170.

## What

`CLAUDE.md` states that a state table has a maximum entry count and a maximum age. #33
built the entry count and the two per-stream caps. No field held a timestamp, so a
connection that sent one segment and then stopped held its slot until 100 further
connections pushed it out.

A stream entry now carries `last_seen`, the packet timestamp of its most recent segment.
`add_segment` removes every stream that receives no segment for `max_stream_age` seconds.

## Why the removal drops the whole entry

#32 added a `seen` set of `(seq, length)` pairs, and #33 added the stored byte count. An
eviction that removed a segment and left either one behind would make `add_segment` drop
a re-sent segment as a duplicate, and would leave the byte count high. The age eviction
deletes the whole entry with `del self.streams[key]`, so all three leave together.
`test_an_age_eviction_accepts_the_same_segment_again` measures it.

## The clock

The age reads the packet timestamp, never the wall clock.
`.claude/rules/conformance.md`: "A capture file replays faster than real time, and a wall
clock would evict state the capture still needs."

`ja4plus/utils/tcp_stream.py` imports no clock. The caller states the timestamp through
the new `packet_seconds` helper in `ja4plus/utils/packet_utils.py`, which reads
`packet.time` and returns None when the packet carries none. A stream whose `last_seen`
is None never ages out, so a missing packet time evicts nothing rather than falling back
to a wall clock.

## The third caller

The issue body names two callers. A sweep of `ja4plus/` finds a third `add_segment` call
site at `ja4plus/fingerprinters/ja4ssh.py:164`, but its receiver is `SSHMessageTracker`
in `ja4plus/utils/ssh_utils.py:99`, a different class with a different signature. The
signature change therefore reaches exactly two call sites,
`ja4plus/fingerprinters/ja4h.py:92` and `ja4plus/fingerprinters/ja4x.py:130`.

## The measurement that bounds the risk

**The default is 600 seconds.** The longest gap between two segments of one stream across
`tests/foxio_vectors/` is **320.714503 seconds**, on `ssh-r.pcap`, stream
`192.168.1.169:64980-192.168.1.197:22`. The second reading is `http1.pcapng` at
60.042404 seconds. The measurement reads every capture with `rdpcap`, keys each TCP
segment the way `ja4h.py` keys a stream, and records the widest gap between two packet
timestamps of one key.

**No reference value moves. The count is zero.** The conformance suite reports 1375
passed, 146 skipped and 120 xfailed before the change and after it, against 120 keys in
`tests/foxio_deviations.json`.

**The bound is safe because of what today fingerprinters read, not because the bound is
inherently safe.** JA4H and JA4X read the head of a stream, so a stream that leaves late
in a capture changes no value. This has the same shape as the #33 byte cap, which
truncates `http2-with-cookies.pcapng` from 1853328 bytes to 1048554 and moves nothing. A
later issue that reads further into a stream, or that adds a vector with a wider gap,
must measure this age again.

## One divergence to note

`docs/specs/features/03-concurrency-safety.md` states "The default maximum age is 300
seconds." That is below the 320.714503-second measurement. That feature set is not built,
and its other defaults do not describe this reassembler: it states 10000 entries where
`max_streams` is 100 for JA4H and 50 for JA4X.

A 300-second age gives the same conformance counts, because the one stream above 300
seconds is SSH traffic that JA4H and JA4X read nothing from. This pull request follows
the measurement and takes 600, and `docs/implementation_notes.md` records the divergence.
The feature file stays for the issue that builds it.

## How tested

Every new test failed against the code as it stood. 11 of the 12 failed:

```
E  TypeError: TCPStreamReassembler.__init__() got an unexpected keyword argument
   max_stream_age. Did you mean max_streams?
E  AttributeError: TCPStreamReassembler object has no attribute max_stream_age.
   Did you mean: max_stream_bytes?
E  KeyError: last_seen
E  AssertionError: 10.0.0.1:12345-10.0.0.2:80 unexpectedly found in OrderedDict(...)
```

The twelfth, `test_the_module_reads_no_wall_clock`, passes against the code as it stands,
because the module imports no clock today. **It is not evidence for the packet-clock
criterion.** It is a guard against a later wall-clock import. The two behaviour tests
carry that criterion, and both failed before the change:
`test_removes_a_stream_that_receives_no_segment_for_the_maximum_age` and
`test_the_packet_clock_alone_ages_a_stream`.

The five gates:

```
pytest tests/ -m "not spec_validation"   1050 passed, 8 xfailed, 93 subtests passed
pytest tests/ -m spec_validation         1375 passed, 146 skipped, 120 xfailed
ruff check ja4plus/ tests/               All checks passed!
ruff format --check ja4plus/ tests/      102 files already formatted
mypy ja4plus/                            Success: no issues found in 27 source files
```

Coverage of the two changed modules holds at 99%. `ja4plus/utils/packet_utils.py` is
100% and `ja4plus/utils/tcp_stream.py` is 99%, which are the readings before the change.

## Out of scope

48 JA4L and QUIC tests pass without `--cov` and fail with it, on this base commit before
this change. #177 records it. This pull request changes none of them.

Verified against: https://scapy.readthedocs.io/en/latest/api/scapy.packet.html (scapy 2.6, retrieved 2026-08-07)
