### PR TITLE
Ship the py.typed marker and declare the public interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The package ships the `py.typed` marker and declares `__all__`** (#47). Round TBD.
+  The new file `ja4plus/py.typed` follows PEP 561, and `pyproject.toml` ships it as
+  package data. A caller who runs `mypy --strict` against their own code now resolves
+  the annotations of `ja4plus`: `unzip -l dist/*.whl` lists `ja4plus/py.typed`, and a
+  consumer installed from that wheel reads `result.fingerprint` as `str`.
+  **`ja4plus.__all__` names the 25 promised names**, and version 1.0.0 keeps each one
+  until version 2.0.0. A name absent from `__all__` is not promised. The list holds the
+  typed result, the processor, the ten fingerprinter classes, the ten one-shot
+  functions, the two certificate helpers and `__version__`. `bind_loopback_ipv6`,
+  `register_tunnel_dissectors`, `__author__` and `__license__` stay out: the package
+  calls the first two at import time, and the last two describe the project and not the
+  interface.
+  **`ProcessorStats` is public at `ja4plus.processor.ProcessorStats`**, because
+  `Processor.stats` returns `dict[str, ProcessorStats]`; the class moves nowhere.
+  `docs/specs/features/04-typed-api.md` states FR-typed-api-9, FR-typed-api-10,
+  FR-typed-api-12 and FR-typed-api-13.
+
 - **`Processor.process_packet_with_errors` returns the results and the errors** (#45).
   Round TBD. `process_packet` logs a fingerprinter error at DEBUG and returns the
   results alone, so a caller could not tell a packet that produces no fingerprint from a

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,5 +1,49 @@
 # API Reference
 
+## Public interface
+
+`ja4plus.__all__` names the interface the project promises. Version 1.0.0 promises that
+a name in that list stays until version 2.0.0. A name absent from the list is not
+promised, and the project may change it in any release.
+
+```python
+import ja4plus
+
+ja4plus.__all__   # the 25 promised names
+```
+
+| Group | Names |
+|---|---|
+| Result and processor | `FingerprintResult`, `Processor` |
+| Fingerprinter classes | `JA4Fingerprinter`, `JA4SFingerprinter`, `JA4HFingerprinter`, `JA4LFingerprinter`, `JA4XFingerprinter`, `JA4SSHFingerprinter`, `JA4TFingerprinter`, `JA4TSFingerprinter`, `JA4DFingerprinter`, `JA4D6Fingerprinter` |
+| One-shot functions | `generate_ja4`, `generate_ja4s`, `generate_ja4h`, `generate_ja4l`, `generate_ja4x`, `generate_ja4ssh`, `generate_ja4t`, `generate_ja4ts`, `generate_ja4d`, `generate_ja4d6` |
+| Certificate helpers | `compute_ja4x_from_der`, `compute_ja4x_from_pem` |
+| Version | `__version__` |
+
+A module states its own public names in its own `__all__`. `ja4plus.types` names
+`FingerprintResult`, and `ja4plus.processor` names `Processor` and `ProcessorStats`.
+`Processor.stats` returns `dict[str, ProcessorStats]`, so a caller who annotates the
+report imports the class from `ja4plus.processor`.
+
+Four names of the top-level namespace are not promised. `bind_loopback_ipv6` and
+`register_tunnel_dissectors` are the two calls the package makes at import time, so a
+caller needs neither name. `__author__` and `__license__` describe the project and not
+the interface, and the distribution metadata carries the license.
+
+### Type checking
+
+The package ships a `py.typed` marker, and the wheel carries it. A caller who runs
+`mypy --strict` against their own code therefore resolves the annotations of `ja4plus`.
+
+```python
+from ja4plus import FingerprintResult
+
+result = FingerprintResult(type="ja4", fingerprint="t13d1516h2_8daaf6152771_b0da82dd1658")
+name: str = result.fingerprint   # mypy reads `str`
+```
+
+Verified against: https://peps.python.org/pep-0561/ (retrieved 2026-08-08).
+
 ## Fingerprinter Classes
 
 All fingerprinters inherit from `BaseFingerprinter` and share a common interface.

--- a/ja4plus/__init__.py
+++ b/ja4plus/__init__.py
@@ -89,3 +89,48 @@ def compute_ja4x_from_pem(cert_pem_bytes: bytes | str) -> str | None:
 __version__ = "0.6.0"
 __author__ = "ja4plus contributors"
 __license__ = "BSD-3-Clause"
+
+# FR-typed-api-12 and FR-typed-api-13 of `docs/specs/features/04-typed-api.md` make this
+# list the interface version 1.0.0 promises. A name here stays until version 2.0.0, and a
+# name absent from here is not promised. The list therefore names what a caller may
+# import from `ja4plus`, and a module states its own public names in its own `__all__`.
+#
+# `bind_loopback_ipv6` and `register_tunnel_dissectors` stay out. This module calls both
+# at import time, so a caller needs neither name.
+#
+# `__author__` and `__license__` stay out. Both describe the project and not the
+# interface, and the distribution metadata carries the license. `__version__` stays in,
+# because `ja4plus --version` reads it and a caller reads it to test compatibility.
+__all__ = [
+    # The typed result and the aggregator that returns it.
+    "FingerprintResult",
+    "Processor",
+    # One fingerprinter class for each of the ten methods. The Go port exports the same
+    # ten types, under parity rule 2.
+    "JA4Fingerprinter",
+    "JA4SFingerprinter",
+    "JA4HFingerprinter",
+    "JA4LFingerprinter",
+    "JA4XFingerprinter",
+    "JA4SSHFingerprinter",
+    "JA4TFingerprinter",
+    "JA4TSFingerprinter",
+    "JA4DFingerprinter",
+    "JA4D6Fingerprinter",
+    # The one-shot form of each method. The port names these `ComputeJA4` and so on.
+    "generate_ja4",
+    "generate_ja4s",
+    "generate_ja4h",
+    "generate_ja4l",
+    "generate_ja4x",
+    "generate_ja4ssh",
+    "generate_ja4t",
+    "generate_ja4ts",
+    "generate_ja4d",
+    "generate_ja4d6",
+    # The certificate helpers. The port names these `ComputeJA4XFromDER` and
+    # `ComputeJA4XFromPEM`.
+    "compute_ja4x_from_der",
+    "compute_ja4x_from_pem",
+    "__version__",
+]

--- a/ja4plus/processor.py
+++ b/ja4plus/processor.py
@@ -40,6 +40,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# `Processor.stats` returns `dict[str, ProcessorStats]`, so a caller who annotates the
+# report names the class. Both names are therefore public, and #47 states the reading.
+# `ja4plus/__init__.py` exports `Processor` alone, so `ProcessorStats` is public at
+# `ja4plus.processor.ProcessorStats`, which is the path `docs/api_reference.md` documents.
+__all__ = ["Processor", "ProcessorStats"]
+
 
 class ProcessorStats:
     """The counts one method reports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,9 @@ ja4plus = "ja4plus.cli:main"
 exclude = ["tests", "tests.*", "examples"]
 
 [tool.setuptools.package-data]
-ja4plus = ["data/*.csv"]
+# PEP 561 asks for the `py.typed` marker, and setuptools ships no file this list omits.
+# Without the entry the wheel carries the annotations and no type checker reads them.
+ja4plus = ["data/*.csv", "py.typed"]
 
 [tool.pytest.ini_options]
 markers = [
@@ -76,15 +78,15 @@ select = ["E4", "E7", "E9", "F", "I"]
 # Each rule below reports more than 50 findings on the existing code, so Epic 0 turns
 # it off. Epic 4, the typed public interface (#15), turns both back on.
 #
-# F401 waits on #47. That issue defines `__all__` and ships the `py.typed` marker.
-# Many of the 84 findings are re-exports in `ja4plus/__init__.py`, and a re-export
-# stops being a finding once the public interface is declared.
+# F401 waits on #297. #47 declared `__all__` in `ja4plus/__init__.py`, which cleared the
+# 21 re-export findings of that file. The rule reports 58 findings across 28 other files,
+# and #297 removes them and turns the rule on.
 #
 # Never enable I001 by hand. `tests/test_ja4.py` and `tests/test_spec_validation.py`
 # call `sys.path.insert` before their imports. Read both files before you turn the rule
 # on, and confirm that the fix keeps every import below the path insertion.
 ignore = [
-    "F401",  # 84 findings. Most are the re-exports in `ja4plus/__init__.py`.
+    "F401",  # 58 findings. None of them sits in `ja4plus/__init__.py`.
     "I001",  # 82 findings. Every module orders its imports by hand.
 ]
 

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -1,0 +1,94 @@
+"""The public interface of the package, and the marker that types it.
+
+`docs/specs/features/04-typed-api.md` states FR-typed-api-9, FR-typed-api-10,
+FR-typed-api-12 and FR-typed-api-13. Version 1.0.0 promises that the interface does not
+change again before version 2.0.0, so this file reads the promise back.
+
+Verified against: https://peps.python.org/pep-0561/ (retrieved 2026-08-08).
+"""
+
+from pathlib import Path
+
+import pytest
+
+import ja4plus
+from ja4plus import processor as processor_module
+
+# The interface version 1.0.0 promises. A name here stays until version 2.0.0, so the
+# list is the decision this test guards and not a copy of `dir(ja4plus)`.
+EXPECTED_PUBLIC_NAMES = [
+    "FingerprintResult",
+    "Processor",
+    "JA4Fingerprinter",
+    "JA4SFingerprinter",
+    "JA4HFingerprinter",
+    "JA4LFingerprinter",
+    "JA4XFingerprinter",
+    "JA4SSHFingerprinter",
+    "JA4TFingerprinter",
+    "JA4TSFingerprinter",
+    "JA4DFingerprinter",
+    "JA4D6Fingerprinter",
+    "generate_ja4",
+    "generate_ja4s",
+    "generate_ja4h",
+    "generate_ja4l",
+    "generate_ja4x",
+    "generate_ja4ssh",
+    "generate_ja4t",
+    "generate_ja4ts",
+    "generate_ja4d",
+    "generate_ja4d6",
+    "compute_ja4x_from_der",
+    "compute_ja4x_from_pem",
+    "__version__",
+]
+
+
+def test_the_package_declares_its_public_interface():
+    """FR-typed-api-12 asks `ja4plus/__init__.py` to list every public name."""
+    assert ja4plus.__all__ == EXPECTED_PUBLIC_NAMES
+
+
+@pytest.mark.parametrize("name", EXPECTED_PUBLIC_NAMES)
+def test_every_public_name_is_importable_from_the_package(name):
+    """A name in `__all__` that the package does not bind breaks `import *`."""
+    assert hasattr(ja4plus, name), name
+
+
+def test_the_public_interface_holds_no_duplicate_name():
+    """A duplicate name hides a merge that added one name twice."""
+    assert len(ja4plus.__all__) == len(set(ja4plus.__all__))
+
+
+def test_the_side_effect_helpers_stay_out_of_the_public_interface():
+    """`ja4plus/__init__.py` calls both helpers itself, so neither is a promised name.
+
+    FR-typed-api-13 states that a name absent from `__all__` is not part of the
+    interface the project promises.
+    """
+    assert "bind_loopback_ipv6" not in ja4plus.__all__
+    assert "register_tunnel_dissectors" not in ja4plus.__all__
+
+
+def test_the_processor_module_declares_ProcessorStats_public():
+    """`Processor.stats` returns `dict[str, ProcessorStats]`, so the name is public.
+
+    The name is public at `ja4plus.processor.ProcessorStats`, which is the import path
+    `docs/api_reference.md` documents. #47 decides that the name is public and moves the
+    class nowhere.
+    """
+    assert processor_module.__all__ == ["Processor", "ProcessorStats"]
+
+
+def test_the_package_ships_the_py_typed_marker():
+    """PEP 561 asks a package that supports type checking for a `py.typed` file."""
+    marker = Path(ja4plus.__file__).resolve().parent / "py.typed"
+    assert marker.is_file()
+
+
+def test_the_build_ships_the_marker_as_package_data():
+    """A marker that the wheel omits types nothing, and setuptools ships no unlisted file."""
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+    assert '"py.typed"' in text


### PR DESCRIPTION
Part of #15. Closes nothing on merge here: the batch pull request of Epic 4 closes #47.

## What this changes

1. **`ja4plus/py.typed`**, a new empty marker file, shipped as package data through
   `pyproject.toml`. PEP 561 asks for the file, and setuptools ships no file the
   `package-data` list omits.
2. **`ja4plus.__all__`**, which names the 25 names version 1.0.0 promises.
3. **`ja4plus/processor.py` declares its own `__all__`**, naming `Processor` and
   `ProcessorStats`. The class moves nowhere.
4. **Documentation**: a `## Public interface` section in `docs/api_reference.md`, and a
   changelog entry that reads `Round TBD`.
5. **`pyproject.toml` F401 comment**: the old comment named #47 as the issue that turns
   the rule on. #297 now holds that work, and the count moved from 84 to 58.

## Why these 25 names

The list is a decision and not a copy of `dir(ja4plus)`. A name in `__all__` stays
until version 2.0.0, and FR-typed-api-13 states that a name absent from `__all__` is
not promised.

| Group | Names | Reason |
|---|---|---|
| Result and processor | `FingerprintResult`, `Processor` | `docs/specs/features/04-typed-api.md` names both under `## Interfaces`. The port exports `FingerprintResult` and `Processor`. |
| Fingerprinter classes | The ten `JA4*Fingerprinter` classes | The port exports the same ten types. Parity rule 2. |
| One-shot functions | The ten `generate_ja4*` functions | The port exports `ComputeJA4` and its siblings. Parity rule 2. |
| Certificate helpers | `compute_ja4x_from_der`, `compute_ja4x_from_pem` | The port exports `ComputeJA4XFromDER` and `ComputeJA4XFromPEM`. `README.md:200` documents both. |
| Version | `__version__` | `ja4plus --version` reads it, and a caller reads it to test compatibility. |

Four names of the top-level namespace stay out.

- `bind_loopback_ipv6` and `register_tunnel_dissectors`: `ja4plus/__init__.py` calls
  both at import time, so a caller needs neither name.
- `__author__` and `__license__`: both describe the project and not the interface.

**The specification and the port disagree about no name**, so this pull request escalates
none. The port exports `LookupResult`, `LookupFingerprint` and `DatabaseInfo` at its
package level, and this project holds the matching code in `ja4plus/ja4db.py`.
FR-typed-api-12 covers `ja4plus/__init__.py`, which imports that module nowhere, and
Epic 7 owns the lookup interface. This pull request therefore adds no top-level name.

## The `ProcessorStats` reading

`docs/specs/features/04-typed-api.md:100` lists `ProcessorStats` beside
`FingerprintResult` in `ja4plus/types.py`, and the class sits in `ja4plus/processor.py`
today. #45 and #46 both left the move, because neither issue names it.

**This pull request decides the one question #47 owns: the name is public.**
`Processor.stats` returns `dict[str, ProcessorStats]`, so a caller who annotates the
report names the class. The port ships no equivalent, so parity rule 2 names no
interface to adopt and nothing disagrees.

The name is public **at `ja4plus.processor.ProcessorStats`**, which is the import path
`docs/api_reference.md` documents. `ja4plus/processor.py` states it in its own `__all__`,
following `ja4plus/types.py`. **The class moves nowhere, and no top-level name is
added**, because a name added to `ja4plus.__all__` needs version 2.0.0 to leave it
again, and a later Epic 4 or Epic 5 issue owns the move to `ja4plus/types.py`.

## How this was tested

The six new cases failed on the base branch first, then the change made them pass.
`tests/test_public_interface.py` holds 31 cases, of which 25 read one promised name
each.

**Acceptance criterion 1 — `unzip -l dist/*.whl` lists `ja4plus/py.typed`.** Built with
`python -m build` in the worktree:

```
$ unzip -l dist/ja4plus-0.6.0-py3-none-any.whl
        0  08-08-2026 17:48   ja4plus/py.typed
     4740  08-08-2026 17:43   ja4plus/data/ja4plus-mapping.csv
```

The sdist carries it too: `ja4plus-0.6.0/ja4plus/py.typed`.

**Acceptance criterion 3 — a caller who runs `mypy --strict` resolves the annotations.**
Measured, and not asserted. A throwaway virtual environment installed the built wheel
and `mypy`, and read a consumer of two lines. A success alone proves nothing, because an
unresolved package reads as `Any`, so the measurement holds a negative control:

```python
wrong: int = result.fingerprint
```

```
consumer_negative.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
```

`mypy` read the annotation from the installed wheel, so the marker ships and a type
checker honours it.

## Gates

| Gate | Base | This branch |
|---|---|---|
| `pytest -m "not spec_validation"` | 1673 passed, 8 xfailed, 93 subtests | 1704 passed, 8 xfailed, 93 subtests |
| `pytest -m spec_validation` | 1477 passed, 143 skipped, 137 xfailed | 1477 passed, 143 skipped, 137 xfailed |
| `ruff check ja4plus/ tests/` | clean | clean |
| `ruff format --check ja4plus/ tests/` | clean | clean |
| `mypy --strict ja4plus/` | clean | clean |

No fingerprint value moved. The conformance suite reports the same four counts.

Verified against: https://peps.python.org/pep-0561/ (retrieved 2026-08-08).
Verified against: https://github.com/Crank-Git/ja4plus-go (`types.go`, `processor.go`,
`lookup.go`, `ja4x.go`, read on 2026-08-08, `master`).
