### PR TITLE
Record the output schema and hold its version rule (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,17 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   same. A new column appends to the end of the row and raises no version.
   `TheSchemaDocument` parses the page and compares its field table against the written
   CSV header and the written JSON object, so the page and the code cannot drift apart.
-  **Seven mutations each make the file fail**, measured on 2026-08-08: a swap of two CSV
-  columns fails 6 cases, an appended column fails 4, a dropped JSON field fails 4, a
-  raise of `SCHEMA_VERSION` with no history entry fails 4, a renamed column in the page
-  alone fails 3, a changed stability promise fails 1, and a deleted rule sentence fails
-  1. **The `json` and `csv` formats carry the stability promise, and the `table` format
+  Two further cases read the value of each field, because a swap of two values changes
+  the meaning of both fields and moves no name. **Ten mutations each make the file
+  fail**, measured on 2026-08-08 against a baseline of 41 passed: a swap of two CSV
+  columns fails 7 cases, an appended column fails 4, a dropped JSON field fails 5, a
+  raise of `SCHEMA_VERSION` with no history entry fails 6, a renamed column in the page
+  alone fails 3, a changed stability promise fails 1, a deleted rule sentence fails 1, a
+  swap of two JSON values fails 1, a swap of two CSV values fails 2, and a write of
+  `src_port` into `dst_port` fails 2. The appended column is the case that proves the
+  rule: it fails the page checks, because a new field must be documented, and it leaves
+  the version checks green, because a new field raises no version.
+  **The `json` and `csv` formats carry the stability promise, and the `table` format
   carries none**, which the page states and a check reads back. The page records that
   `ja4`, `ja4s`, `ja4h` and `ja4x` write a raw form and the other six methods write
   `null`; `ja4x` now writes `JA4X_r`, which #267 added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,23 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The output schema carries a version, and `docs/output-schema.md` records it** (#50).
+  Round TBD. The new page states the schema version, the eleven fields, the raw form
+  each of the ten methods writes, and the rule that raises the version. **The rule is a
+  check and not prose alone.** `SCHEMA_HISTORY` in `tests/test_output_schema.py` freezes
+  the column list of each released version, and `TheSchemaVersionRule` fails when a
+  released column moves, changes name or goes away while `SCHEMA_VERSION` stays the
+  same. A new column appends to the end of the row and raises no version.
+  `TheSchemaDocument` parses the page and compares its field table against the written
+  CSV header and the written JSON object, so the page and the code cannot drift apart.
+  **Seven mutations each make the file fail**, measured on 2026-08-08: a swap of two CSV
+  columns fails 6 cases, an appended column fails 4, a dropped JSON field fails 4, a
+  raise of `SCHEMA_VERSION` with no history entry fails 4, a renamed column in the page
+  alone fails 3, a changed stability promise fails 1, and a deleted rule sentence fails
+  1. **The `json` and `csv` formats carry the stability promise, and the `table` format
+  carries none**, which the page states and a check reads back. The page records that
+  `ja4`, `ja4s`, `ja4h` and `ja4x` write a raw form and the other six methods write
+  `null`; `ja4x` now writes `JA4X_r`, which #267 added.
 - **The package ships the `py.typed` marker and declares `__all__`** (#47). Round TBD.
   The new file `ja4plus/py.typed` follows PEP 561, and `pyproject.toml` ships it as
   package data. A caller who runs `mypy --strict` against their own code now resolves

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 - [Usage Guide](usage.md) - Detailed usage for each fingerprinter with examples
 - [API Reference](api_reference.md) - Classes, methods, and convenience functions
+- [Output Schema](output-schema.md) - The versioned schema of the `json` and `csv` formats
 - [Implementation Notes](implementation_notes.md) - Spec deviations and undocumented behaviors
 
 ## Quick Links

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -1,0 +1,115 @@
+# The output schema
+
+The command-line program writes one record for each fingerprint it produces. This page
+records the schema of that record and the version of that schema. A downstream tool
+reads this page to learn what it may rely on.
+
+`docs/specs/features/05-structured-output.md` defines the feature.
+`ja4plus/output.py` writes the records, and `tests/test_output_schema.py` reads this
+page back and compares it against the written record.
+
+**The current schema version is 1.**
+
+## The version rule
+
+The rule holds three parts:
+
+- The schema version rises when a field goes away or its meaning changes.
+- A new field raises no version.
+- A new CSV column appends to the end of the row.
+
+A JSON object omits no field, and a field with no value is `null`. A CSV row holds one
+value for each column, and a column with no value is empty. The record therefore holds
+the same field set whatever options the user passed. `--lookup` changes the value of
+`identified_as` and no other part of the record.
+
+`tests/test_output_schema.py` holds the rule as a check. `SCHEMA_HISTORY` in that file
+records the column list of each released version. The check fails when a released
+column moves, changes name or goes away while `SCHEMA_VERSION` stays the same.
+
+## How a parser reads the version
+
+A parser reads `schema_version` first. A parser that understands version 1 accepts a
+record whose `schema_version` is 1, and rejects a record whose `schema_version` is
+above 1. A parser reads a field by name in the JSON format, and by the position of the
+header name in the CSV format. A parser that ignores a field it does not know keeps
+working when this project appends one.
+
+## Stability
+
+| Format | Stability promise | Who reads it |
+|---|---|---|
+| `json` | Yes | A tool. The format writes one JSON object on each line. |
+| `csv` | Yes | A spreadsheet or a database. The column order is fixed. |
+| `table` | No | A person at a terminal. The layout may change in any release. |
+
+The `table` format carries no stability promise, and it writes no `schema_version`. It
+packs the four endpoint values into one `Source` column for a person to read. A tool
+reads the `json` format or the `csv` format instead.
+
+## Fields
+
+The record holds eleven fields. The CSV format writes them as eleven columns in this
+order, and the JSON format writes them as eleven keys.
+
+| Position | Field | JSON type | Empty value | Meaning |
+|---|---|---|---|---|
+| 1 | `schema_version` | number | Never empty | The version of this schema. It is `1`. |
+| 2 | `timestamp` | string or null | `null` | The time of the packet that produced the fingerprint, in RFC 3339 form with the suffix `Z`. |
+| 3 | `type` | string | Never empty | The method name in lowercase, for example `ja4` or `ja4ssh`. |
+| 4 | `fingerprint` | string | Never empty | The fingerprint string of that method. |
+| 5 | `raw` | string or null | `null` | The raw form, when the method writes one. |
+| 6 | `raw_original_order` | string or null | `null` | The original-order raw form, when the method writes one. |
+| 7 | `src_ip` | string | `""` | The source address of the packet or the connection. |
+| 8 | `src_port` | number | `0` | The source port. It is `0` when the packet carries no port. |
+| 9 | `dst_ip` | string | `""` | The destination address. |
+| 10 | `dst_port` | number | `0` | The destination port. It is `0` when the packet carries no port. |
+| 11 | `identified_as` | string or null | `null` | The application name the lookup returned. It is `null` without `--lookup`, and `null` when the lookup finds no match. |
+
+The CSV format writes an empty column where the JSON format writes `null`. The CSV
+format writes `0` where the JSON format writes the number `0`.
+
+Fields 2 through 10 carry the names of `FingerprintResult`, which carries the names of
+the `ja4plus-go` struct under parity rule 2. `schema_version` and `identified_as`
+belong to the command-line program, and the library result carries neither.
+
+## The raw forms
+
+Four of the ten methods write a raw form. The other six write `null` in both raw
+fields.
+
+| Method | `raw` | `raw_original_order` |
+|---|---|---|
+| `ja4` | The `JA4_r` value. | The `JA4_ro` value. |
+| `ja4s` | The `JA4S_r` value. | The `JA4S_r` value. |
+| `ja4h` | `null` | The `JA4H_ro` value. |
+| `ja4x` | The `JA4X_r` value. | The `JA4X_r` value. |
+| `ja4t`, `ja4ts`, `ja4l`, `ja4ssh`, `ja4d`, `ja4d6` | `null` | `null` |
+
+JA4S and JA4X sort no list, so one value serves both raw fields. JA4H writes no `JA4H_r`
+value, so its `raw` field is always `null`.
+
+## An example JSON record
+
+```json
+{"schema_version": 1, "timestamp": "2004-05-13T10:17:08.222534Z", "type": "ja4h", "fingerprint": "ge11nr08enus_dacf082e1695_000000000000_000000000000", "raw": null, "raw_original_order": "ge11nr08enus_Host,User-Agent,Accept,Accept-Language,Accept-Encoding,Accept-Charset,Keep-Alive,Connection_", "src_ip": "145.254.160.237", "src_port": 3372, "dst_ip": "65.208.228.223", "dst_port": 80, "identified_as": null}
+```
+
+The `json` format writes one object on each line. The output is no JSON array, so a
+reader parses each line on its own.
+
+## An example CSV file
+
+```
+schema_version,timestamp,type,fingerprint,raw,raw_original_order,src_ip,src_port,dst_ip,dst_port,identified_as
+1,2004-05-13T10:17:07.311224Z,ja4t,8760_2-1-1-4_1460_00,,,145.254.160.237,3372,65.208.228.223,80,
+```
+
+The writer quotes a value that holds a comma. The `raw_original_order` value of JA4H
+holds commas, so the writer quotes it.
+
+## The history of the schema
+
+| Version | Release | What changed |
+|---|---|---|
+| 1 | Unreleased | The first published schema. It holds the eleven fields above. |

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -1,12 +1,12 @@
 # The output schema
 
-The command-line program writes one record for each fingerprint it produces. This page
-records the schema of that record and the version of that schema. A downstream tool
+The command-line program writes one output line for each fingerprint it produces. This
+page records the schema of that line and the version of that schema. A downstream tool
 reads this page to learn what it may rely on.
 
 `docs/specs/features/05-structured-output.md` defines the feature.
-`ja4plus/output.py` writes the records, and `tests/test_output_schema.py` reads this
-page back and compares it against the written record.
+`ja4plus/output.py` writes the output lines, and `tests/test_output_schema.py` reads
+this page back and compares it against the written output line.
 
 **The current schema version is 1.**
 
@@ -19,9 +19,9 @@ The rule holds three parts:
 - A new CSV column appends to the end of the row.
 
 A JSON object omits no field, and a field with no value is `null`. A CSV row holds one
-value for each column, and a column with no value is empty. The record therefore holds
-the same field set whatever options the user passed. `--lookup` changes the value of
-`identified_as` and no other part of the record.
+value for each column, and a column with no value is empty. The output line therefore
+holds the same field set whatever options the user passed. `--lookup` changes the value
+of `identified_as` and no other part of the line.
 
 `tests/test_output_schema.py` holds the rule as a check. `SCHEMA_HISTORY` in that file
 records the column list of each released version. The check fails when a released
@@ -29,11 +29,11 @@ column moves, changes name or goes away while `SCHEMA_VERSION` stays the same.
 
 ## How a parser reads the version
 
-A parser reads `schema_version` first. A parser that understands version 1 accepts a
-record whose `schema_version` is 1, and rejects a record whose `schema_version` is
+A parser reads `schema_version` first. A parser that understands version 1 accepts an
+output line whose `schema_version` is 1, and rejects a line whose `schema_version` is
 above 1. A parser reads a field by name in the JSON format, and by the position of the
-header name in the CSV format. A parser that ignores a field it does not know keeps
-working when this project appends one.
+header name in the CSV format. When this project appends a field, a parser that ignores
+an unknown field keeps working.
 
 ## Stability
 
@@ -49,8 +49,8 @@ reads the `json` format or the `csv` format instead.
 
 ## Fields
 
-The record holds eleven fields. The CSV format writes them as eleven columns in this
-order, and the JSON format writes them as eleven keys.
+The output line holds eleven fields. The CSV format writes them as eleven columns in
+this order, and the JSON format writes them as eleven keys.
 
 | Position | Field | JSON type | Empty value | Meaning |
 |---|---|---|---|---|
@@ -75,8 +75,9 @@ belong to the command-line program, and the library result carries neither.
 
 ## The raw forms
 
-Four of the ten methods write a raw form. The other six write `null` in both raw
-fields.
+Four of the ten methods write a value into a raw field. The other six write `null` into
+both raw fields. JA4H writes a value into one raw field and `null` into the other, so
+read the table for the exact behaviour of each method.
 
 | Method | `raw` | `raw_original_order` |
 |---|---|---|
@@ -89,7 +90,7 @@ fields.
 JA4S and JA4X sort no list, so one value serves both raw fields. JA4H writes no `JA4H_r`
 value, so its `raw` field is always `null`.
 
-## An example JSON record
+## An example JSON object
 
 ```json
 {"schema_version": 1, "timestamp": "2004-05-13T10:17:08.222534Z", "type": "ja4h", "fingerprint": "ge11nr08enus_dacf082e1695_000000000000_000000000000", "raw": null, "raw_original_order": "ge11nr08enus_Host,User-Agent,Accept,Accept-Language,Accept-Encoding,Accept-Charset,Keep-Alive,Connection_", "src_ip": "145.254.160.237", "src_port": 3372, "dst_ip": "65.208.228.223", "dst_port": 80, "identified_as": null}

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -206,7 +206,7 @@ class TheCsvHeader(unittest.TestCase):
             "--lookup",
             "analyze",
             HTTP_CAP,
-            lookup_client=StubLookupClient({"8760_2-1-1-4_1460_0": "Test Application"}),
+            lookup_client=StubLookupClient({"8760_2-1-1-4_1460_00": "Test Application"}),
         )
         self.assertEqual(plain_code, 0)
         self.assertEqual(lookup_code, 0)
@@ -220,7 +220,7 @@ class TheCsvHeader(unittest.TestCase):
             "--lookup",
             "analyze",
             HTTP_CAP,
-            lookup_client=StubLookupClient({"8760_2-1-1-4_1460_0": "Test Application"}),
+            lookup_client=StubLookupClient({"8760_2-1-1-4_1460_00": "Test Application"}),
         )
         self.assertEqual(code, 0)
         rows = csv_rows(looked_up)
@@ -249,13 +249,13 @@ class TheCsvRows(unittest.TestCase):
         self.assertEqual(row["dst_ip"], "65.208.228.223")
         self.assertEqual(row["dst_port"], "80")
         self.assertEqual(row["type"], "ja4t")
-        self.assertEqual(row["fingerprint"], "8760_2-1-1-4_1460_0")
+        self.assertEqual(row["fingerprint"], "8760_2-1-1-4_1460_00")
 
     def test_a_column_with_no_value_is_empty_rather_than_absent(self):
         stream = io.StringIO()
         writer = CsvWriter(stream)
         writer.write_header()
-        writer.write(FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_0"))
+        writer.write(FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_00"))
         rows = csv_rows(stream.getvalue())
         row = dict(zip(rows[0], rows[1]))
         self.assertEqual(row["raw"], "")
@@ -322,7 +322,7 @@ class TheJsonLinesObject(unittest.TestCase):
     def test_a_field_with_no_value_is_null_rather_than_absent(self):
         stream = io.StringIO()
         JsonLinesWriter(stream).write(
-            FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_0")
+            FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_00")
         )
         record = json.loads(stream.getvalue())
         self.assertEqual(set(record), DOCUMENTED_FIELDS)
@@ -334,7 +334,7 @@ class TheJsonLinesObject(unittest.TestCase):
     def test_the_json_object_holds_the_identified_name_that_the_lookup_returned(self):
         stream = io.StringIO()
         JsonLinesWriter(stream).write(
-            FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_0"),
+            FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_00"),
             identified_as="Test Application",
         )
         self.assertEqual(json.loads(stream.getvalue())["identified_as"], "Test Application")
@@ -346,7 +346,7 @@ class TheTimestamp(unittest.TestCase):
         JsonLinesWriter(stream).write(
             FingerprintResult(
                 type="ja4t",
-                fingerprint="8760_2-1-1-4_1460_0",
+                fingerprint="8760_2-1-1-4_1460_00",
                 timestamp=datetime(2026, 8, 6, 12, 34, 56, 789012, tzinfo=timezone.utc),
             )
         )
@@ -418,7 +418,7 @@ class TheTableFormat(unittest.TestCase):
         writer.write(
             FingerprintResult(
                 type="ja4t",
-                fingerprint="8760_2-1-1-4_1460_0",
+                fingerprint="8760_2-1-1-4_1460_00",
                 src_ip="145.254.160.237",
                 src_port=3372,
                 dst_ip="65.208.228.223",
@@ -428,7 +428,7 @@ class TheTableFormat(unittest.TestCase):
         lines = stream.getvalue().splitlines()
         self.assertIn("Source", lines[0])
         self.assertIn("145.254.160.237:3372 -> 65.208.228.223:80", lines[2])
-        self.assertIn("8760_2-1-1-4_1460_0", lines[2])
+        self.assertIn("8760_2-1-1-4_1460_00", lines[2])
 
 
 class TheSchemaVersion(unittest.TestCase):

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -9,16 +9,19 @@ import csv
 import io
 import json
 import os
+import re
 import unittest
 from contextlib import ExitStack
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-from ja4plus.output import CSV_COLUMNS, CsvWriter, JsonLinesWriter, TableWriter
+from ja4plus.output import CSV_COLUMNS, SCHEMA_VERSION, CsvWriter, JsonLinesWriter, TableWriter
 from ja4plus.types import FingerprintResult
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 HTTP_CAP = os.path.join(DATA_DIR, "http.cap")
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCHEMA_DOC = os.path.join(REPO_ROOT, "docs", "output-schema.md")
 
 # `docs/specs/features/05-structured-output.md` states this order, and the mockup
 # `docs/specs/mockups/01-cli-output.html` repeats it. The test holds its own copy, so a
@@ -40,6 +43,89 @@ DOCUMENTED_COLUMNS = [
 # The JSON object carries one field for each CSV column. FR-structured-output-5 asks for
 # a value that is present and null rather than absent.
 DOCUMENTED_FIELDS = set(DOCUMENTED_COLUMNS)
+
+# The frozen record of what each schema version published. #50 owns it. A released
+# version never loses an entry here, because the entry is the evidence a downstream
+# parser relies on. Add a key when the version rises, and change no key that exists.
+SCHEMA_HISTORY = {
+    1: [
+        "schema_version",
+        "timestamp",
+        "type",
+        "fingerprint",
+        "raw",
+        "raw_original_order",
+        "src_ip",
+        "src_port",
+        "dst_ip",
+        "dst_port",
+        "identified_as",
+    ],
+}
+
+
+def released_columns(version):
+    """Return the columns of the newest released version at or below the version.
+
+    Args:
+        version: The schema version the module writes.
+
+    Returns:
+        The frozen column list of that version, or of the highest recorded version
+        below it when `SCHEMA_HISTORY` holds no entry for it.
+    """
+    recorded = [key for key in SCHEMA_HISTORY if key <= version]
+    return SCHEMA_HISTORY[max(recorded)]
+
+
+def schema_document():
+    """Return the text of `docs/output-schema.md`.
+
+    Returns:
+        The whole file as one string.
+
+    Raises:
+        AssertionError: The file does not exist. FR-structured-output-13 requires it.
+    """
+    assert os.path.exists(SCHEMA_DOC), f"{SCHEMA_DOC} does not exist"
+    with open(SCHEMA_DOC, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def document_table(heading):
+    """Return the rows of the first Markdown table below the heading.
+
+    The document is the contract a downstream parser reads, so a test reads it back
+    rather than trusting a constant that the same commit could change.
+
+    Args:
+        heading: The exact heading line, for example `## Fields`.
+
+    Returns:
+        A list of rows. Each row is a list of the stripped cell values, and the header
+        row and the rule row of the table are removed.
+
+    Raises:
+        AssertionError: The document holds no such heading, or no table below it.
+    """
+    text = schema_document()
+    assert heading in text, f"the document holds no heading {heading!r}"
+    body = text.split(heading, 1)[1]
+    rows = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("|"):
+            rows.append([cell.strip() for cell in stripped.strip("|").split("|")])
+        elif rows:
+            break
+    assert len(rows) > 2, f"the section {heading!r} holds no table"
+    # Row 0 names the columns and row 1 is the rule of dashes.
+    return rows[2:]
+
+
+def documented_columns():
+    """Return the field names the document lists, in the order it lists them."""
+    return [row[1].strip("`") for row in document_table("## Fields")]
 
 
 class StubLookupClient:
@@ -343,6 +429,132 @@ class TheTableFormat(unittest.TestCase):
         self.assertIn("Source", lines[0])
         self.assertIn("145.254.160.237:3372 -> 65.208.228.223:80", lines[2])
         self.assertIn("8760_2-1-1-4_1460_0", lines[2])
+
+
+class TheSchemaVersion(unittest.TestCase):
+    """#50 owns the rule that raises the schema version."""
+
+    def test_the_module_writes_the_schema_version_the_specification_states(self):
+        self.assertEqual(SCHEMA_VERSION, 1)
+
+    def test_every_json_object_holds_the_schema_version(self):
+        out, err, code = run_cli("--format", "json", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0, f"the command exited with {code}. stderr: {err}")
+        records = json_records(out)
+        self.assertGreater(len(records), 0)
+        for record in records:
+            self.assertEqual(record["schema_version"], SCHEMA_VERSION)
+
+    def test_every_csv_row_holds_the_schema_version(self):
+        out, err, code = run_cli("--format", "csv", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0, f"the command exited with {code}. stderr: {err}")
+        rows = csv_rows(out)
+        self.assertGreater(len(rows), 1, "the capture produces no data row")
+        column = rows[0].index("schema_version")
+        for row in rows[1:]:
+            self.assertEqual(row[column], str(SCHEMA_VERSION))
+
+    def test_the_table_format_writes_no_schema_version(self):
+        """FR-structured-output-7 gives the table format no stability promise."""
+        stream = io.StringIO()
+        writer = TableWriter(stream)
+        writer.write_header()
+        writer.write(FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_00"))
+        self.assertNotIn("schema_version", stream.getvalue())
+
+
+class TheSchemaVersionRule(unittest.TestCase):
+    """The rule of `docs/output-schema.md`, held so that a change of the schema fails.
+
+    A new column appends to the end and raises no version. A removal, a rename or an
+    insertion moves a released column, and it raises the version.
+    """
+
+    def test_a_released_column_keeps_its_position_until_the_version_rises(self):
+        released = released_columns(SCHEMA_VERSION)
+        current = list(CSV_COLUMNS)
+        prefix_holds = current[: len(released)] == released
+        self.assertTrue(
+            prefix_holds or SCHEMA_VERSION > max(SCHEMA_HISTORY),
+            "a released column moved, changed name or went away. Append a new column to "
+            "the end of CSV_COLUMNS, or raise SCHEMA_VERSION and record the new version "
+            f"in SCHEMA_HISTORY. released={released} current={current}",
+        )
+
+    def test_a_released_field_stays_in_the_json_object_until_the_version_rises(self):
+        stream = io.StringIO()
+        JsonLinesWriter(stream).write(
+            FingerprintResult(type="ja4t", fingerprint="8760_2-1-1-4_1460_00")
+        )
+        present = set(json.loads(stream.getvalue()))
+        released = set(released_columns(SCHEMA_VERSION))
+        self.assertTrue(
+            released <= present or SCHEMA_VERSION > max(SCHEMA_HISTORY),
+            f"the JSON object lost the released fields {sorted(released - present)}. "
+            "Raise SCHEMA_VERSION and record the new version in SCHEMA_HISTORY.",
+        )
+
+    def test_the_history_records_the_version_the_module_writes(self):
+        self.assertIn(
+            SCHEMA_VERSION,
+            SCHEMA_HISTORY,
+            "SCHEMA_VERSION rose and SCHEMA_HISTORY records no column list for it",
+        )
+
+    def test_the_history_holds_no_version_above_the_version_the_module_writes(self):
+        self.assertEqual(max(SCHEMA_HISTORY), SCHEMA_VERSION)
+
+
+class TheSchemaDocument(unittest.TestCase):
+    """FR-structured-output-13 asks the documentation to record the schema."""
+
+    def test_the_repository_holds_the_schema_document(self):
+        self.assertTrue(os.path.exists(SCHEMA_DOC), f"{SCHEMA_DOC} does not exist")
+
+    def test_the_document_lists_every_column_in_the_written_order(self):
+        self.assertEqual(documented_columns(), list(CSV_COLUMNS))
+
+    def test_the_csv_header_matches_the_documented_column_list(self):
+        """The acceptance criterion of #50, read from the document rather than a constant."""
+        out, err, code = run_cli("--format", "csv", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0, f"the command exited with {code}. stderr: {err}")
+        self.assertEqual(csv_rows(out)[0], documented_columns())
+
+    def test_the_json_object_holds_exactly_the_documented_fields(self):
+        out, _, code = run_cli("--format", "json", "analyze", HTTP_CAP)
+        self.assertEqual(code, 0)
+        records = json_records(out)
+        self.assertGreater(len(records), 0)
+        for record in records:
+            self.assertEqual(list(record), documented_columns())
+
+    def test_the_document_describes_every_field(self):
+        for row in document_table("## Fields"):
+            field = row[1]
+            for cell in row:
+                self.assertNotEqual(cell, "", f"the row for {field} holds an empty cell")
+
+    def test_the_document_states_the_schema_version_the_module_writes(self):
+        match = re.search(r"The current schema version is (\d+)\.", schema_document())
+        self.assertIsNotNone(match, "the document states no current schema version")
+        self.assertEqual(int(match.group(1)), SCHEMA_VERSION)
+
+    def test_the_document_states_which_format_carries_a_stability_promise(self):
+        promises = {row[0].strip("`"): row[1] for row in document_table("## Stability")}
+        self.assertEqual(set(promises), {"json", "csv", "table"})
+        self.assertEqual(promises["json"], "Yes")
+        self.assertEqual(promises["csv"], "Yes")
+        self.assertEqual(promises["table"], "No")
+
+    def test_the_document_states_the_rule_that_raises_the_version(self):
+        text = schema_document()
+        for sentence in (
+            "The schema version rises when a field goes away or its meaning changes.",
+            "A new field raises no version.",
+            "A new CSV column appends to the end of the row.",
+            "A JSON object omits no field, and a field with no value is `null`.",
+        ):
+            self.assertIn(sentence, text, f"the document does not state: {sentence}")
 
 
 if __name__ == "__main__":

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -65,17 +65,19 @@ SCHEMA_HISTORY = {
 
 
 def released_columns(version):
-    """Return the columns of the newest released version at or below the version.
+    """Return the frozen column list of the schema version.
 
     Args:
         version: The schema version the module writes.
 
     Returns:
-        The frozen column list of that version, or of the highest recorded version
-        below it when `SCHEMA_HISTORY` holds no entry for it.
+        The column list `SCHEMA_HISTORY` records for that version.
+
+    Raises:
+        KeyError: `SCHEMA_HISTORY` records no list for that version.
+            `test_the_history_records_the_version_the_module_writes` names the cause.
     """
-    recorded = [key for key in SCHEMA_HISTORY if key <= version]
-    return SCHEMA_HISTORY[max(recorded)]
+    return SCHEMA_HISTORY[version]
 
 
 def schema_document():
@@ -109,8 +111,11 @@ def document_table(heading):
         AssertionError: The document holds no such heading, or no table below it.
     """
     text = schema_document()
-    assert heading in text, f"the document holds no heading {heading!r}"
-    body = text.split(heading, 1)[1]
+    # The match is one whole line, so a longer heading that starts with the same words
+    # selects no table. A substring match would read the wrong section.
+    anchor = f"\n{heading}\n"
+    assert text.count(anchor) == 1, f"the document holds no one heading line {heading!r}"
+    body = text.split(anchor, 1)[1]
     rows = []
     for line in body.splitlines():
         stripped = line.strip()
@@ -473,12 +478,12 @@ class TheSchemaVersionRule(unittest.TestCase):
     def test_a_released_column_keeps_its_position_until_the_version_rises(self):
         released = released_columns(SCHEMA_VERSION)
         current = list(CSV_COLUMNS)
-        prefix_holds = current[: len(released)] == released
-        self.assertTrue(
-            prefix_holds or SCHEMA_VERSION > max(SCHEMA_HISTORY),
+        self.assertEqual(
+            current[: len(released)],
+            released,
             "a released column moved, changed name or went away. Append a new column to "
             "the end of CSV_COLUMNS, or raise SCHEMA_VERSION and record the new version "
-            f"in SCHEMA_HISTORY. released={released} current={current}",
+            "in SCHEMA_HISTORY.",
         )
 
     def test_a_released_field_stays_in_the_json_object_until_the_version_rises(self):
@@ -488,11 +493,75 @@ class TheSchemaVersionRule(unittest.TestCase):
         )
         present = set(json.loads(stream.getvalue()))
         released = set(released_columns(SCHEMA_VERSION))
-        self.assertTrue(
-            released <= present or SCHEMA_VERSION > max(SCHEMA_HISTORY),
-            f"the JSON object lost the released fields {sorted(released - present)}. "
-            "Raise SCHEMA_VERSION and record the new version in SCHEMA_HISTORY.",
+        self.assertEqual(
+            released - present,
+            set(),
+            "the JSON object lost a released field. Raise SCHEMA_VERSION and record the "
+            "new version in SCHEMA_HISTORY.",
         )
+
+    def test_every_json_field_carries_the_value_of_the_field_it_names(self):
+        """A swap of two values changes the meaning of both fields and moves no name.
+
+        The name checks above read the keys alone, so a writer that put `raw` under
+        `raw_original_order` would pass them. This case reads the values.
+        """
+        result = FingerprintResult(
+            type="ja4",
+            fingerprint="t13d1516h2_8daaf6152771_02713d6af862",
+            raw="the raw value",
+            raw_original_order="the original order value",
+            src_ip="145.254.160.237",
+            src_port=3372,
+            dst_ip="65.208.228.223",
+            dst_port=80,
+            timestamp=datetime(2026, 8, 6, 12, 34, 56, 789012, tzinfo=timezone.utc),
+        )
+        stream = io.StringIO()
+        JsonLinesWriter(stream).write(result, identified_as="Test Application")
+        record = json.loads(stream.getvalue())
+        self.assertEqual(record["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(record["timestamp"], "2026-08-06T12:34:56.789012Z")
+        self.assertEqual(record["type"], result.type)
+        self.assertEqual(record["fingerprint"], result.fingerprint)
+        self.assertEqual(record["raw"], result.raw)
+        self.assertEqual(record["raw_original_order"], result.raw_original_order)
+        self.assertEqual(record["src_ip"], result.src_ip)
+        self.assertEqual(record["src_port"], result.src_port)
+        self.assertEqual(record["dst_ip"], result.dst_ip)
+        self.assertEqual(record["dst_port"], result.dst_port)
+        self.assertEqual(record["identified_as"], "Test Application")
+
+    def test_every_csv_column_carries_the_value_of_the_column_it_names(self):
+        """The CSV counterpart of the case above. A swap of two values fails here."""
+        result = FingerprintResult(
+            type="ja4",
+            fingerprint="t13d1516h2_8daaf6152771_02713d6af862",
+            raw="the raw value",
+            raw_original_order="the original order value",
+            src_ip="145.254.160.237",
+            src_port=3372,
+            dst_ip="65.208.228.223",
+            dst_port=80,
+            timestamp=datetime(2026, 8, 6, 12, 34, 56, 789012, tzinfo=timezone.utc),
+        )
+        stream = io.StringIO()
+        writer = CsvWriter(stream)
+        writer.write_header()
+        writer.write(result, identified_as="Test Application")
+        rows = csv_rows(stream.getvalue())
+        row = dict(zip(rows[0], rows[1]))
+        self.assertEqual(row["schema_version"], str(SCHEMA_VERSION))
+        self.assertEqual(row["timestamp"], "2026-08-06T12:34:56.789012Z")
+        self.assertEqual(row["type"], result.type)
+        self.assertEqual(row["fingerprint"], result.fingerprint)
+        self.assertEqual(row["raw"], result.raw)
+        self.assertEqual(row["raw_original_order"], result.raw_original_order)
+        self.assertEqual(row["src_ip"], result.src_ip)
+        self.assertEqual(row["src_port"], str(result.src_port))
+        self.assertEqual(row["dst_ip"], result.dst_ip)
+        self.assertEqual(row["dst_port"], str(result.dst_port))
+        self.assertEqual(row["identified_as"], "Test Application")
 
     def test_the_history_records_the_version_the_module_writes(self):
         self.assertIn(


### PR DESCRIPTION
Part of #16. Builds #50. Targets `epic/16-structured-output`. Every head commit carries `[skip ci]`.

## What this adds

New page `docs/output-schema.md`. It records the schema version, the eleven fields, the raw form each of the ten methods writes, the rule that raises the version, and which format carries a stability promise.

#49 wrote `SCHEMA_VERSION = 1` into `ja4plus/output.py` and asserted nothing about it. This pull request owns the rule, the page and the checks that hold both. **No file under `ja4plus/` changes.**

## The rule, stated so a check enforces it

The page states four sentences, and `TheSchemaDocument::test_the_document_states_the_rule_that_raises_the_version` reads each one back:

- The schema version rises when a field goes away or its meaning changes.
- A new field raises no version.
- A new CSV column appends to the end of the row.
- A JSON object omits no field, and a field with no value is `null`.

`SCHEMA_HISTORY` in `tests/test_output_schema.py` freezes the column list of each released version. `TheSchemaVersionRule::test_a_released_column_keeps_its_position_until_the_version_rises` requires the frozen list to stay a prefix of `CSV_COLUMNS` while `SCHEMA_VERSION` holds. An append passes. An insertion, a rename or a removal fails until the version rises and the history records the new list.

`TheSchemaDocument` parses the Markdown field table of the page and compares it against the written CSV header and the written JSON object. The page and the code therefore cannot drift apart.

## The comparison is proven by its reversal

Ten mutations, measured on 2026-08-08 in this worktree with the corrected harness. The baseline is `41 passed`.

| Mutation | Result |
|---|---|
| Swap `src_ip` and `src_port` in `CSV_COLUMNS` | 7 failed |
| Append `new_field` to `CSV_COLUMNS` | 4 failed, and the version rule stays green, which is the specified behaviour |
| Drop `raw_original_order` from the JSON object | 5 failed |
| Raise `SCHEMA_VERSION` to 2 with no history entry | 6 failed |
| Rename `src_ip` to `source_ip` in the page alone | 3 failed |
| Change the `csv` stability promise to `No` | 1 failed |
| Delete the sentence `A new field raises no version.` | 1 failed |
| Swap the JSON values of `raw` and `raw_original_order` | 1 failed |
| Swap the CSV values of `raw` and `raw_original_order` | 2 failed |
| Write `src_port` into `dst_port` | 2 failed |

The append case is the one that matters most: it fails the page checks, because a new field must be documented, and it passes the version checks, because a new field raises no version.

The last three cases exist because of the self-review. A swap of two values changes the meaning of both fields and moves no name, so the name checks alone passed it. See the review comment on this pull request.

**A warning for the next round that proves a gate by reversal here.** My first harness reported that a swap of two CSV columns left the suite green. The tests were right and the harness was wrong: the swap preserves the file size, the copy preserved the mtime, and Python reused a stale `.pyc`, so the mutated module never loaded. Every length-preserving mutation silently did nothing. The harness now clears `__pycache__` and sets `PYTHONDONTWRITEBYTECODE=1`.

## A correction to the base

**The base of this branch was red before the first commit.** `tests/test_output_schema.py` failed two cases at `50ec718`, and passed all 23 at `eeb96bf`. The merge of `dev` carried `f63265e Write the JA4T and JA4TS form the user decided (#300)` onto fixtures that #49 had pinned to the earlier JA4T form. D1 of that ruling gives a zero window scale the two-digit form, so `8760_2-1-1-4_1460_0` became `8760_2-1-1-4_1460_00`. This pull request corrects the stale literals. It decides nothing; the user already decided the form in #300.

## The schema this page describes is the schema the writers emit

The page describes what `ja4plus` writes today, read from the writers rather than from the earlier text. `ja4x` now writes `JA4X_r` into both raw fields, which #267 added and which the `dev` sync carried here. `ja4h` writes `JA4H_ro` into `raw_original_order` and `null` into `raw`, because it publishes no `JA4H_r` value. The other six methods write `null` in both.

## How this was tested

All five gates, run in a virtual environment in the worktree.

```
.venv/bin/pytest tests/ -m "not spec_validation"   1801 passed, 8 xfailed, 93 subtests passed
.venv/bin/pytest tests/ -m spec_validation         1531 passed, 143 skipped, 135 xfailed
.venv/bin/ruff check ja4plus/ tests/               All checks passed!
.venv/bin/ruff format --check ja4plus/ tests/      142 files already formatted
.venv/bin/mypy --strict ja4plus/                   Success: no issues found in 30 source files
```

The conformance suite is identical to the base, and the register invariant holds: `tests/foxio_deviations.json` holds 135 keys against 135 `xfailed` cases, before and after. The unit suite moves from `1781 passed, 2 failed` to `1801 passed`: 18 new cases, plus the two the base correction repairs.

Coverage holds at 88%. It cannot fall, because `git diff --stat origin/epic/16-structured-output -- ja4plus/` is empty.

The self-review found that `ja4plus/output.py` uses a noun the `## Terms` table forbids. That code is #49's and already merged, so #306 records it rather than this pull request changing it.

`CHANGELOG.md` carries `Round TBD`, per #302. The project manager assigns the round.

Verified against: `docs/specs/features/05-structured-output.md` (FR-structured-output-3, -7, -8, -13) and `.claude/rules/ste.md`, both read in this worktree on 2026-08-08.
