### PR TITLE
Write output records with separate address and port fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The command-line program writes the addresses and the ports as separate fields**
+  (#49). Round TBD. The `json` and the `csv` formats replace the composite `source`
+  field of version 0.6.0 with `src_ip`, `src_port`, `dst_ip` and `dst_port`, so a
+  downstream tool parses no composite string. The CSV header is now fixed at
+  `schema_version,timestamp,type,fingerprint,raw,raw_original_order,src_ip,src_port,dst_ip,dst_port,identified_as`,
+  and it no longer changes with `--lookup`. Every field is present in every record: a
+  field with no value is `null` in the `json` format and empty in the `csv` format.
+  `identified_as` is therefore present without `--lookup`, where version 0.6.0 omitted
+  it. Each record also carries the packet `timestamp` in RFC 3339 form. New module
+  `ja4plus/output.py` holds one writer per format. #50 documents the schema and its
+  version.
+
 - **`Processor.process_packet` returns a list of `FingerprintResult`** (#45). Round TBD.
   The method returned a list of dictionaries through version 0.6.0. A caller who reads
   `result["fingerprint"]` keeps working for one major version, and item access emits a

--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ ja4plus --lookup analyze capture.pcap
 
 Output formats: `--format table` (default), `json` (JSONL), `csv`
 
+The `json` and the `csv` formats write the same fields whatever flags you pass. Each
+record carries the source address, the source port, the destination address and the
+destination port as separate fields, in this order:
+
+```
+schema_version,timestamp,type,fingerprint,raw,raw_original_order,src_ip,src_port,dst_ip,dst_port,identified_as
+```
+
+A field with no value is `null` in the `json` format and empty in the `csv` format. The
+`table` format is for a person reading a terminal, and it carries no stability promise.
+
 ## Fingerprint Lookup
 
 ja4plus includes a bundled database of known JA4+ fingerprints from FoxIO's [ja4plus-mapping.csv](https://github.com/FoxIO-LLC/ja4/blob/main/ja4plus-mapping.csv). Identifies Chrome, Firefox, Safari, Python, Cobalt Strike, Sliver, IcedID, and more.

--- a/ja4plus/cli.py
+++ b/ja4plus/cli.py
@@ -13,14 +13,14 @@ Subcommands:
 from __future__ import annotations
 
 import argparse
-import csv
-import json
 import os
 import sys
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from ja4plus import __version__
+from ja4plus.output import OutputWriter, build_writer
+from ja4plus.types import FingerprintResult
 from ja4plus.fingerprinters.base import BaseFingerprinter
 from ja4plus.fingerprinters.ja4 import JA4Fingerprinter
 from ja4plus.fingerprinters.ja4s import JA4SFingerprinter
@@ -39,11 +39,6 @@ if TYPE_CHECKING:
     from scapy.packet import Packet
 
     from ja4plus.ja4db import JA4DBClient
-
-# One row the command writes. A row holds the source, the method name and the
-# fingerprint, and the raw form and the original-order raw form where the method
-# publishes them.
-ResultRow = tuple[Any, ...]
 
 VALID_TYPES = [
     "ja4",
@@ -91,41 +86,111 @@ def _build_fingerprinters(types: list[str]) -> dict[str, BaseFingerprinter]:
     return {name: ALL_FINGERPRINTERS[name]() for name in types}
 
 
-def _get_packet_source(packet: Packet) -> str:
-    """Return a source string like src_ip:src_port -> dst_ip:dst_port."""
+def _packet_endpoints(packet: Packet) -> tuple[str, int, str, int]:
+    """Return the source address, the source port, the destination address and the port.
+
+    FR-structured-output-1 asks every output format to carry the four values as separate
+    fields, so the command reads them apart rather than as one string.
+
+    Every packet is hostile input, so a layer this call cannot read produces the empty
+    address and the port zero.
+
+    Args:
+        packet: The packet to read.
+
+    Returns:
+        A tuple of the source address, the source port, the destination address and the
+        destination port. The address is empty and the port is zero where the packet
+        carries no value.
+    """
+    src_ip = dst_ip = ""
+    src_port = dst_port = 0
     try:
         from scapy.all import IP, IPv6, TCP, UDP
 
-        src_ip = dst_ip = ""
-        src_port = dst_port = None
-
         if packet.haslayer(IP):
-            src_ip = packet[IP].src
-            dst_ip = packet[IP].dst
+            src_ip = str(packet[IP].src)
+            dst_ip = str(packet[IP].dst)
         elif packet.haslayer(IPv6):
-            from scapy.all import IPv6 as IPv6Layer
-
-            src_ip = packet[IPv6Layer].src
-            dst_ip = packet[IPv6Layer].dst
+            src_ip = str(packet[IPv6].src)
+            dst_ip = str(packet[IPv6].dst)
 
         if packet.haslayer(TCP):
-            src_port = packet[TCP].sport
-            dst_port = packet[TCP].dport
+            src_port = int(packet[TCP].sport)
+            dst_port = int(packet[TCP].dport)
         elif packet.haslayer(UDP):
-            src_port = packet[UDP].sport
-            dst_port = packet[UDP].dport
-
-        if src_port is not None:
-            return f"{src_ip}:{src_port} -> {dst_ip}:{dst_port}"
-        elif src_ip:
-            return f"{src_ip} -> {dst_ip}"
-    except (AttributeError, IndexError, TypeError):
+            src_port = int(packet[UDP].sport)
+            dst_port = int(packet[UDP].dport)
+    except (AttributeError, IndexError, TypeError, ValueError):
         pass
-    return "unknown"
+    return src_ip, src_port, dst_ip, dst_port
 
 
-def _close_open_windows(fingerprinters: dict[str, BaseFingerprinter]) -> list[ResultRow]:
-    """Return one result row for every window the fingerprinters hold open.
+def _packet_timestamp(packet: Packet) -> datetime | None:
+    """Return the time the capture recorded for the packet, or None when it has none.
+
+    `scapy` holds the time as a decimal count of seconds from the epoch, and it names no
+    zone. The count is UTC, so the call builds a UTC time.
+
+    Args:
+        packet: The packet to read.
+
+    Returns:
+        The packet time as a UTC `datetime`, or None when the packet carries no readable
+        time.
+    """
+    seconds = getattr(packet, "time", None)
+    if seconds is None:
+        return None
+    try:
+        return datetime.fromtimestamp(float(seconds), tz=timezone.utc)
+    except (OSError, OverflowError, TypeError, ValueError):
+        return None
+
+
+def _endpoints_from_connection(connection: str) -> tuple[str, int, str, int]:
+    """Return the four endpoint values that a connection key names.
+
+    A window that no packet closes carries the connection key and no packet, so the
+    command reads the endpoints back from the key. The key form is
+    `<address>:<port>-<address>:<port>`. An IPv6 address holds a colon and no hyphen, so
+    the first hyphen separates the two endpoints and the last colon of each half
+    separates the port.
+
+    Args:
+        connection: The connection key the fingerprinter reported.
+
+    Returns:
+        A tuple of the source address, the source port, the destination address and the
+        destination port. A key this call cannot read produces empty addresses and the
+        port zero.
+    """
+    first, separator, second = connection.partition("-")
+    if not separator:
+        return "", 0, "", 0
+    src_ip, src_port = _split_endpoint(first)
+    dst_ip, dst_port = _split_endpoint(second)
+    return src_ip, src_port, dst_ip, dst_port
+
+
+def _split_endpoint(endpoint: str) -> tuple[str, int]:
+    """Return the address and the port that one half of a connection key names.
+
+    Args:
+        endpoint: One half of a connection key, such as `172.16.225.48:57377`.
+
+    Returns:
+        The address and the port. A half that carries no numeric port returns the whole
+        half as the address and the port zero.
+    """
+    address, separator, port = endpoint.rpartition(":")
+    if not separator or not port.isdigit():
+        return endpoint, 0
+    return address, int(port)
+
+
+def _close_open_windows(fingerprinters: dict[str, BaseFingerprinter]) -> list[FingerprintResult]:
+    """Return one result for every window the fingerprinters hold open.
 
     Run this function when the packet source ends without an error. JA4SSH is the only
     method that holds a window, and #214 decided that it emits the window a connection
@@ -139,70 +204,91 @@ def _close_open_windows(fingerprinters: dict[str, BaseFingerprinter]) -> list[Re
         fingerprinters: The map of method name to fingerprinter that the command built.
 
     Returns:
-        A list of `(source, fp_type, fingerprint, None, None)` tuples, in the order the
-        fingerprinters emitted them. The source reads the connection key of the window,
-        because no packet produces the value.
+        A list of `FingerprintResult`, in the order the fingerprinters emitted them. The
+        endpoints read the connection key of the window, because no packet produces
+        them. The timestamp is None for the same reason.
     """
-    rows: list[ResultRow] = []
+    results: list[FingerprintResult] = []
     for fp_type, fp in fingerprinters.items():
         for entry in fp.close_open_windows():
-            connection = entry.get("connection", "")
-            # The key form is `<client>-<server>`, and an IPv6 address holds a colon and
-            # no hyphen, so the first hyphen separates the two endpoints.
-            client, separator, server = connection.partition("-")
-            source = f"{client} -> {server}" if separator else connection
-            rows.append((source, fp_type, entry["fingerprint"], None, None))
-    return rows
+            src_ip, src_port, dst_ip, dst_port = _endpoints_from_connection(
+                entry.get("connection", "")
+            )
+            results.append(
+                FingerprintResult(
+                    type=fp_type,
+                    fingerprint=entry["fingerprint"],
+                    src_ip=src_ip,
+                    src_port=src_port,
+                    dst_ip=dst_ip,
+                    dst_port=dst_port,
+                )
+            )
+    return results
 
 
-def _output_results(
-    results: Sequence[ResultRow],
-    fmt: str,
-    # typeshed publishes no public name for the object `csv.writer` returns.
-    writer: Any = None,
+def _fingerprint_one_packet(
+    packet: Packet, fingerprinters: dict[str, BaseFingerprinter]
+) -> list[FingerprintResult]:
+    """Return one result for every method that reads a fingerprint from the packet.
+
+    The command reads the endpoints and the time once, because every method that reads
+    the same packet reports the same four endpoint values and the same time.
+
+    Args:
+        packet: The packet to read.
+        fingerprinters: The map of method name to fingerprinter that the command built.
+
+    Returns:
+        A list of `FingerprintResult`, in the order the fingerprinters ran. The list is
+        empty when the packet produces no fingerprint.
+    """
+    results: list[FingerprintResult] = []
+    src_ip, src_port, dst_ip, dst_port = _packet_endpoints(packet)
+    timestamp = _packet_timestamp(packet)
+    for fp_type, fp in fingerprinters.items():
+        try:
+            fingerprint = fp.process_packet(packet)
+        except Exception:
+            # #51 replaces this silent pass with a diagnostic on standard error.
+            continue
+        if not fingerprint:
+            continue
+        results.append(
+            FingerprintResult(
+                type=fp_type,
+                fingerprint=fingerprint,
+                raw=getattr(fp, "last_raw", None),
+                raw_original_order=getattr(fp, "last_raw_original_order", None),
+                src_ip=src_ip,
+                src_port=src_port,
+                dst_ip=dst_ip,
+                dst_port=dst_port,
+                timestamp=timestamp,
+            )
+        )
+    return results
+
+
+def _write_results(
+    results: list[FingerprintResult],
+    writer: OutputWriter,
     ja4db_client: JA4DBClient | None = None,
 ) -> None:
-    """
-    Output a list of result tuples in the requested format.
+    """Write every result to the writer, with the identification the lookup returned.
 
-    Each result is (source, fp_type, fingerprint, raw, raw_oo) where raw and
-    raw_oo are optional (None for fingerprinters that don't expose them).
-    writer is only used for csv format (a csv.writer instance).
-    ja4db_client is optional JA4DBClient for fingerprint identification.
+    Args:
+        results: The results to write, in the order the fingerprinters emitted them.
+        writer: The writer the `--format` option selected.
+        ja4db_client: The lookup client, or None when the user passed no `--lookup`.
     """
-    for entry in results:
-        # Backward compat: accept 3-tuples too
-        if len(entry) == 3:
-            source, fp_type, fingerprint = entry
-            raw, raw_oo = None, None
-        else:
-            source, fp_type, fingerprint, raw, raw_oo = entry
-
-        identified = ""
+    for result in results:
+        identified: str | None = None
         if ja4db_client:
-            match = ja4db_client.lookup(fingerprint)
+            match = ja4db_client.lookup(result.fingerprint)
             if match:
-                identified = match.get("application", "")
-
-        if fmt == "json":
-            obj: dict[str, Any] = {"source": source, "type": fp_type, "fingerprint": fingerprint}
-            if raw is not None:
-                obj["raw"] = raw
-            if raw_oo is not None:
-                obj["raw_original_order"] = raw_oo
-            if ja4db_client:
-                obj["identified_as"] = identified or None
-            print(json.dumps(obj))
-        elif fmt == "csv":
-            row = [source, fp_type, fingerprint]
-            if ja4db_client:
-                row.append(identified)
-            writer.writerow(row)
-        else:  # table
-            if identified:
-                print(f"{source:<50}  {fp_type:<10}  {fingerprint}  ({identified})")
-            else:
-                print(f"{source:<50}  {fp_type:<10}  {fingerprint}")
+                identified = match.get("application") or None
+        writer.write(result, identified)
 
 
 def _init_lookup(args: argparse.Namespace) -> JA4DBClient | None:
@@ -229,20 +315,10 @@ def cmd_analyze(args: argparse.Namespace) -> None:
     fingerprinters = _build_fingerprinters(types)
     ja4db_client = _init_lookup(args)
 
-    # Set up output
-    csv_writer = None
-    if args.format == "table":
-        header = f"{'Source':<50}  {'Type':<10}  Fingerprint"
-        if ja4db_client:
-            header += "  Identified As"
-        print(header)
-        print("-" * (110 if ja4db_client else 90))
-    elif args.format == "csv":
-        csv_writer = csv.writer(sys.stdout)
-        row = ["source", "type", "fingerprint"]
-        if ja4db_client:
-            row.append("identified_as")
-        csv_writer.writerow(row)
+    # FR-structured-output-4 asks for the same columns whatever flags the user passed, so
+    # the header reads no flag.
+    writer = build_writer(args.format, sys.stdout)
+    writer.write_header()
 
     try:
         from scapy.utils import PcapReader
@@ -253,24 +329,14 @@ def cmd_analyze(args: argparse.Namespace) -> None:
     try:
         with PcapReader(pcap_file) as reader:
             for packet in reader:
-                source = _get_packet_source(packet)
-                row_batch: list[ResultRow] = []
-                for fp_type, fp in fingerprinters.items():
-                    try:
-                        result = fp.process_packet(packet)
-                        if result:
-                            raw = getattr(fp, "last_raw", None)
-                            raw_oo = getattr(fp, "last_raw_original_order", None)
-                            row_batch.append((source, fp_type, result, raw, raw_oo))
-                    except Exception:
-                        pass
-                if row_batch:
-                    _output_results(row_batch, args.format, csv_writer, ja4db_client)
+                batch = _fingerprint_one_packet(packet, fingerprinters)
+                if batch:
+                    _write_results(batch, writer, ja4db_client)
             # The capture ends here, and a connection that never closes still holds a
             # window open. #214 decided that JA4SSH emits that window.
             trailing = _close_open_windows(fingerprinters)
             if trailing:
-                _output_results(trailing, args.format, csv_writer, ja4db_client)
+                _write_results(trailing, writer, ja4db_client)
     except FileNotFoundError:
         print(f"Error: file not found: {pcap_file}", file=sys.stderr)
         sys.exit(1)
@@ -297,36 +363,17 @@ def cmd_live(args: argparse.Namespace) -> None:
     fingerprinters = _build_fingerprinters(types)
     ja4db_client = _init_lookup(args)
 
-    csv_writer = None
-    if args.format == "table":
-        header = f"{'Source':<50}  {'Type':<10}  Fingerprint"
-        if ja4db_client:
-            header += "  Identified As"
-        print(header)
-        print("-" * (110 if ja4db_client else 90))
-    elif args.format == "csv":
-        csv_writer = csv.writer(sys.stdout)
-        row = ["source", "type", "fingerprint"]
-        if ja4db_client:
-            row.append("identified_as")
-        csv_writer.writerow(row)
+    # FR-structured-output-4 asks for the same columns whatever flags the user passed, so
+    # the header reads no flag.
+    writer = build_writer(args.format, sys.stdout)
+    writer.write_header()
 
     print(f"Starting live capture on '{args.interface}'... (Ctrl-C to stop)", file=sys.stderr)
 
     def process_packet(packet: Packet) -> None:
-        source = _get_packet_source(packet)
-        row_batch: list[ResultRow] = []
-        for fp_type, fp in fingerprinters.items():
-            try:
-                result = fp.process_packet(packet)
-                if result:
-                    raw = getattr(fp, "last_raw", None)
-                    raw_oo = getattr(fp, "last_raw_original_order", None)
-                    row_batch.append((source, fp_type, result, raw, raw_oo))
-            except Exception:
-                pass
-        if row_batch:
-            _output_results(row_batch, args.format, csv_writer, ja4db_client)
+        batch = _fingerprint_one_packet(packet, fingerprinters)
+        if batch:
+            _write_results(batch, writer, ja4db_client)
             sys.stdout.flush()
 
     try:
@@ -347,7 +394,7 @@ def cmd_live(args: argparse.Namespace) -> None:
     # open. #214 decided that JA4SSH emits that window.
     trailing = _close_open_windows(fingerprinters)
     if trailing:
-        _output_results(trailing, args.format, csv_writer, ja4db_client)
+        _write_results(trailing, writer, ja4db_client)
         sys.stdout.flush()
 
 
@@ -386,25 +433,15 @@ def cmd_cert(args: argparse.Namespace) -> None:
         print("Error: could not generate JA4X fingerprint from certificate", file=sys.stderr)
         sys.exit(1)
 
-    source = os.path.basename(cert_file)
-    results: list[ResultRow] = [(source, "ja4x", fingerprint)]
+    # A certificate file carries no address, no port and no packet time, so the record
+    # holds the empty address, the port zero and no time. FR-structured-output-5 asks
+    # for a column that is empty rather than absent.
+    results = [FingerprintResult(type="ja4x", fingerprint=fingerprint)]
     ja4db_client = _init_lookup(args)
 
-    csv_writer = None
-    if args.format == "table":
-        header = f"{'Source':<50}  {'Type':<10}  Fingerprint"
-        if ja4db_client:
-            header += "  Identified As"
-        print(header)
-        print("-" * (110 if ja4db_client else 90))
-    elif args.format == "csv":
-        csv_writer = csv.writer(sys.stdout)
-        row = ["source", "type", "fingerprint"]
-        if ja4db_client:
-            row.append("identified_as")
-        csv_writer.writerow(row)
-
-    _output_results(results, args.format, csv_writer, ja4db_client)
+    writer = build_writer(args.format, sys.stdout)
+    writer.write_header()
+    _write_results(results, writer, ja4db_client)
 
 
 def cmd_db(args: argparse.Namespace) -> None:

--- a/ja4plus/output.py
+++ b/ja4plus/output.py
@@ -1,0 +1,253 @@
+"""The writers that turn a `FingerprintResult` into an output record.
+
+`docs/specs/features/05-structured-output.md` defines this module. The JSON Lines
+format and the CSV format carry a stability promise, so both write the same field set
+whatever flags the user passed. The table format is for a person reading a terminal,
+and it carries no promise.
+
+A writer reads a `FingerprintResult` and adds the two fields the command-line program
+owns: `schema_version` and `identified_as`. `ja4plus/types.py` states why the library
+result carries neither.
+"""
+
+# Python 3.9 is the floor, and it evaluates no annotation written as `str | None`
+# without this import.
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime, timezone
+from typing import Any, TextIO
+
+from ja4plus.types import FingerprintResult
+
+__all__ = [
+    "CSV_COLUMNS",
+    "SCHEMA_VERSION",
+    "CsvWriter",
+    "JsonLinesWriter",
+    "OutputWriter",
+    "TableWriter",
+    "build_writer",
+]
+
+# The behaviour rules of `docs/specs/features/05-structured-output.md` state that the
+# schema version starts at 1, and the acceptance criteria of #50 state the same value.
+# #50 owns the rule that raises it and the document that records it. This module writes
+# the value and decides nothing about it.
+SCHEMA_VERSION = 1
+
+# FR-structured-output-4 fixes this order, and a new column appends to the end. A
+# downstream parser reads a column by position, so an insertion breaks it.
+CSV_COLUMNS = (
+    "schema_version",
+    "timestamp",
+    "type",
+    "fingerprint",
+    "raw",
+    "raw_original_order",
+    "src_ip",
+    "src_port",
+    "dst_ip",
+    "dst_port",
+    "identified_as",
+)
+
+# The table format aligns the source column to this width. The value matches the width
+# version 0.6.0 used, so a person who reads both releases sees one layout.
+_SOURCE_WIDTH = 50
+_TYPE_WIDTH = 10
+_RULE_WIDTH = 90
+
+
+def format_timestamp(value: datetime | None) -> str | None:
+    """Return the time in RFC 3339 form, or None when there is no time.
+
+    A time that carries no zone reads as UTC, because a packet timestamp counts seconds
+    from the epoch and names no zone. The call writes the suffix `Z` rather than
+    `+00:00`, because the mockup and the schema example both show `Z`.
+
+    Args:
+        value: The packet timestamp, or None when the packet carries none.
+
+    Returns:
+        A string such as `2026-08-06T12:34:56.789012Z`, or None.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def display_source(result: FingerprintResult) -> str:
+    """Return the endpoints of the result as one string for a person to read.
+
+    Only the table format calls this. FR-structured-output-1 asks every format to carry
+    the addresses and the ports as separate fields, and the JSON and CSV writers do.
+
+    Args:
+        result: The result to describe.
+
+    Returns:
+        `src_ip:src_port -> dst_ip:dst_port` when the result carries ports,
+        `src_ip -> dst_ip` when it carries addresses alone, and `unknown` when it
+        carries neither. Version 0.6.0 wrote the same three forms.
+    """
+    if result.src_port or result.dst_port:
+        return f"{result.src_ip}:{result.src_port} -> {result.dst_ip}:{result.dst_port}"
+    if result.src_ip or result.dst_ip:
+        return f"{result.src_ip} -> {result.dst_ip}"
+    return "unknown"
+
+
+class OutputWriter:
+    """The interface the three formats share.
+
+    A caller builds one writer, calls `write_header` once, then calls `write` for each
+    result. A format with no header leaves `write_header` as the call that does nothing.
+
+    Args:
+        stream: The text stream the writer writes to.
+    """
+
+    def __init__(self, stream: TextIO) -> None:
+        self.stream = stream
+
+    def write_header(self) -> None:
+        """Write the header of the format. The base class writes nothing."""
+
+    def write(self, result: FingerprintResult, identified_as: str | None = None) -> None:
+        """Write one record.
+
+        Args:
+            result: The fingerprint and the endpoints that produced it.
+            identified_as: The application name the lookup returned, or None when the
+                user passed no `--lookup` or the lookup found no match.
+
+        Raises:
+            NotImplementedError: The base class writes no record.
+        """
+        raise NotImplementedError
+
+
+class JsonLinesWriter(OutputWriter):
+    """The writer that puts one JSON object on each line.
+
+    FR-structured-output-2 asks for one object per line, so the output is not one JSON
+    array. A reader that streams the output parses each line on its own.
+    """
+
+    def write(self, result: FingerprintResult, identified_as: str | None = None) -> None:
+        """Write one JSON object and one newline.
+
+        FR-structured-output-5 asks for a field that is present and null rather than
+        absent, so the object holds every column of `CSV_COLUMNS`.
+
+        Args:
+            result: The fingerprint and the endpoints that produced it.
+            identified_as: The application name the lookup returned, or None.
+        """
+        record: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "timestamp": format_timestamp(result.timestamp),
+            "type": result.type,
+            "fingerprint": result.fingerprint,
+            "raw": result.raw,
+            "raw_original_order": result.raw_original_order,
+            "src_ip": result.src_ip,
+            "src_port": result.src_port,
+            "dst_ip": result.dst_ip,
+            "dst_port": result.dst_port,
+            "identified_as": identified_as or None,
+        }
+        self.stream.write(json.dumps(record) + "\n")
+
+
+class CsvWriter(OutputWriter):
+    """The writer that puts one CSV row on each line.
+
+    FR-structured-output-4 asks for the same columns whatever flags the user passed, so
+    the header and every row hold all eleven columns of `CSV_COLUMNS`.
+    """
+
+    def __init__(self, stream: TextIO) -> None:
+        super().__init__(stream)
+        # typeshed publishes no public name for the object `csv.writer` returns. The
+        # module quotes a field that holds a comma, which a hand-built row would not.
+        self._writer: Any = csv.writer(stream)
+
+    def write_header(self) -> None:
+        """Write the header row."""
+        self._writer.writerow(list(CSV_COLUMNS))
+
+    def write(self, result: FingerprintResult, identified_as: str | None = None) -> None:
+        """Write one data row.
+
+        FR-structured-output-5 asks for a column that is empty rather than absent, so a
+        value of None writes an empty column.
+
+        Args:
+            result: The fingerprint and the endpoints that produced it.
+            identified_as: The application name the lookup returned, or None.
+        """
+        self._writer.writerow(
+            [
+                SCHEMA_VERSION,
+                format_timestamp(result.timestamp) or "",
+                result.type,
+                result.fingerprint,
+                result.raw or "",
+                result.raw_original_order or "",
+                result.src_ip,
+                result.src_port,
+                result.dst_ip,
+                result.dst_port,
+                identified_as or "",
+            ]
+        )
+
+
+class TableWriter(OutputWriter):
+    """The writer that aligns the records for a person reading a terminal.
+
+    FR-structured-output-7 gives this format no stability promise, so it writes the
+    endpoints as one source column. A tool reads the JSON or the CSV format instead.
+    """
+
+    def write_header(self) -> None:
+        """Write the column names and the rule below them."""
+        self.stream.write(f"{'Source':<{_SOURCE_WIDTH}}  {'Type':<{_TYPE_WIDTH}}  Fingerprint\n")
+        self.stream.write("-" * _RULE_WIDTH + "\n")
+
+    def write(self, result: FingerprintResult, identified_as: str | None = None) -> None:
+        """Write one aligned row.
+
+        Args:
+            result: The fingerprint and the endpoints that produced it.
+            identified_as: The application name the lookup returned, or None. The row
+                holds it in brackets at the end when the lookup found a match.
+        """
+        source = display_source(result)
+        row = f"{source:<{_SOURCE_WIDTH}}  {result.type:<{_TYPE_WIDTH}}  {result.fingerprint}"
+        if identified_as:
+            row += f"  ({identified_as})"
+        self.stream.write(row + "\n")
+
+
+def build_writer(fmt: str, stream: TextIO) -> OutputWriter:
+    """Return the writer that the format name selects.
+
+    Args:
+        fmt: One of `table`, `json` and `csv`. FR-structured-output-6 names the three.
+        stream: The text stream the writer writes to.
+
+    Returns:
+        The writer for that format. An unknown name returns the table writer, because
+        `argparse` rejects an unknown name before the program reaches this call.
+    """
+    if fmt == "json":
+        return JsonLinesWriter(stream)
+    if fmt == "csv":
+        return CsvWriter(stream)
+    return TableWriter(stream)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,13 @@ class TestAnalyzePcap(unittest.TestCase):
         self.assertGreater(len(lines), 0, "Expected at least one JSON line")
         for line in lines:
             obj = json.loads(line)
-            self.assertIn("source", obj)
+            # #49 replaced the composite `source` field with the four endpoint fields.
+            # `tests/test_output_schema.py` holds the whole field set.
+            self.assertNotIn("source", obj)
+            self.assertIn("src_ip", obj)
+            self.assertIn("src_port", obj)
+            self.assertIn("dst_ip", obj)
+            self.assertIn("dst_port", obj)
             self.assertIn("type", obj)
             self.assertIn("fingerprint", obj)
 
@@ -70,11 +76,16 @@ class TestAnalyzePcap(unittest.TestCase):
         reader = csv.reader(io.StringIO(out))
         rows = list(reader)
         self.assertGreater(len(rows), 1, "Expected header + at least one data row")
-        self.assertEqual(rows[0], ["source", "type", "fingerprint"])
-        # All data rows should have 3 columns
+        # #49 fixed the column order. `tests/test_output_schema.py` compares the header
+        # against the documented list.
+        from ja4plus.output import CSV_COLUMNS
+
+        self.assertEqual(rows[0], list(CSV_COLUMNS))
         for row in rows[1:]:
             if row:  # skip blank lines
-                self.assertEqual(len(row), 3, f"Expected 3 columns, got: {row}")
+                self.assertEqual(
+                    len(row), len(CSV_COLUMNS), f"Expected {len(CSV_COLUMNS)} columns, got: {row}"
+                )
 
     def test_analyze_types_filter(self):
         """--types ja4t restricts output to JA4T fingerprints only."""
@@ -157,7 +168,12 @@ class TestTheTrailingJA4SSHWindow(unittest.TestCase):
         records = [json.loads(line) for line in out.strip().splitlines() if line.strip()]
         values = [record["fingerprint"] for record in records]
         self.assertEqual(values, ["c36s36_c76s124_c74s5", "c36s52_c42s76_c51s2"])
-        self.assertEqual(records[1]["source"], "172.16.225.48:57377 -> 54.160.114.75:22")
+        # No packet closes this window, so #49 reads the four endpoint fields back from
+        # the connection key that the fingerprinter reported.
+        self.assertEqual(records[1]["src_ip"], "172.16.225.48")
+        self.assertEqual(records[1]["src_port"], 57377)
+        self.assertEqual(records[1]["dst_ip"], "54.160.114.75")
+        self.assertEqual(records[1]["dst_port"], 22)
 
 
 class TestInvalidTypes(unittest.TestCase):

--- a/tests/test_ja4db.py
+++ b/tests/test_ja4db.py
@@ -348,4 +348,7 @@ class TestCLILookupFlag:
         if result.returncode == 0 and result.stdout.strip():
             for line in result.stdout.strip().split("\n"):
                 obj = json.loads(line)
-                assert "identified_as" not in obj  # Not present without --lookup
+                # FR-structured-output-5 asks for a field that is present and null
+                # rather than absent, so the field set reads no flag. #49 changed this
+                # expectation from the absent field of version 0.6.0.
+                assert obj["identified_as"] is None

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -1,0 +1,349 @@
+"""Tests for the output records that `ja4plus/output.py` writes.
+
+`docs/specs/features/05-structured-output.md` defines the schema. #49 covers the
+separate address and port fields, the fixed CSV column order and the empty column.
+#50 covers the schema version rule and `docs/output-schema.md`.
+"""
+
+import csv
+import io
+import json
+import os
+import unittest
+from contextlib import ExitStack
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from ja4plus.output import CSV_COLUMNS, CsvWriter, JsonLinesWriter, TableWriter
+from ja4plus.types import FingerprintResult
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+HTTP_CAP = os.path.join(DATA_DIR, "http.cap")
+
+# `docs/specs/features/05-structured-output.md` states this order, and the mockup
+# `docs/specs/mockups/01-cli-output.html` repeats it. The test holds its own copy, so a
+# change to `CSV_COLUMNS` alone fails here.
+DOCUMENTED_COLUMNS = [
+    "schema_version",
+    "timestamp",
+    "type",
+    "fingerprint",
+    "raw",
+    "raw_original_order",
+    "src_ip",
+    "src_port",
+    "dst_ip",
+    "dst_port",
+    "identified_as",
+]
+
+# The JSON object carries one field for each CSV column. FR-structured-output-5 asks for
+# a value that is present and null rather than absent.
+DOCUMENTED_FIELDS = set(DOCUMENTED_COLUMNS)
+
+
+class StubLookupClient:
+    """A lookup client that answers from a dict and reaches no network.
+
+    `--lookup` builds a `JA4DBClient`, and that client falls back to `ja4db.com`. A test
+    that built the real client would depend on the network.
+
+    Args:
+        matches: A dict that maps a fingerprint to an application name.
+    """
+
+    def __init__(self, matches=None):
+        self.matches = matches or {}
+
+    def lookup(self, fingerprint):
+        """Return the match dict for the fingerprint, or None when there is no match."""
+        application = self.matches.get(fingerprint)
+        return {"application": application} if application else None
+
+
+def run_cli(*argv, lookup_client=None):
+    """Run the command-line program, and return its standard output, error and status.
+
+    Args:
+        argv: The arguments that follow the program name.
+        lookup_client: A stub that replaces the client `--lookup` builds, or None to
+            leave the real client in place.
+
+    Returns:
+        A tuple of the standard output, the standard error and the exit status.
+    """
+    from ja4plus.cli import main
+
+    captured_out = io.StringIO()
+    captured_err = io.StringIO()
+    exit_code = 0
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["ja4plus"] + list(argv)))
+        stack.enter_context(patch("sys.stdout", captured_out))
+        stack.enter_context(patch("sys.stderr", captured_err))
+        if lookup_client is not None:
+            stack.enter_context(patch("ja4plus.cli._init_lookup", return_value=lookup_client))
+        try:
+            main()
+        except SystemExit as e:
+            exit_code = e.code if e.code is not None else 0
+
+    return captured_out.getvalue(), captured_err.getvalue(), exit_code
+
+
+def csv_rows(text):
+    """Return the parsed rows of the CSV text, with the blank trailing row removed."""
+    return [row for row in csv.reader(io.StringIO(text)) if row]
+
+
+def json_records(text):
+    """Return one parsed object for each non-empty line of the text."""
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+class TheCsvHeader(unittest.TestCase):
+    def test_the_csv_header_matches_the_documented_column_order(self):
+        out, err, code = run_cli("--format", "csv", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0, f"the command exited with {code}. stderr: {err}")
+        rows = csv_rows(out)
+        self.assertEqual(rows[0], DOCUMENTED_COLUMNS)
+
+    def test_the_module_column_list_matches_the_documented_column_order(self):
+        self.assertEqual(list(CSV_COLUMNS), DOCUMENTED_COLUMNS)
+
+    def test_the_csv_header_is_identical_with_and_without_lookup(self):
+        plain, _, plain_code = run_cli("--format", "csv", "analyze", HTTP_CAP)
+        looked_up, _, lookup_code = run_cli(
+            "--format",
+            "csv",
+            "--lookup",
+            "analyze",
+            HTTP_CAP,
+            lookup_client=StubLookupClient({"8760_2-1-1-4_1460_0": "Test Application"}),
+        )
+        self.assertEqual(plain_code, 0)
+        self.assertEqual(lookup_code, 0)
+        self.assertEqual(csv_rows(plain)[0], csv_rows(looked_up)[0])
+
+    def test_lookup_changes_the_identified_as_value_and_no_other_column(self):
+        """The proof that the header test above compares two different runs."""
+        looked_up, _, code = run_cli(
+            "--format",
+            "csv",
+            "--lookup",
+            "analyze",
+            HTTP_CAP,
+            lookup_client=StubLookupClient({"8760_2-1-1-4_1460_0": "Test Application"}),
+        )
+        self.assertEqual(code, 0)
+        rows = csv_rows(looked_up)
+        identified = rows[0].index("identified_as")
+        values = [row[identified] for row in rows[1:]]
+        self.assertIn("Test Application", values)
+
+
+class TheCsvRows(unittest.TestCase):
+    def test_every_csv_row_holds_one_value_for_each_column(self):
+        out, err, code = run_cli("--format", "csv", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0, f"the command exited with {code}. stderr: {err}")
+        rows = csv_rows(out)
+        self.assertGreater(len(rows), 1, "the capture produces no data row")
+        for row in rows[1:]:
+            self.assertEqual(len(row), len(DOCUMENTED_COLUMNS), f"wrong column count: {row}")
+
+    def test_the_csv_row_holds_the_address_and_the_port_in_separate_columns(self):
+        out, _, code = run_cli("--format", "csv", "--types", "ja4t", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0)
+        rows = csv_rows(out)
+        header = rows[0]
+        row = dict(zip(header, rows[1]))
+        self.assertEqual(row["src_ip"], "145.254.160.237")
+        self.assertEqual(row["src_port"], "3372")
+        self.assertEqual(row["dst_ip"], "65.208.228.223")
+        self.assertEqual(row["dst_port"], "80")
+        self.assertEqual(row["type"], "ja4t")
+        self.assertEqual(row["fingerprint"], "8760_2-1-1-4_1460_0")
+
+    def test_a_column_with_no_value_is_empty_rather_than_absent(self):
+        stream = io.StringIO()
+        writer = CsvWriter(stream)
+        writer.write_header()
+        writer.write(FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_0"))
+        rows = csv_rows(stream.getvalue())
+        row = dict(zip(rows[0], rows[1]))
+        self.assertEqual(row["raw"], "")
+        self.assertEqual(row["raw_original_order"], "")
+        self.assertEqual(row["timestamp"], "")
+        self.assertEqual(row["identified_as"], "")
+        self.assertEqual(len(rows[1]), len(DOCUMENTED_COLUMNS))
+
+    def test_the_csv_writer_quotes_a_fingerprint_that_holds_a_comma(self):
+        stream = io.StringIO()
+        writer = CsvWriter(stream)
+        writer.write(
+            FingerprintResult(
+                type="ja4h",
+                fingerprint="ge11nr08enus_dacf082e1695_000000000000_000000000000",
+                raw_original_order="ge11nr08enus_Host,User-Agent,Accept_",
+            )
+        )
+        text = stream.getvalue()
+        self.assertIn('"ge11nr08enus_Host,User-Agent,Accept_"', text)
+        row = csv_rows(text)[0]
+        self.assertEqual(
+            row[DOCUMENTED_COLUMNS.index("raw_original_order")],
+            "ge11nr08enus_Host,User-Agent,Accept_",
+        )
+
+
+class TheJsonLinesObject(unittest.TestCase):
+    def test_the_json_format_writes_one_object_per_line(self):
+        out, err, code = run_cli("--format", "json", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0, f"the command exited with {code}. stderr: {err}")
+        lines = [line for line in out.splitlines() if line.strip()]
+        self.assertGreater(len(lines), 1, "the capture produces fewer than two records")
+        for line in lines:
+            parsed = json.loads(line)
+            self.assertIsInstance(parsed, dict)
+
+    def test_every_json_object_holds_every_documented_field(self):
+        out, _, code = run_cli("--format", "json", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0)
+        records = json_records(out)
+        self.assertGreater(len(records), 0)
+        for record in records:
+            self.assertEqual(set(record), DOCUMENTED_FIELDS)
+
+    def test_the_json_object_holds_the_source_port_as_a_number(self):
+        """`--format json | jq -e '.src_port'` succeeds only for a present, true value."""
+        out, _, code = run_cli("--format", "json", "--types", "ja4t", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0)
+        record = json_records(out)[0]
+        self.assertEqual(record["src_ip"], "145.254.160.237")
+        self.assertEqual(record["src_port"], 3372)
+        self.assertEqual(record["dst_ip"], "65.208.228.223")
+        self.assertEqual(record["dst_port"], 80)
+        self.assertIsInstance(record["src_port"], int)
+
+    def test_the_json_object_holds_no_composite_source_field(self):
+        out, _, code = run_cli("--format", "json", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0)
+        for record in json_records(out):
+            self.assertNotIn("source", record)
+            self.assertNotIn("->", record["src_ip"])
+
+    def test_a_field_with_no_value_is_null_rather_than_absent(self):
+        stream = io.StringIO()
+        JsonLinesWriter(stream).write(
+            FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_0")
+        )
+        record = json.loads(stream.getvalue())
+        self.assertEqual(set(record), DOCUMENTED_FIELDS)
+        self.assertIsNone(record["raw"])
+        self.assertIsNone(record["raw_original_order"])
+        self.assertIsNone(record["timestamp"])
+        self.assertIsNone(record["identified_as"])
+
+    def test_the_json_object_holds_the_identified_name_that_the_lookup_returned(self):
+        stream = io.StringIO()
+        JsonLinesWriter(stream).write(
+            FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_0"),
+            identified_as="Test Application",
+        )
+        self.assertEqual(json.loads(stream.getvalue())["identified_as"], "Test Application")
+
+
+class TheTimestamp(unittest.TestCase):
+    def test_the_writer_states_the_timestamp_in_rfc_3339_form(self):
+        stream = io.StringIO()
+        JsonLinesWriter(stream).write(
+            FingerprintResult(
+                type="ja4t",
+                fingerprint="8760_2-1-1-4_1460_0",
+                timestamp=datetime(2026, 8, 6, 12, 34, 56, 789012, tzinfo=timezone.utc),
+            )
+        )
+        self.assertEqual(json.loads(stream.getvalue())["timestamp"], "2026-08-06T12:34:56.789012Z")
+
+    def test_the_record_carries_the_timestamp_of_the_packet_that_made_it(self):
+        out, _, code = run_cli("--format", "json", "--types", "ja4t", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0)
+        # The first packet of `http.cap` carries the epoch time 1084443427.311224.
+        self.assertEqual(json_records(out)[0]["timestamp"], "2004-05-13T10:17:07.311224Z")
+
+
+class TheEndpointReaders(unittest.TestCase):
+    """`ja4plus/cli.py` reads the four endpoint values from a packet or a window key."""
+
+    def test_the_reader_returns_the_four_values_of_an_ipv4_tcp_packet(self):
+        from scapy.all import IP, TCP
+
+        from ja4plus.cli import _packet_endpoints
+
+        packet = IP(src="1.2.3.4", dst="5.6.7.8") / TCP(sport=54321, dport=443)
+        self.assertEqual(_packet_endpoints(packet), ("1.2.3.4", 54321, "5.6.7.8", 443))
+
+    def test_the_reader_returns_the_four_values_of_an_ipv6_udp_packet(self):
+        from scapy.all import IPv6, UDP
+
+        from ja4plus.cli import _packet_endpoints
+
+        packet = IPv6(src="2001:db8::1", dst="2001:db8::2") / UDP(sport=443, dport=54321)
+        self.assertEqual(_packet_endpoints(packet), ("2001:db8::1", 443, "2001:db8::2", 54321))
+
+    def test_the_reader_returns_the_port_zero_for_a_packet_that_carries_no_port(self):
+        from scapy.all import IP
+
+        from ja4plus.cli import _packet_endpoints
+
+        self.assertEqual(
+            _packet_endpoints(IP(src="1.2.3.4", dst="5.6.7.8")), ("1.2.3.4", 0, "5.6.7.8", 0)
+        )
+
+    def test_the_reader_splits_a_connection_key_that_holds_ipv4_addresses(self):
+        from ja4plus.cli import _endpoints_from_connection
+
+        self.assertEqual(
+            _endpoints_from_connection("172.16.225.48:57377-54.160.114.75:22"),
+            ("172.16.225.48", 57377, "54.160.114.75", 22),
+        )
+
+    def test_the_reader_splits_a_connection_key_that_holds_ipv6_addresses(self):
+        from ja4plus.cli import _endpoints_from_connection
+
+        self.assertEqual(
+            _endpoints_from_connection("2001:db8::1:22-2001:db8::2:57377"),
+            ("2001:db8::1", 22, "2001:db8::2", 57377),
+        )
+
+    def test_the_reader_returns_empty_values_for_a_connection_key_it_cannot_read(self):
+        from ja4plus.cli import _endpoints_from_connection
+
+        self.assertEqual(_endpoints_from_connection(""), ("", 0, "", 0))
+        self.assertEqual(_endpoints_from_connection("nothing"), ("", 0, "", 0))
+
+
+class TheTableFormat(unittest.TestCase):
+    def test_the_table_writes_the_endpoints_as_one_source_column(self):
+        stream = io.StringIO()
+        writer = TableWriter(stream)
+        writer.write_header()
+        writer.write(
+            FingerprintResult(
+                type="ja4t",
+                fingerprint="8760_2-1-1-4_1460_0",
+                src_ip="145.254.160.237",
+                src_port=3372,
+                dst_ip="65.208.228.223",
+                dst_port=80,
+            )
+        )
+        lines = stream.getvalue().splitlines()
+        self.assertIn("Source", lines[0])
+        self.assertIn("145.254.160.237:3372 -> 65.208.228.223:80", lines[2])
+        self.assertIn("8760_2-1-1-4_1460_0", lines[2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #16. Builds #49.

## What

`ja4plus/cli.py:123` wrote `{"source": ..., "type": ..., "fingerprint": ...}`, where
`source` packed both addresses and both ports into one string. Lines 128 to 134 added
`identified_as` only when the user passed `--lookup`, so the CSV header changed with the
command line. Both stop.

New module `ja4plus/output.py` holds one writer per format: `TableWriter`,
`JsonLinesWriter` and `CsvWriter`. Each writer reads a `FingerprintResult`, which Epic 4
shipped, and adds the two fields the command-line program owns: `schema_version` and
`identified_as`.

The fixed CSV column order:

```
schema_version,timestamp,type,fingerprint,raw,raw_original_order,src_ip,src_port,dst_ip,dst_port,identified_as
```

The JSON object carries the same eleven fields, and a field with no value is `null`
rather than absent.

## Why

- FR-structured-output-1 — every format carries the four endpoint values as separate
  fields.
- FR-structured-output-2 — the JSON format writes one object per line.
- FR-structured-output-4 — the CSV format writes the same columns whatever flags the
  user passed.
- FR-structured-output-5 — a column with no value is empty rather than absent.

## How tested

TDD. `tests/test_output_schema.py` came first and failed on the absent module
`ja4plus.output`, then the module made it pass. 23 tests cover the header, the column
count, the separate endpoint columns, the empty column, the null field, the CSV quoting
of a value that holds a comma, the RFC 3339 timestamp and the four endpoint readers.

Five gates, all green in the worktree:

```
.venv/bin/pytest tests/ -m "not spec_validation"   1727 passed, 8 xfailed
.venv/bin/pytest tests/ -m spec_validation         1477 passed, 143 skipped, 137 xfailed
.venv/bin/ruff check ja4plus/ tests/               All checks passed
.venv/bin/ruff format --check ja4plus/ tests/      139 files already formatted
.venv/bin/mypy --strict ja4plus/                   Success: no issues found in 29 source files
```

The conformance suite is identical to the base branch `epic/16-structured-output` at
`92fcc98`, measured before the first edit: **1477 passed, 143 skipped, 137 xfailed**.

Coverage rose. `ja4plus/cli.py` 60% to 62%, new `ja4plus/output.py` 93%, total 86.6% to
87.3%.

## Behaviour this change alters, beyond the acceptance criteria

Three items a reviewer should confirm are wanted. None is a new decision; each follows
from the requirements above.

1. **`identified_as` is now present without `--lookup`, as `null`.**
   FR-structured-output-5 asks for a present, null field. `tests/test_ja4db.py`
   asserted the opposite for version 0.6.0, so this change reverses that assertion.
2. **The `cert` subcommand no longer shows the file name in the source column.** A
   certificate carries no address, no port and no packet time, so the record holds the
   empty address, the port zero and no time. The table row therefore reads `unknown`.
   FR-structured-output-7 gives the table no stability promise.
3. **The table header no longer gains an `Identified As` column under `--lookup`.** The
   row still carries the name in brackets, and the mockup shows the same fixed
   three-column table header.

## Scope

- `schema_version` — this change writes the column and decides nothing about the rule.
  The value `1` is not invented here: the behaviour rules of
  `docs/specs/features/05-structured-output.md` state "The schema version starts at 1",
  and the acceptance criteria of #50 state `"schema_version": 1`. #50 owns the rule that
  raises it and the document that records it, so no test here asserts the value.
- `docs/output-schema.md` — #50 owns it. This change updates `README.md` and
  `CHANGELOG.md` only.
- `Processor` — #51 owns the move from the fingerprinter dictionary, and #51 owns the
  fingerprinter error diagnostic. The `except Exception: continue` of
  `_fingerprint_one_packet` carries a comment that names #51.
- `--output`, the standard error split and `BrokenPipeError` — #52 owns all three.
- No fingerprinter changed, and no fingerprint moved.
- `ja4plus/__init__.py` `__all__` is untouched. `ja4plus/output.py` serves the
  command-line program and states its own module `__all__`.

## Changelog

`CHANGELOG.md` carries the entry under `## [Unreleased]`, round `TBD`.

## Verified against

- `docs/specs/features/05-structured-output.md` (this repository, at `92fcc98`) — the
  column order, the field set and the behaviour rules.
- `docs/specs/mockups/01-cli-output.html` (this repository, at `92fcc98`) — the RFC 3339
  timestamp form and the table layout. Guidance, not a contract.
- https://scapy.readthedocs.io/en/latest/api/scapy.packet.html (scapy 2.6, retrieved
  2026-08-08) — `Packet.time` holds a decimal count of seconds from the epoch.

## Self-review

I ran the correctness, security and interface lenses myself rather than spawning review
children. Three findings, all fixed before this pull request:

1. The first draft of `_endpoints_from_connection` split on the last colon of the whole
   key, which broke an IPv6 key. It now partitions on the first hyphen, then reads the
   port from the last colon of each half. Two tests cover IPv4 and IPv6 keys.
2. The IPv6 branch of `_packet_endpoints` changed from `IPv6 as IPv6Layer` to `IPv6`,
   and no test reached it. I measured the branch with a real scapy packet, then added
   `test_the_reader_returns_the_four_values_of_an_ipv6_udp_packet`.
3. `test_the_csv_header_is_identical_with_and_without_lookup` compares two runs, and it
   would pass if `--lookup` silently did nothing. I added
   `test_lookup_changes_the_identified_as_value_and_no_other_column`, which proves the
   second run really identified a fingerprint.

The `--lookup` tests use a stub client. The real `JA4DBClient` falls back to `ja4db.com`,
and a test must reach no network.
