### PR TITLE
Add FingerprintResult with deprecated item access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`FingerprintResult` is the typed result of the public interface** (#44). The new
+  module `ja4plus/types.py` holds a frozen dataclass with nine fields, and `ja4plus`
+  exports the name. The field names are the snake-case form of the `FingerprintResult`
+  struct of the Go port, under parity rule 2, so the field that names the method is
+  `type` and not `method`. A result reads by field name as well as by attribute, so
+  code written against the dictionary of version 0.6.0 keeps working for one major
+  version. **Item access emits a `DeprecationWarning` that names the attribute form.**
+  The item access covers reading only, and a result supports no item assignment.
+  `Processor.process_packet` still returns a list of dictionaries, and #45 changes it.
+  No fingerprint value moved. `docs/specs/features/04-typed-api.md` states
+  FR-typed-api-1, FR-typed-api-2, FR-typed-api-5 and FR-typed-api-6.
+
 - **JA4SSH emits the window a connection holds open when the capture ends**
   (#214). Every fingerprinter and the processor now carry `close_open_windows()`.
   Call it when the packet source ends. `ja4plus analyze` calls it after the file

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -187,6 +187,55 @@ hassh = fp.get_hassh_fingerprints()              # HASSH fingerprints
 lookup = fp.lookup_hassh(hassh_value)            # Known HASSH lookup
 ```
 
+## Result type
+
+### ja4plus.types
+
+`FingerprintResult` is the typed result of the public interface. It is a frozen
+dataclass, because a result describes something that already happened.
+
+| Field | Type | Constraint |
+|---|---|---|
+| `type` | `str` | One of the ten method names, lowercase. |
+| `fingerprint` | `str` | The fingerprint string. Never empty. |
+| `raw` | `str \| None` | The raw form, when the method defines one. |
+| `raw_original_order` | `str \| None` | The original-order raw form, when the method defines one. |
+| `src_ip` | `str` | The source address. Empty when the packet carries no address. |
+| `src_port` | `int` | The source port. Zero when the packet carries no port. |
+| `dst_ip` | `str` | The destination address. |
+| `dst_port` | `int` | The destination port. |
+| `timestamp` | `datetime \| None` | The packet timestamp, or `None` when the packet carries none. |
+
+The field names are the snake-case form of the `FingerprintResult` struct of the Go
+port, under parity rule 2. The field that names the method is `type`, not `method`.
+
+```python
+from ja4plus import FingerprintResult
+
+result = FingerprintResult(type="ja4", fingerprint="t13d1516h2_8daaf6152771_b0da82dd1658")
+result.type          # "ja4"
+result.fingerprint   # "t13d1516h2_8daaf6152771_b0da82dd1658"
+result.timestamp     # None
+```
+
+#### The deprecated item access
+
+Version 0.6.0 returned a dictionary. A result reads by field name too, so that code
+written against the dictionary keeps working for one major version.
+
+Warning: item access emits a `DeprecationWarning`. Read the attribute instead.
+
+```python
+result["fingerprint"]   # the same value, and one DeprecationWarning
+result["method"]        # KeyError. The field is `type`.
+```
+
+The item access covers reading only. `result["fingerprint"] = "x"` raises `TypeError`,
+and `result.fingerprint = "x"` raises `dataclasses.FrozenInstanceError`.
+
+`Processor.process_packet` still returns a list of dictionaries. #45 changes it to
+return a list of `FingerprintResult`.
+
 ## Processor
 
 ### ja4plus.processor

--- a/ja4plus/__init__.py
+++ b/ja4plus/__init__.py
@@ -17,6 +17,7 @@ from ja4plus.fingerprinters.ja4ts import JA4TSFingerprinter
 from ja4plus.fingerprinters.ja4d import JA4DFingerprinter
 from ja4plus.fingerprinters.ja4d6 import JA4D6Fingerprinter
 from ja4plus.processor import Processor
+from ja4plus.types import FingerprintResult
 
 # Function-based API
 from ja4plus.fingerprinters.ja4 import generate_ja4

--- a/ja4plus/types.py
+++ b/ja4plus/types.py
@@ -1,0 +1,86 @@
+"""The typed result the public interface returns.
+
+`docs/specs/features/04-typed-api.md` defines this module. The `### Result` table of
+`docs/specs/spec.md` holds the field list, and `tests/test_types.py` reads that table
+back.
+"""
+
+# Python 3.9 is the floor, and it evaluates no annotation written as `str | None`
+# without this import.
+from __future__ import annotations
+
+import dataclasses
+import warnings
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+__all__ = ["FingerprintResult"]
+
+
+@dataclass(frozen=True)
+class FingerprintResult:
+    """One fingerprint, with the addresses and the time of the packet that made it.
+
+    The field names are the snake-case form of the `FingerprintResult` struct of the Go
+    port, under parity rule 2. The field that names the method is `type`, because the
+    port calls it `Type` and the dictionary of version 0.6.0 already uses that key.
+
+    The result is frozen. It describes something that already happened, so nothing
+    changes it after a fingerprinter returns it.
+
+    Attributes:
+        type: The method name, lowercase. One of the ten this library implements.
+        fingerprint: The fingerprint string. Never empty.
+        raw: The raw form, when the method defines one.
+        raw_original_order: The original-order raw form, when the method defines one.
+        src_ip: The source address. Empty when the packet carries no address.
+        src_port: The source port. Zero when the packet carries no port.
+        dst_ip: The destination address.
+        dst_port: The destination port.
+        timestamp: The packet timestamp, or None when the packet carries none.
+
+    Verified against: https://github.com/Crank-Git/ja4plus-go/blob/master/types.go
+    (retrieved 2026-08-06).
+    """
+
+    type: str
+    fingerprint: str
+    raw: str | None = None
+    raw_original_order: str | None = None
+    src_ip: str = ""
+    src_port: int = 0
+    dst_ip: str = ""
+    dst_port: int = 0
+    timestamp: datetime | None = None
+
+    def __getitem__(self, key: str) -> Any:
+        """Return the value of the field the key names.
+
+        Version 0.6.0 returned a dictionary. This method keeps that caller working for
+        one major version, and it warns the caller to read the attribute instead.
+
+        Args:
+            key: A field name of this dataclass.
+
+        Returns:
+            The value the field of that name holds.
+
+        Raises:
+            KeyError: This dataclass holds no field of that name. The key `"method"`
+                reaches this, because the field is `type`.
+        """
+        if key not in _FIELD_NAMES:
+            raise KeyError(key)
+        warnings.warn(
+            f"Item access on a FingerprintResult is deprecated. Read result.{key} instead.",
+            DeprecationWarning,
+            # The caller's line is the useful one, not this method's line.
+            stacklevel=2,
+        )
+        return getattr(self, key)
+
+
+# The membership test of `__getitem__` reads this set, so item access reaches a field
+# and no other attribute.
+_FIELD_NAMES = frozenset(field.name for field in dataclasses.fields(FingerprintResult))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,165 @@
+"""Tests that `FingerprintResult` matches the data model and deprecates item access.
+
+`docs/specs/features/04-typed-api.md` states FR-typed-api-1, FR-typed-api-2,
+FR-typed-api-5 and FR-typed-api-6. The `### Result` table of `docs/specs/spec.md`
+holds the field list, and one case here reads that table, so a field the spec adds
+fails this suite until the dataclass carries it.
+
+These cases import no fingerprinter and they produce no fingerprint.
+"""
+
+import dataclasses
+import re
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import ja4plus
+from ja4plus.types import FingerprintResult
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SPEC = REPO_ROOT / "docs" / "specs" / "spec.md"
+
+# One filled result. Every field holds a value a reader can tell from every other
+# value, so a case that reads the wrong field fails.
+SAMPLE = FingerprintResult(
+    type="ja4",
+    fingerprint="t13d1516h2_8daaf6152771_b0da82dd1658",
+    raw="t13d1516h2_002f,0035_0005,000a",
+    raw_original_order="t13d1516h2_0035,002f_000a,0005",
+    src_ip="10.0.0.1",
+    src_port=44100,
+    dst_ip="10.0.0.2",
+    dst_port=443,
+    timestamp=datetime(2026, 8, 8, 12, 0, 0, tzinfo=timezone.utc),
+)
+
+
+def _spec_field_names() -> list[str]:
+    """Return the field names the `### Result` table of the spec lists.
+
+    Returns:
+        The first cell of each table row, in the order the table holds.
+
+    Raises:
+        AssertionError: The spec holds no `### Result` table.
+    """
+    text = SPEC.read_text(encoding="utf-8")
+    start = text.index("\n### Result\n")
+    end = text.index("\n### ", start + 1)
+    section = text[start:end]
+    names = re.findall(r"^\| `([a-z_]+)` \|", section, flags=re.MULTILINE)
+    assert names, "`docs/specs/spec.md` holds no `### Result` field table"
+    return names
+
+
+def test_the_field_names_match_the_spec_data_model():
+    """The dataclass carries the fields the spec lists, in the spec's order."""
+    declared = [field.name for field in dataclasses.fields(FingerprintResult)]
+    assert declared == _spec_field_names()
+
+
+def test_the_package_exports_the_result_type():
+    """`ja4plus.FingerprintResult` is the dataclass `ja4plus.types` defines."""
+    assert ja4plus.FingerprintResult is FingerprintResult
+
+
+def test_the_result_is_a_frozen_dataclass():
+    """FR-typed-api-1 states the result is a frozen dataclass."""
+    assert dataclasses.is_dataclass(FingerprintResult)
+    assert FingerprintResult.__dataclass_params__.frozen is True
+
+
+def test_item_access_returns_the_value_the_attribute_holds():
+    """Every field reads the same through both forms."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        for field in dataclasses.fields(FingerprintResult):
+            assert SAMPLE[field.name] == getattr(SAMPLE, field.name)
+
+
+def test_item_access_by_the_type_key_returns_the_method_name():
+    """`result["type"]` returns the value `result.type` holds."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        value = SAMPLE["type"]
+    assert value == "ja4"
+    assert value == SAMPLE.type
+
+
+def test_item_access_emits_a_deprecation_warning():
+    """FR-typed-api-6 states that item access emits a `DeprecationWarning`."""
+    with pytest.warns(DeprecationWarning) as record:
+        SAMPLE["fingerprint"]
+    assert len(record) == 1
+    message = str(record[0].message)
+    assert "FingerprintResult" in message
+    assert "result.fingerprint" in message
+
+
+def test_attribute_access_emits_no_warning():
+    """A reader of the new form sees no warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert SAMPLE.fingerprint == "t13d1516h2_8daaf6152771_b0da82dd1658"
+
+
+def test_the_method_key_raises_a_key_error():
+    """The field is `type`, so `result["method"]` raises `KeyError`."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(KeyError):
+            SAMPLE["method"]
+
+
+def test_a_private_attribute_name_raises_a_key_error():
+    """Item access reads a field, so it reaches no other attribute."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(KeyError):
+            SAMPLE["__class__"]
+
+
+def test_attribute_assignment_raises_a_frozen_instance_error():
+    """The result is frozen, so a caller changes no field."""
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        SAMPLE.fingerprint = "x"
+
+
+def test_item_assignment_raises_a_type_error():
+    """The deprecated item access covers reading only."""
+    with pytest.raises(TypeError):
+        SAMPLE["fingerprint"] = "x"
+
+
+def test_item_deletion_raises_a_type_error():
+    """A result supports no item deletion either."""
+    with pytest.raises(TypeError):
+        del SAMPLE["fingerprint"]
+
+
+def test_the_optional_fields_hold_the_documented_defaults():
+    """A result built from the two required fields holds the spec's defaults."""
+    result = FingerprintResult(type="ja4t", fingerprint="64240_2-4-8-1-1-3-3_1460_8")
+    assert result.raw is None
+    assert result.raw_original_order is None
+    assert result.src_ip == ""
+    assert result.src_port == 0
+    assert result.dst_ip == ""
+    assert result.dst_port == 0
+    assert result.timestamp is None
+
+
+def test_two_results_that_hold_the_same_fields_are_equal():
+    """The dataclass compares by value, so a test can assert on a whole result."""
+    other = dataclasses.replace(SAMPLE)
+    assert other == SAMPLE
+    assert other != dataclasses.replace(SAMPLE, fingerprint="other")
+
+
+def test_a_result_is_hashable():
+    """The result is frozen, so a caller counts results with a set."""
+    assert len({SAMPLE, dataclasses.replace(SAMPLE)}) == 1


### PR DESCRIPTION
Closes nothing on its own. Part of #15. Implements #44.

## What this adds

`ja4plus/types.py` holds `FingerprintResult`, a frozen dataclass with the nine fields
the `### Result` table of `docs/specs/spec.md` lists. `ja4plus` exports the name.

The field names are the snake-case form of the `FingerprintResult` struct of the Go
port, under parity rule 2. The field that names the method is `type` and not `method`,
because the port calls it `Type` and the dictionary of version 0.6.0 already uses that
key.

Item access reads a field by name and emits a `DeprecationWarning` that names the
attribute form, so code written against the dictionary keeps working for one major
version. The access covers reading only.

## Why

Version 1.0.0 promises that the interface does not change again before version 2.0.0.
FR-typed-api-1, FR-typed-api-2, FR-typed-api-5 and FR-typed-api-6 of
`docs/specs/features/04-typed-api.md` state this part of the promise.

## What stays out

`ja4plus/processor.py` still returns dictionaries. #45 changes that. No file under
`ja4plus/fingerprinters/` moved and no fingerprint value changed.

`ja4plus/__init__.py` still declares no `__all__` and the package ships no `py.typed`
marker. #47 owns both.

## How this is tested

The tests came first. Commit 546baa8 adds `tests/test_types.py` and the suite fails
there with `ModuleNotFoundError: No module named 'ja4plus.types'`. Commit 73205e7 adds
the module.

`tests/test_types.py` holds 15 cases. One case reads the `### Result` table of
`docs/specs/spec.md` at run time and compares the nine names against
`dataclasses.fields(FingerprintResult)`, in order. A field the spec adds fails that
case until the dataclass carries it.

The two `KeyError` cases run under `warnings.simplefilter("error", DeprecationWarning)`.
A `__getitem__` that warned before it tested the key would fail them.

## Gate results

| Gate | Result |
|---|---|
| `pytest tests/ -m "not spec_validation"` | 1656 passed, 8 xfailed, 93 subtests passed |
| `pytest tests/ -m spec_validation` | 1477 passed, 143 skipped, 137 xfailed |
| `ruff check ja4plus/ tests/` | All checks passed |
| `ruff format --check ja4plus/ tests/` | 135 files already formatted |
| `mypy ja4plus/` | no issues found in 28 source files |

Coverage of `ja4plus/types.py` is 100%, 24 statements, 0 missed. No coverage fell:
this branch adds a new module and changes one import line.

`mypy --strict --follow-imports=silent ja4plus/types.py` also reports no issue, so the
new module carries no work forward to #47.

## Documentation

`docs/api_reference.md` gains a `## Result type` section with the field table, the
deprecated item access, and the note that the processor still returns dictionaries.
`CHANGELOG.md` gains an `Added` entry under `[Unreleased]`.

## Verified against

https://github.com/Crank-Git/ja4plus-go/blob/master/types.go (`FingerprintResult`
struct, retrieved 2026-08-06). The field list and the `Type` name come from there under
parity rule 2.

## Review

I reviewed the diff myself with one Sonnet child agent on the correctness, test-quality,
writing-standard and scope lenses. It returned and it reported no defect. Its one
observation is that `ja4plus/__init__.py` still holds no `__all__`, which #47 owns.
