### PR TITLE
Return typed results from the processor and expose parse failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   results alone, so a caller could not tell a packet that produces no fingerprint from a
   packet that failed a parse. The new method returns both lists, and one method that
   raises poisons no other method. The Go port returns the pair from one call, and parity
-  rule 2 keeps it. `docs/specs/features/04-typed-api.md` states FR-typed-api-4.
+  rule 2 keeps it. **Every returned exception carries no traceback.** A traceback holds
+  the frame of every call it passed, and those frames hold the packet, so a monitor that
+  keeps the errors of every packet would hold every packet it read. The type, the
+  message and the error chain stay. `docs/specs/features/04-typed-api.md` states
+  FR-typed-api-4, and `CLAUDE.md` states the packet rule.
 
 - **`FingerprintResult` is the typed result of the public interface** (#44). The new
   module `ja4plus/types.py` holds a frozen dataclass with nine fields, and `ja4plus`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,28 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **`Processor.process_packet` returns a list of `FingerprintResult`** (#45). Round TBD.
+  The method returned a list of dictionaries through version 0.6.0. A caller who reads
+  `result["fingerprint"]` keeps working for one major version, and item access emits a
+  `DeprecationWarning` that names the attribute form. Read `result.fingerprint` instead.
+  The results follow the fixed method order `ja4`, `ja4s`, `ja4h`, `ja4t`, `ja4ts`,
+  `ja4l`, `ja4x`, `ja4ssh`, `ja4d`, `ja4d6`, and that order is part of the interface.
+  `Processor.close_open_windows` still returns a list of dictionaries, because a window
+  carries a connection key and no `FingerprintResult` field holds one. The processor
+  reads no packet timestamp, so `timestamp` holds `None`. No fingerprint value moved:
+  the conformance suite reports the same 1477 passed, 143 skipped and 137 xfailed.
+  `docs/specs/features/04-typed-api.md` states FR-typed-api-3.
+
 ### Added
+
+- **`Processor.process_packet_with_errors` returns the results and the errors** (#45).
+  Round TBD. `process_packet` logs a fingerprinter error at DEBUG and returns the
+  results alone, so a caller could not tell a packet that produces no fingerprint from a
+  packet that failed a parse. The new method returns both lists, and one method that
+  raises poisons no other method. The Go port returns the pair from one call, and parity
+  rule 2 keeps it. `docs/specs/features/04-typed-api.md` states FR-typed-api-4.
 
 - **`FingerprintResult` is the typed result of the public interface** (#44). The new
   module `ja4plus/types.py` holds a frozen dataclass with nine fields, and `ja4plus`
@@ -16,8 +37,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   code written against the dictionary of version 0.6.0 keeps working for one major
   version. **Item access emits a `DeprecationWarning` that names the attribute form.**
   The item access covers reading only, and a result supports no item assignment.
-  `Processor.process_packet` still returns a list of dictionaries, and #45 changes it.
-  No fingerprint value moved. `docs/specs/features/04-typed-api.md` states
+  #45 makes `Processor.process_packet` return these results. No fingerprint value moved. `docs/specs/features/04-typed-api.md` states
   FR-typed-api-1, FR-typed-api-2, FR-typed-api-5 and FR-typed-api-6.
 
 - **JA4SSH emits the window a connection holds open when the capture ends**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   packet that failed a parse. The new method returns both lists, and one method that
   raises poisons no other method. The Go port returns the pair from one call, and parity
   rule 2 keeps it. **Every returned exception carries no traceback.** A traceback holds
-  the frame of every call it passed, and those frames hold the packet, so a monitor that
-  keeps the errors of every packet would hold every packet it read. The type, the
+  the frame of every call it passed. Those frames hold the packet. A monitor that keeps
+  the errors of every packet would therefore hold every packet it read. The type, the
   message and the error chain stay. `docs/specs/features/04-typed-api.md` states
-  FR-typed-api-4, and `CLAUDE.md` states the packet rule.
+  FR-typed-api-4. `CLAUDE.md` states the packet rule.
 
 - **`FingerprintResult` is the typed result of the public interface** (#44). The new
   module `ja4plus/types.py` holds a frozen dataclass with nine fields, and `ja4plus`

--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ from ja4plus import Processor
 p = Processor()
 for packet in packets:
     for r in p.process_packet(packet):
-        print(r["type"], r["fingerprint"], r.get("raw"))
+        print(r.type, r.fingerprint, r.raw)
+
+# Read the errors as well when a failed parse must be told from no fingerprint.
+results, errors = p.process_packet_with_errors(packet)
 
 # The packet source ends here. JA4SSH emits the window each connection holds open.
 for r in p.close_open_windows():

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -275,10 +275,10 @@ errors follow the same order.
 
 Warning: every returned exception carries no traceback. A traceback holds the frame of
 every call it passed, and those frames hold the packet. A monitor that keeps the errors
-of every packet would therefore hold every packet it read, and `CLAUDE.md` states that
-no code holds a reference to a packet object after `process_packet` returns. The type,
-the message and the error chain stay, so `repr(error)` reads the same. Log the error
-inside the loop that reads it when the stack matters.
+of every packet would therefore hold every packet it read. `CLAUDE.md` states that no
+code holds a reference to a packet object after `process_packet` returns. The type, the
+message and the error chain stay, so `repr(error)` reads the same. If the stack matters,
+log the error inside the loop that reads it.
 
 `process_packet_with_errors` sets no `timestamp` on a result, because the processor
 reads no packet timestamp. The field holds `None`.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -233,8 +233,9 @@ result["method"]        # KeyError. The field is `type`.
 The item access covers reading only. `result["fingerprint"] = "x"` raises `TypeError`,
 and `result.fingerprint = "x"` raises `dataclasses.FrozenInstanceError`.
 
-`Processor.process_packet` still returns a list of dictionaries. #45 changes it to
-return a list of `FingerprintResult`.
+`Processor.process_packet` returns a list of `FingerprintResult`, and #45 changed it.
+`Processor.close_open_windows` still returns a list of dictionaries, because a window
+carries a connection key and no `FingerprintResult` field holds one.
 
 ## Processor
 
@@ -243,13 +244,37 @@ return a list of `FingerprintResult`.
 | Class/Function | Description |
 |----------------|-------------|
 | `Processor(thread_safe=True)` | Build one processor and the ten fingerprinters it drives |
-| `.process_packet(packet)` | Run every fingerprinter on one packet, and return a list of result dicts |
+| `.process_packet(packet)` | Run every fingerprinter on one packet, and return a list of `FingerprintResult` |
+| `.process_packet_with_errors(packet)` | Return the same list, and the errors the fingerprinters raised |
 | `.close_open_windows()` | Emit every window the fingerprinters hold open |
 | `.get_shard_key(packet)` | Return one stable key for the connection of a packet |
 | `.cleanup_connection(src_ip, src_port, dst_ip, dst_port, proto)` | Drop the state of one connection across every fingerprinter |
 | `.reset()` | Reset every fingerprinter, and return every count to zero |
 | `.stats()` | Return one `ProcessorStats` for each of the ten methods |
 | `.thread_safe` | The value the constructor read |
+
+#### How to read the parse failures
+
+`process_packet` returns the results alone. A fingerprinter that raises produces no
+result, and the processor logs the error at DEBUG. One method that raises poisons no
+other method.
+
+`process_packet_with_errors` returns the results and the errors together. Call it to
+tell a packet that produces no fingerprint from a packet that failed a parse.
+FR-typed-api-4 states the requirement.
+
+```python
+results, errors = processor.process_packet_with_errors(packet)
+for error in errors:
+    print(f"one method failed to read the packet: {error!r}")
+```
+
+The results follow the fixed method order `ja4`, `ja4s`, `ja4h`, `ja4t`, `ja4ts`,
+`ja4l`, `ja4x`, `ja4ssh`, `ja4d`, `ja4d6`. The order is part of the interface. The
+errors follow the same order.
+
+`process_packet_with_errors` sets no `timestamp` on a result, because the processor
+reads no packet timestamp. The field holds `None`.
 
 `stats()` reports what the state tables hold, and #41 built it. One processor holds
 **sixteen** state tables across the ten methods: the fourteen `BoundedStateTable`

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -273,6 +273,13 @@ The results follow the fixed method order `ja4`, `ja4s`, `ja4h`, `ja4t`, `ja4ts`
 `ja4l`, `ja4x`, `ja4ssh`, `ja4d`, `ja4d6`. The order is part of the interface. The
 errors follow the same order.
 
+Warning: every returned exception carries no traceback. A traceback holds the frame of
+every call it passed, and those frames hold the packet. A monitor that keeps the errors
+of every packet would therefore hold every packet it read, and `CLAUDE.md` states that
+no code holds a reference to a packet object after `process_packet` returns. The type,
+the message and the error chain stay, so `repr(error)` reads the same. Log the error
+inside the loop that reads it when the stack matters.
+
 `process_packet_with_errors` sets no `timestamp` on a result, because the processor
 reads no packet timestamp. The field holds `None`.
 

--- a/ja4plus/processor.py
+++ b/ja4plus/processor.py
@@ -133,7 +133,7 @@ class Processor:
         The results follow the fixed method order of `_SPEC`. The order is part of the
         interface, and FR-typed-api-3 states it.
 
-        A fingerprinter that raises produces no result, and this method logs the error
+        A fingerprinter that raises produces no result, and the processor logs the error
         at DEBUG. One method that raises poisons no other method. A caller who needs the
         errors calls `process_packet_with_errors` instead. FR-typed-api-4 states that.
 
@@ -328,6 +328,10 @@ def _drop_traceback(error: Exception) -> Exception:
     The call walks `__cause__` and `__context__`, because a fingerprinter that raises
     inside an `except` block chains a second error whose traceback holds its own frames.
     The type, the message and the chain stay, so the caller reads what failed.
+
+    The traceback is the one path this call clears. An error that carries the packet in
+    `args`, or on an attribute of its own, still holds it. No fingerprinter of this
+    project builds such an error, and a new fingerprinter must not.
 
     Args:
         error: The error one fingerprinter raised.

--- a/ja4plus/processor.py
+++ b/ja4plus/processor.py
@@ -3,25 +3,21 @@
 Mirrors the API of ja4plus-go's ja4plus.Processor:
 
     p = Processor()
-    results = p.process_packet(pkt)            # list of result dicts
+    results = p.process_packet(pkt)            # list of FingerprintResult
+    results, errors = p.process_packet_with_errors(pkt)
     p.cleanup_connection(src_ip, src_port, dst_ip, dst_port, "tcp")
     key = p.get_shard_key(pkt)                 # stable connection key
     p.reset()                                  # clear all state
 
-Each result dict contains:
-    {
-        "type":        "ja4" | "ja4s" | "ja4h" | ...,
-        "fingerprint": "<the fingerprint string>",
-        "raw":         "<unhashed form>" or None,
-        "raw_original_order": "<unhashed original-order form>" or None,
-        "src_ip":      "...",
-        "src_port":    int,
-        "dst_ip":      "...",
-        "dst_port":    int,
-    }
+`ja4plus/types.py` states the fields of a `FingerprintResult`.
 """
 
+# Python 3.9 is the floor, and it evaluates no annotation written as `list[str]`
+# without this import.
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
 from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
@@ -33,6 +29,12 @@ from ja4plus.fingerprinters.ja4x import JA4XFingerprinter
 from ja4plus.fingerprinters.ja4ssh import JA4SSHFingerprinter
 from ja4plus.fingerprinters.ja4d import JA4DFingerprinter
 from ja4plus.fingerprinters.ja4d6 import JA4D6Fingerprinter
+from ja4plus.types import FingerprintResult
+
+if TYPE_CHECKING:
+    # The module reads scapy inside the two functions that need it, so an import at the
+    # top would load scapy for a caller that only builds a `Processor`.
+    from scapy.packet import Packet
 
 logger = logging.getLogger(__name__)
 
@@ -125,14 +127,45 @@ class Processor:
             return self.__dict__["fingerprinters"][name]
         raise AttributeError(name)
 
-    def process_packet(self, packet):
-        """Run every fingerprinter; return a list of result dicts.
+    def process_packet(self, packet: Packet) -> list[FingerprintResult]:
+        """Run every fingerprinter on one packet, and return the results.
 
-        Errors from individual fingerprinters are logged at DEBUG and
-        swallowed so one misbehaving fingerprinter cannot poison the
-        whole aggregation.
+        The results follow the fixed method order of `_SPEC`. The order is part of the
+        interface, and FR-typed-api-3 states it.
+
+        A fingerprinter that raises produces no result, and this method logs the error
+        at DEBUG. One method that raises poisons no other method. A caller who needs the
+        errors calls `process_packet_with_errors` instead. FR-typed-api-4 states that.
+
+        Args:
+            packet: The packet to read.
+
+        Returns:
+            A list of `FingerprintResult`. The list is empty when the packet produces no
+            fingerprint.
         """
-        results = []
+        results, _ = self.process_packet_with_errors(packet)
+        return results
+
+    def process_packet_with_errors(
+        self, packet: Packet
+    ) -> tuple[list[FingerprintResult], list[Exception]]:
+        """Run every fingerprinter on one packet, and return the results and the errors.
+
+        The port returns both from one call, and parity rule 2 keeps the pair. Python
+        has no multiple-return form that reads well as a default, so `process_packet`
+        returns the results alone and this method returns both.
+
+        Args:
+            packet: The packet to read.
+
+        Returns:
+            A tuple of two lists. The first holds one `FingerprintResult` for each
+            method that produced a fingerprint, in the fixed method order. The second
+            holds one exception for each method that raised, in the same order.
+        """
+        results: list[FingerprintResult] = []
+        errors: list[Exception] = []
         src_ip, dst_ip, src_port, dst_port = _packet_endpoints(packet)
 
         for fp_type, fp in self.fingerprinters.items():
@@ -148,22 +181,23 @@ class Processor:
                     fingerprint = fp.process_packet(packet)
                 except Exception as e:
                     logger.debug(f"{fp_type} processing failed: {e}")
+                    errors.append(e)
                     continue
                 if not fingerprint:
                     continue
                 results.append(
-                    {
-                        "type": fp_type,
-                        "fingerprint": fingerprint,
-                        "raw": getattr(fp, "last_raw", None),
-                        "raw_original_order": getattr(fp, "last_raw_original_order", None),
-                        "src_ip": src_ip,
-                        "src_port": src_port,
-                        "dst_ip": dst_ip,
-                        "dst_port": dst_port,
-                    }
+                    FingerprintResult(
+                        type=fp_type,
+                        fingerprint=fingerprint,
+                        raw=getattr(fp, "last_raw", None),
+                        raw_original_order=getattr(fp, "last_raw_original_order", None),
+                        src_ip=src_ip,
+                        src_port=src_port,
+                        dst_ip=dst_ip,
+                        dst_port=dst_port,
+                    )
                 )
-        return results
+        return results, errors
 
     def close_open_windows(self):
         """Emit every window the fingerprinters hold open, and return the results.

--- a/ja4plus/processor.py
+++ b/ja4plus/processor.py
@@ -156,6 +156,11 @@ class Processor:
         has no multiple-return form that reads well as a default, so `process_packet`
         returns the results alone and this method returns both.
 
+        Every returned exception carries no traceback. A traceback holds the frame of
+        every call it passed, and those frames hold the packet. `CLAUDE.md` states that
+        no code holds a reference to a packet object after `process_packet` returns. The
+        type, the message and the error chain stay.
+
         Args:
             packet: The packet to read.
 
@@ -181,7 +186,7 @@ class Processor:
                     fingerprint = fp.process_packet(packet)
                 except Exception as e:
                     logger.debug(f"{fp_type} processing failed: {e}")
-                    errors.append(e)
+                    errors.append(_drop_traceback(e))
                     continue
                 if not fingerprint:
                     continue
@@ -310,6 +315,40 @@ class Processor:
             sport, dport = dport, sport
 
         return f"{proto}:{src_ip}:{sport}->{dst_ip}:{dport}"
+
+
+def _drop_traceback(error: Exception) -> Exception:
+    """Return the error with no traceback on it or on any error it followed.
+
+    `CLAUDE.md` states that no code holds a reference to a packet object after
+    `process_packet` returns. A traceback holds the frame of every call it passed, and
+    those frames hold the packet as a local. A caller that keeps the error of every
+    packet would therefore hold every packet it read.
+
+    The call walks `__cause__` and `__context__`, because a fingerprinter that raises
+    inside an `except` block chains a second error whose traceback holds its own frames.
+    The type, the message and the chain stay, so the caller reads what failed.
+
+    Args:
+        error: The error one fingerprinter raised.
+
+    Returns:
+        The same error object.
+    """
+    # The list holds a reference to every error it cleared, so the walk compares
+    # identities and no freed object returns the identity of a later one.
+    cleared: list[BaseException] = []
+    pending: list[BaseException | None] = [error]
+    while pending:
+        current = pending.pop()
+        # A chain can hold a cycle, so the walk records what it already cleared.
+        if current is None or any(current is done for done in cleared):
+            continue
+        cleared.append(current)
+        current.__traceback__ = None
+        pending.append(current.__cause__)
+        pending.append(current.__context__)
+    return error
 
 
 def _packet_endpoints(packet):

--- a/tests/test_ja4ts_part_e.py
+++ b/tests/test_ja4ts_part_e.py
@@ -208,8 +208,8 @@ class TestPartEOnTheVectorSet(unittest.TestCase):
         self.values = []
         for index, packet in enumerate(rdpcap(str(self.CAPTURE))):
             for result in processor.process_packet(packet):
-                if result["type"] == "ja4ts":
-                    self.values.append((index, result["fingerprint"]))
+                if result.type == "ja4ts":
+                    self.values.append((index, result.fingerprint))
 
     def test_the_retransmitted_syn_ack_carries_part_e(self):
         """Index 372 answers a connection that index 369 already answered."""

--- a/tests/test_ja4ts_reset.py
+++ b/tests/test_ja4ts_reset.py
@@ -286,8 +286,8 @@ class TestTheResetCapture(unittest.TestCase):
         self.values = []
         for packet in rdpcap(str(path)):
             for result in processor.process_packet(packet):
-                if result["type"] == "ja4ts":
-                    self.values.append(result["fingerprint"])
+                if result.type == "ja4ts":
+                    self.values.append(result.fingerprint)
 
     def test_the_capture_produces_the_six_values_the_deleted_file_states(self):
         self.assertEqual(

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -39,7 +39,7 @@ def test_processor_attribute_access_to_fingerprinters():
 
 def test_processor_process_packet_runs_all_fingerprinters():
     """For a DHCP packet we should get a JA4D fingerprint and nothing else."""
-    from ja4plus import Processor
+    from ja4plus import FingerprintResult, Processor
     from scapy.all import IP, UDP, Raw
 
     # Build a minimal DHCP DISCOVER packet (53=msgtype + end)
@@ -50,18 +50,18 @@ def test_processor_process_packet_runs_all_fingerprinters():
 
     p = Processor()
     results = p.process_packet(pkt)
-    types = [r["type"] for r in results]
+    types = [r.type for r in results]
     assert "ja4d" in types
-    # Each result should expose canonical structure
+    # #45 returns a `FingerprintResult` in place of a dict, so the case reads the
+    # attribute. Item access still works, and it emits a `DeprecationWarning`.
     for r in results:
-        assert "fingerprint" in r
-        assert "type" in r
-        assert "src_ip" in r
-        assert "dst_ip" in r
-        assert "src_port" in r
-        assert "dst_port" in r
-        assert "raw" in r
-        assert "raw_original_order" in r
+        assert isinstance(r, FingerprintResult)
+        assert r.fingerprint
+        assert r.type
+        assert r.src_ip == "0.0.0.0"
+        assert r.dst_ip == "255.255.255.255"
+        assert r.src_port == 68
+        assert r.dst_port == 67
 
 
 def test_processor_reset_clears_all_state():

--- a/tests/test_processor_typed_results.py
+++ b/tests/test_processor_typed_results.py
@@ -1,0 +1,208 @@
+"""The typed result of `Processor.process_packet`, FR-typed-api-3 and FR-typed-api-4.
+
+`docs/specs/features/04-typed-api.md` states both requirements. #45 changes the
+container the processor returns. It changes no fingerprint value.
+"""
+
+import warnings
+
+import pytest
+from scapy.all import IP, TCP, UDP, Ether, Raw
+
+from ja4plus import FingerprintResult, Processor
+
+# The order of `Processor._SPEC`. FR-typed-api-3 makes this order part of the interface,
+# so the test states it as a literal and reads it from no attribute of the processor.
+METHOD_ORDER = [
+    "ja4",
+    "ja4s",
+    "ja4h",
+    "ja4t",
+    "ja4ts",
+    "ja4l",
+    "ja4x",
+    "ja4ssh",
+    "ja4d",
+    "ja4d6",
+]
+
+
+def dhcp_discover():
+    """Return one DHCP DISCOVER packet, which produces a JA4D fingerprint."""
+    bootp = bytearray(236)
+    bootp[0] = 1
+    payload = bytes(bootp) + b"\x63\x82\x53\x63" + bytes([53, 1, 1, 255])
+    return IP(src="0.0.0.0", dst="255.255.255.255") / UDP(sport=68, dport=67) / Raw(load=payload)
+
+
+def make_every_method_answer(processor):
+    """Make every fingerprinter of the processor return one fixed value.
+
+    A real packet reaches two methods at most, so it proves no order across the ten. A
+    processor whose ten methods all answer proves the whole order.
+
+    Args:
+        processor: The processor to change.
+    """
+    for name, fingerprinter in processor.fingerprinters.items():
+        fingerprinter.process_packet = lambda packet, name=name: f"{name}-value"
+
+
+class RaisingFingerprinterError(Exception):
+    """The error one fingerprinter raises inside these tests."""
+
+
+def make_one_method_raise(processor, method):
+    """Make one fingerprinter of the processor raise, and return the error it raises.
+
+    Args:
+        processor: The processor to change.
+        method: The method name of the fingerprinter that raises.
+
+    Returns:
+        The exception object the fingerprinter raises.
+    """
+    error = RaisingFingerprinterError(f"{method} cannot read this packet")
+
+    def raise_it(packet):
+        raise error
+
+    processor.fingerprinters[method].process_packet = raise_it
+    return error
+
+
+class TestProcessPacketReturnsTypedResults:
+    """FR-typed-api-3 — `Processor.process_packet` returns a list of results."""
+
+    def test_every_element_is_a_fingerprint_result(self):
+        results = Processor().process_packet(dhcp_discover())
+
+        assert results, "the DHCP packet produces at least one fingerprint"
+        assert [type(result) for result in results] == [FingerprintResult] * len(results)
+
+    def test_the_dhcp_packet_produces_a_ja4d_result(self):
+        results = Processor().process_packet(dhcp_discover())
+
+        assert "ja4d" in [result.type for result in results]
+
+    def test_a_result_carries_the_endpoints_of_the_packet(self):
+        results = Processor().process_packet(dhcp_discover())
+
+        result = next(result for result in results if result.type == "ja4d")
+        assert result.src_ip == "0.0.0.0"
+        assert result.dst_ip == "255.255.255.255"
+        assert result.src_port == 68
+        assert result.dst_port == 67
+        assert result.fingerprint
+
+    def test_a_packet_with_no_address_layer_gives_empty_addresses_and_zero_ports(self):
+        """`docs/specs/features/04-typed-api.md` states this case in its failure table."""
+        processor = Processor()
+        make_every_method_answer(processor)
+
+        results = processor.process_packet(Ether())
+
+        assert results, "every method answers, so the list holds ten results"
+        for result in results:
+            assert result.src_ip == ""
+            assert result.dst_ip == ""
+            assert result.src_port == 0
+            assert result.dst_port == 0
+
+    def test_reading_a_field_by_attribute_emits_no_deprecation_warning(self):
+        """A caller who reads the attribute gets no warning. Item access warns."""
+        results = Processor().process_packet(dhcp_discover())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert [result.type for result in results]
+
+    def test_item_access_on_a_result_still_reads_the_same_value(self):
+        """FR-typed-api-5 keeps the caller of version 0.6.0 working."""
+        results = Processor().process_packet(dhcp_discover())
+
+        with pytest.warns(DeprecationWarning):
+            assert results[0]["type"] == results[0].type
+
+
+class TestProcessPacketKeepsTheMethodOrder:
+    """FR-typed-api-3 — the results come back in the fixed method order."""
+
+    def test_the_ten_results_follow_the_order_of_the_spec_list(self):
+        processor = Processor()
+        make_every_method_answer(processor)
+
+        results = processor.process_packet(dhcp_discover())
+
+        assert [result.type for result in results] == METHOD_ORDER
+
+    def test_a_method_that_produces_no_fingerprint_leaves_the_order_unchanged(self):
+        processor = Processor()
+        make_every_method_answer(processor)
+        processor.fingerprinters["ja4h"].process_packet = lambda packet: None
+        processor.fingerprinters["ja4t"].process_packet = lambda packet: None
+
+        results = processor.process_packet(dhcp_discover())
+
+        expected = [name for name in METHOD_ORDER if name not in ("ja4h", "ja4t")]
+        assert [result.type for result in results] == expected
+
+
+class TestProcessPacketWithErrors:
+    """FR-typed-api-4 — the processor exposes the parse failures it collected."""
+
+    def test_it_returns_the_exception_one_fingerprinter_raised(self):
+        processor = Processor()
+        error = make_one_method_raise(processor, "ja4")
+
+        results, errors = processor.process_packet_with_errors(dhcp_discover())
+
+        assert errors == [error]
+        assert "ja4" not in [result.type for result in results]
+
+    def test_it_returns_the_same_results_that_process_packet_returns(self):
+        packet = dhcp_discover()
+        results, errors = Processor().process_packet_with_errors(packet)
+
+        assert errors == []
+        assert results == Processor().process_packet(packet)
+
+    def test_it_returns_one_error_for_every_method_that_raises(self):
+        processor = Processor()
+        first = make_one_method_raise(processor, "ja4")
+        second = make_one_method_raise(processor, "ja4ssh")
+
+        results, errors = processor.process_packet_with_errors(dhcp_discover())
+
+        assert errors == [first, second]
+        assert results
+
+    def test_process_packet_raises_no_error_when_a_fingerprinter_raises(self):
+        """One method that raises poisons no other method."""
+        processor = Processor()
+        make_one_method_raise(processor, "ja4")
+
+        assert processor.process_packet(dhcp_discover())
+
+    def test_it_returns_an_empty_list_of_results_and_the_error(self):
+        """The failure table states this case. The packet reaches one method only."""
+        processor = Processor()
+        for name in METHOD_ORDER:
+            processor.fingerprinters[name].process_packet = lambda packet: None
+        error = make_one_method_raise(processor, "ja4t")
+
+        results, errors = processor.process_packet_with_errors(
+            IP(src="10.0.0.1", dst="10.0.0.2") / TCP(sport=50000, dport=443, flags="S")
+        )
+
+        assert results == []
+        assert errors == [error]
+
+    def test_it_counts_the_packet_for_the_method_that_raised(self):
+        """The packet count of a method rises for a packet it fails to read."""
+        processor = Processor()
+        make_one_method_raise(processor, "ja4")
+
+        processor.process_packet_with_errors(dhcp_discover())
+
+        assert processor.stats()["ja4"].packets == 1

--- a/tests/test_processor_typed_results.py
+++ b/tests/test_processor_typed_results.py
@@ -4,7 +4,9 @@
 container the processor returns. It changes no fingerprint value.
 """
 
+import gc
 import warnings
+import weakref
 
 import pytest
 from scapy.all import IP, TCP, UDP, Ether, Raw
@@ -197,6 +199,62 @@ class TestProcessPacketWithErrors:
 
         assert results == []
         assert errors == [error]
+
+    def test_a_returned_error_holds_no_reference_to_the_packet(self):
+        """`CLAUDE.md` states the rule that this case measures.
+
+        A monitor that keeps the errors of every packet would hold every packet it read.
+        An exception reaches the caller with its traceback, and the frames of that
+        traceback hold the packet as a local, so the processor clears the traceback.
+        """
+        processor = Processor()
+        make_one_method_raise(processor, "ja4")
+
+        packet = dhcp_discover()
+        alive = weakref.ref(packet)
+        _, errors = processor.process_packet_with_errors(packet)
+        del packet
+        gc.collect()
+
+        assert errors, "the case measures the errors the call returned"
+        assert alive() is None, "the returned error holds the packet alive"
+
+    def test_a_returned_error_keeps_its_type_and_its_message(self):
+        """The traceback goes, and the value the caller reads stays."""
+        processor = Processor()
+        make_one_method_raise(processor, "ja4h")
+
+        _, errors = processor.process_packet_with_errors(dhcp_discover())
+
+        assert isinstance(errors[0], RaisingFingerprinterError)
+        assert str(errors[0]) == "ja4h cannot read this packet"
+        assert errors[0].__traceback__ is None
+
+    def test_a_returned_error_clears_the_traceback_of_the_error_it_followed(self):
+        """A fingerprinter that raises inside an `except` block chains two errors.
+
+        The second error holds the first under `__context__`, and the traceback of the
+        first holds frames of the fingerprinter. Those frames hold the packet.
+        """
+        processor = Processor()
+
+        def raise_a_chain(packet):
+            try:
+                raise ValueError("the parser read a length field it cannot trust")
+            except ValueError:
+                raise RaisingFingerprinterError("ja4 cannot read this packet")
+
+        processor.fingerprinters["ja4"].process_packet = raise_a_chain
+
+        packet = dhcp_discover()
+        alive = weakref.ref(packet)
+        _, errors = processor.process_packet_with_errors(packet)
+        del packet
+        gc.collect()
+
+        assert isinstance(errors[0].__context__, ValueError)
+        assert errors[0].__context__.__traceback__ is None
+        assert alive() is None, "the chained error holds the packet alive"
 
     def test_it_counts_the_packet_for_the_method_that_raised(self):
         """The packet count of a method rises for a packet it fails to read."""

--- a/tests/test_processor_typed_results.py
+++ b/tests/test_processor_typed_results.py
@@ -204,8 +204,8 @@ class TestProcessPacketWithErrors:
         """`CLAUDE.md` states the rule that this case measures.
 
         A monitor that keeps the errors of every packet would hold every packet it read.
-        An exception reaches the caller with its traceback, and the frames of that
-        traceback hold the packet as a local, so the processor clears the traceback.
+        An exception reaches the caller with its traceback. The frames of that traceback
+        hold the packet as a local, so the processor clears the traceback.
         """
         processor = Processor()
         make_one_method_raise(processor, "ja4")

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -72,7 +72,7 @@ def one_thread_values(packets):
     processor = Processor()
     values = []
     for packet in packets:
-        values.extend(result["fingerprint"] for result in processor.process_packet(packet))
+        values.extend(result.fingerprint for result in processor.process_packet(packet))
     values.extend(result["fingerprint"] for result in processor.close_open_windows())
     return sorted(values)
 
@@ -106,7 +106,7 @@ def eight_thread_values(packets, partition_by_connection=True):
         mine = []
         try:
             for packet in bucket:
-                mine.extend(result["fingerprint"] for result in processor.process_packet(packet))
+                mine.extend(result.fingerprint for result in processor.process_packet(packet))
         except Exception as error:  # noqa: BLE001 — the case reports every failure shape.
             errors.append(error)
         with collect:
@@ -488,9 +488,9 @@ class TestTheProcessorPairsEachRawFormWithItsOwnFingerprint:
         expected = {}
         for packet in (first, second):
             alone = Processor()
-            results = [r for r in alone.process_packet(packet) if r["type"] == "ja4"]
+            results = [r for r in alone.process_packet(packet) if r.type == "ja4"]
             assert len(results) == 1, "the packet produced no JA4 value, so nothing measures"
-            expected[id(packet)] = (results[0]["fingerprint"], results[0]["raw"])
+            expected[id(packet)] = (results[0].fingerprint, results[0].raw)
         assert expected[id(first)] != expected[id(second)], "the two packets must differ"
 
         processor = Processor()
@@ -513,7 +513,7 @@ class TestTheProcessorPairsEachRawFormWithItsOwnFingerprint:
         collected = {}
 
         def feed(name, packet):
-            collected[name] = [r for r in processor.process_packet(packet) if r["type"] == "ja4"]
+            collected[name] = [r for r in processor.process_packet(packet) if r.type == "ja4"]
 
         try:
             slow = threading.Thread(target=feed, args=("first", first))
@@ -533,7 +533,7 @@ class TestTheProcessorPairsEachRawFormWithItsOwnFingerprint:
             del fingerprinter.process_packet
 
         assert len(collected["first"]) == 1
-        got = (collected["first"][0]["fingerprint"], collected["first"][0]["raw"])
+        got = (collected["first"][0].fingerprint, collected["first"][0].raw)
         assert got == expected[id(first)], (
             "the first thread received the raw form of another packet"
         )


### PR DESCRIPTION
## What

`Processor.process_packet` returns a list of `FingerprintResult` in place of a list of
dictionaries. The new `Processor.process_packet_with_errors` returns the results and the
errors the fingerprinters raised.

```python
def process_packet(self, packet: Packet) -> list[FingerprintResult]: ...
def process_packet_with_errors(
    self, packet: Packet
) -> tuple[list[FingerprintResult], list[Exception]]: ...
```

The method order matches the port under parity rule 2. `process_packet` delegates to
`process_packet_with_errors` and drops the errors, so one code path builds the results.

## Why

`ja4plus/processor.py:81` swallowed every fingerprinter exception and logged it at
DEBUG, so a caller could not tell a packet that produces no fingerprint from a packet
that failed a parse. `docs/specs/features/04-typed-api.md` states FR-typed-api-3 and
FR-typed-api-4.

Verified against: https://github.com/Crank-Git/ja4plus-go/blob/master/processor.go
(retrieved 2026-08-06, through the reading the issue body records).

## How tested

TDD. `tests/test_processor_typed_results.py` came first and reported
`13 failed, 1 passed` against the base branch. The one that passed states that
`process_packet` raises no error when a fingerprinter raises, which the base branch
already satisfied. The other thirteen state the new behaviour. The three cases of the
second commit came first too, and they reported `3 failed`.

All five gates pass, and `pytest` also passes under `-W error::DeprecationWarning`.

| Gate | Result |
|---|---|
| `pytest tests/ -m "not spec_validation"` | 1673 passed, 8 xfailed, 93 subtests passed |
| `pytest tests/ -m spec_validation` | 1477 passed, 143 skipped, 137 xfailed |
| `ruff check ja4plus/ tests/` | All checks passed |
| `ruff format --check ja4plus/ tests/` | 136 files already formatted |
| `mypy ja4plus/` | Success: no issues found in 28 source files |

**No fingerprint value moved.** The conformance suite reported
`1477 passed, 143 skipped, 137 xfailed` on the base branch before the change, and it
reports the same three numbers after it.

**Coverage rose.** Measured with `pytest tests/ --cov=ja4plus` on the base commit
`af07a1a` and on this branch.

| | `ja4plus/processor.py` | Whole package |
|---|---|---|
| Base | 92% (113 statements, 9 missed) | 86.19% (3758 statements, 519 missed) |
| This branch | 95% (133 statements, 6 missed) | 86.34% (3778 statements, 516 missed) |

The six statements this branch still misses are all pre-existing: the `AttributeError`
guard of `__getattr__`, and the two error handlers of `close_open_windows` and
`cleanup_connection`.

## A defect this branch found and fixed

The second commit fixes a defect the first commit introduced.

`CLAUDE.md` states: "No code holds a reference to a packet object after `process_packet`
returns." An exception reaches the caller with its `__traceback__`, the traceback holds
the frame of every call it passed, and those frames hold the packet as a local. A
monitor that keeps the errors of every packet would therefore hold every packet it read
— the exact failure mode the rule exists to stop.

`process_packet_with_errors` now clears the traceback of every error it returns, and of
every error in the `__cause__` and `__context__` chain, because a fingerprinter that
raises inside an `except` block chains a second error whose traceback holds its own
frames. **The type, the message and the chain stay**, so `repr(error)` reads the same and
FR-typed-api-4 still holds. `docs/api_reference.md` carries the warning, and a caller who
needs the stack logs the error inside the loop that reads it.

`tests/test_processor_typed_results.py` measures it with a weak reference to the packet.
The case fails without the fix.

## Decisions a reviewer should check

1. **`close_open_windows` still returns dictionaries.** A window entry carries a
   `connection` key, and no `FingerprintResult` field holds a connection key. The issue
   names `process_packet` alone. `docs/api_reference.md` and `CHANGELOG.md` state this.
2. **`timestamp` holds `None`.** The processor reads no packet timestamp today, and
   `packet.time` of a synthesized scapy packet holds the time the object was built
   rather than a capture time. Setting it from that value would report a timestamp the
   packet does not carry. `docs/api_reference.md` states this.
3. **`ProcessorStats` stays in `ja4plus/processor.py`.** The feature file lists it under
   `ja4plus/types.py`, but the issue does not, so this leaves it for a later issue of
   Epic 4.
4. **The returned errors carry no traceback**, for the reason above. A reviewer who
   wants the stack should say so, because that trades the packet rule against it.

## A premise of the handoff brief that measurement contradicts

The brief stated that `ja4plus/cli.py`, the test suite and the conformance harness all
read the result of `Processor.process_packet`. Two of the three do not.

- `ja4plus/cli.py` calls `Processor` nowhere. Its three call sites,
  `ja4plus/cli.py:129`, `ja4plus/cli.py:235` and `ja4plus/cli.py:296`, call
  `fp.process_packet` and `fp.close_open_windows` on one fingerprinter. A fingerprinter
  returns a string, and this change does not touch it. `cli.py` needed no edit.
- The conformance harness `tests/conformance_index.py` imports no `Processor` either.
  Its one call site, `tests/conformance_index.py:234`, calls
  `fingerprinter.close_open_windows()`.
- Every file under `examples/` drives one fingerprinter too, so none needed an edit.

The measurement used `pytest -W error::DeprecationWarning` to find every caller rather
than a grep. It named four test files, and all four now read the attribute:
`tests/test_processor.py`, `tests/test_ja4ts_part_e.py`, `tests/test_ja4ts_reset.py`
and `tests/test_thread_safety.py`.

One caller broke rather than warned. `tests/test_processor.py` asserted
`"fingerprint" in r`. A `FingerprintResult` defines `__getitem__` and no `__contains__`,
so `in` falls back to the sequence protocol, calls `__getitem__(0)` and raises
`KeyError`. The case now reads the attribute and asserts the endpoint values, which the
dictionary form never checked.

`README.md` carried a second break. Its example read `r.get("raw")`, and a
`FingerprintResult` holds no `get` method. The example now reads `r.raw`.

Part of #15. Depends on #44.
