### PR TITLE
Record what a green conformance run does not measure

### DIFF
--- a/.claude/rules/conformance.md
+++ b/.claude/rules/conformance.md
@@ -62,6 +62,90 @@ method name plus an occurrence counter.
 method that emits more fingerprints than the reference is a defect, and so is one that
 emits fewer.
 
+## What a green conformance run does not measure
+
+**Warning: a green conformance run states nothing about the frame that carries a value.**
+The suite compares one value for each stream, and it never compares the packet that
+produced it. #736 measured the limit on 2026-08-16 and this section records it.
+
+**#606 moved seven values from one frame to another, and the suite discriminated none of
+them.** That issue moved the QUIC `JA4L-S` emission from the packet that fills point `B`
+to the packet that fills point `D`. #736 restored the point `B` emission and ran the suite
+again. The three counts held at 1676 passed, 142 skipped and 138 xfailed under the change
+and under the restored defect. These are the seven moves.
+
+| Capture | The move |
+|---|---|
+| `chrome-cloudflare-quic-with-secrets.pcapng` | 49 to 52 |
+| `ssh2.pcapng` | 1140 to 1147 |
+| `tls3.pcapng` | 144 to 147 |
+| `tls3.pcapng` | 149 to 153 |
+| `tls3.pcapng` | 155 to 162 |
+| `tls3.pcapng` | 159 to 167 |
+| `tls3.pcapng` | 303 to 312 |
+
+### One of the four reference sources states a frame
+
+**The conformance value comparison reads the one source that frames nothing.** A per-frame
+comparison is possible only where a source states the frame, and #736 read all four.
+
+| Source | States a frame | Values |
+|---|---|---|
+| FoxIO Python expected output, `tests/foxio_vectors/*.json` | No | 1203 |
+| FoxIO Rust snapshots, `tests/foxio_vectors/rust_expected/*.snap` | No | 460 |
+| Zeek baselines, `tests/foxio_vectors/zeek_expected/` | No | 7 baselines |
+| FoxIO Wireshark dissector, `tests/foxio_vectors/wireshark_expected/*.json` | Yes, `frame.number` | 724 |
+
+**The first three key a value on the stream or on the connection.** A Zeek baseline names
+`orig_pkts` and `resp_pkts`, and each one counts the packets of a connection rather than
+names one of them. **The dissector frames every value it writes**, and #736 measured 724
+framed values and none unframed across 26 files.
+
+**The conformance suite builds all 1203 of its value cases from the first source.** No case
+of the suite can read a frame, because the source it reads states none.
+
+### Why the suite compares no frame
+
+**The suite compares the FoxIO Python reference, and the dissector is a different source
+with a different value set.** A per-frame comparison would therefore be a new comparison
+against a new source, and it would add no discrimination to any case the suite runs today.
+#736 measured what that comparison would report, over the 445 dissector values of a hashed
+form on the 26 captures this project holds.
+
+| Reading | Values |
+|---|---|
+| The value agrees and the frame agrees | 206 |
+| The value agrees and the frame differs | 136 |
+| This project produces no such value | 103 |
+
+**The 136 frame disagreements are values this project already produces correctly**, so each
+one would enter `tests/foxio_deviations.json` as a new entry that records a difference this
+project has already ruled. The TCP `JA4L` and `JA4LS` values hold 70 of the 136: the
+dissector writes each one on a later frame than this project. **A comparison whose largest
+class is a recorded divergence measures the register and not the code.**
+
+**The frame is an artifact of one dissector, and the value is what the standard defines.**
+Two FoxIO implementations produce the same value on different packets, and neither one is
+wrong. This project therefore declines the per-frame comparison in the conformance suite.
+
+### Where the frame is measured instead
+
+**A frame this project rules on gets a case of its own.**
+`tests/test_ja4l_quic_point_d_emission.py` holds the frame of every QUIC `JA4L` value
+against `frame.number` of the dissector, and it runs in the unit suite. #736 restored the
+point `B` emission and measured 8 failures in that module, against 0 in the conformance
+suite.
+
+**Warning: leave that module in the unit suite, and never move it to the conformance
+suite.** The `test` job runs the unit suite on six environments and the `conformance` job
+runs the conformance suite on one. A move would therefore take five readings away from the
+one guard this project holds on a frame. #736 declined the move on that reading.
+
+**Warning: read a frame ruling against the unit suite, and never against the conformance
+counts.** `tests/test_conformance_frame_discrimination.py` holds this whole reading, so a
+source that starts to state a frame fails a case here rather than leaving a reader with a
+stale rule.
+
 ## When the FoxIO reference holds a defect
 
 The FoxIO reference decides behaviour. It does not decide behaviour that the reference

--- a/.claude/rules/conformance.md
+++ b/.claude/rules/conformance.md
@@ -106,11 +106,15 @@ of the suite can read a frame, because the source it reads states none.
 
 ### Why the suite compares no frame
 
-**The suite compares the FoxIO Python reference, and the dissector is a different source
-with a different value set.** A per-frame comparison would therefore be a new comparison
-against a new source, and it would add no discrimination to any case the suite runs today.
-#736 measured what that comparison would report, over the 445 dissector values of a hashed
-form on the 26 captures this project holds.
+**The suite compares the FoxIO Python reference, and the dissector holds a different value
+set.** A per-frame comparison reads a new source. It therefore adds no discrimination to
+any case the suite runs today.
+
+**#736 measured what that comparison would report on 2026-08-16.** The measurement ran the
+`Processor` over each of the 26 captures this project holds, it numbered each packet, and
+it read the 445 dissector values of a hashed form against the result. **Warning: the three
+counts below are one measurement, and no case holds them.** Take them again before you
+build on them.
 
 | Reading | Values |
 |---|---|
@@ -118,11 +122,13 @@ form on the 26 captures this project holds.
 | The value agrees and the frame differs | 136 |
 | This project produces no such value | 103 |
 
-**The 136 frame disagreements are values this project already produces correctly**, so each
-one would enter `tests/foxio_deviations.json` as a new entry that records a difference this
-project has already ruled. The TCP `JA4L` and `JA4LS` values hold 70 of the 136: the
-dissector writes each one on a later frame than this project. **A comparison whose largest
-class is a recorded divergence measures the register and not the code.**
+**The 136 frame disagreements are values this project already produces correctly.** Each
+one would enter `tests/foxio_deviations.json` as a new entry. Each entry would record a
+difference this project has already ruled.
+
+**The TCP `JA4L` and `JA4LS` values hold 70 of the 136.** The dissector writes each one on
+a later frame than this project, and none of the 70 is a QUIC value. **A comparison whose
+largest class is a recorded divergence measures the register and not the code.**
 
 **The frame is an artifact of one dissector, and the value is what the standard defines.**
 Two FoxIO implementations produce the same value on different packets, and neither one is
@@ -137,14 +143,21 @@ point `B` emission and measured 8 failures in that module, against 0 in the conf
 suite.
 
 **Warning: leave that module in the unit suite, and never move it to the conformance
-suite.** The `test` job runs the unit suite on six environments and the `conformance` job
-runs the conformance suite on one. A move would therefore take five readings away from the
-one guard this project holds on a frame. #736 declined the move on that reading.
+suite.** The `test` job runs the unit suite on five environments. `.github/workflows/test.yml:86-91`
+holds that matrix: `ubuntu-latest` on Python 3.10, 3.11, 3.12 and 3.13, and `macos-latest`
+on Python 3.12. The `conformance` job runs the conformance suite on one environment. A move
+would therefore take four readings away from the one frame guard this project holds. #736
+declined the move on that reading.
+
+**Warning: the count of five is the matrix after #575, and an older record states six.**
+That issue dropped Python 3.9 on 2026-08-10. `.claude/rules/batch-gate.md` records a
+measurement of that date over six jobs, and that record stays exactly as it is. Read the
+workflow for the present count, and never a record of a past measurement.
 
 **Warning: read a frame ruling against the unit suite, and never against the conformance
-counts.** `tests/test_conformance_frame_discrimination.py` holds this whole reading, so a
-source that starts to state a frame fails a case here rather than leaving a reader with a
-stale rule.
+counts.** `tests/test_conformance_frame_discrimination.py` holds this whole reading. A
+source that starts to state a frame therefore fails a case there, and it leaves no reader
+with a stale rule.
 
 ## When the FoxIO reference holds a defect
 

--- a/tests/test_conformance_frame_discrimination.py
+++ b/tests/test_conformance_frame_discrimination.py
@@ -1,9 +1,9 @@
 """What the conformance suite measures about the frame that carries a value.
 
 **A comparison that is never made reads as a comparison that passes.** #736 measured one.
-#606 moved the QUIC `JA4L-S` emission from the packet that fills point `B` to the packet
-that fills point `D`, and the conformance suite reported the identical three counts under
-the restored defect. Seven values changed frame and the suite discriminated none of them.
+#606 moved the QUIC `JA4L-S` emission to the packet that fills point `D`, from the packet
+that fills point `B`. Seven values changed frame. The conformance suite reported the
+identical three counts under the restored defect, so it discriminated none of them.
 
 This module holds the reading #736 took, so that no later reader derives it again.
 
@@ -39,11 +39,16 @@ RULE_SECTION = "## What a green conformance run does not measure"
 # A key of a reference source that would state the frame that carries a value. The
 # dissector writes `frame.number`, and this module reads every other source for a key of
 # the same kind. A frame states the position of one packet in the capture.
-FRAME_WORDS = ("frame", "packet_number", "packetno", "pktno")
+FRAME_WORDS = ("frame", "packet_number", "packet_num", "packetno", "pkt_num", "pktno")
 
 # The two Zeek fields that count packets. A count states how many packets a connection
 # holds, and it names none of them, so neither field states a frame.
 ZEEK_PACKET_COUNTS = ("orig_pkts", "resp_pkts")
+
+# The key of a method value in a FoxIO Rust snapshot. The rule file states the count these
+# keys reach, so a snapshot that gains or loses a value fails a case rather than leaves
+# that count stale.
+RUST_METHOD_KEYS = frozenset({"ja4", "ja4s", "ja4h", "ja4t", "ja4x", "ja4ssh", "ja4l_c", "ja4l_s"})
 
 # The frame each of the seven values of #606 moved to. The dissector writes the QUIC
 # `ja4.ja4ls` value on each one, and `tests/test_ja4l_quic_point_d_emission.py` holds
@@ -104,23 +109,33 @@ class TestTheSourcesThatStateNoFrame:
         )
 
     def test_the_foxio_rust_snapshot_states_no_frame(self):
-        """The Rust snapshots key a value on the stream, and they state no frame."""
+        """The Rust snapshots key a value on the stream, and they state no frame.
+
+        The reader matches a key of any letter case, so a key the snapshots later spell
+        with a capital reaches the heuristic too.
+        """
         files = _rust_snapshot_files()
         assert len(files) == 11, "the reading covered 11 snapshots"
         named = set()
+        values = 0
         for path in files:
             for line in path.read_text().splitlines():
-                match = re.match(r"^[- ]*([a-z0-9_]+):", line)
-                if match and _names_a_frame(match.group(1)):
-                    named.add(match.group(1))
+                match = re.match(r"^[- ]*([A-Za-z0-9_-]+):", line)
+                if not match:
+                    continue
+                key = match.group(1)
+                if _names_a_frame(key):
+                    named.add(key)
+                if key in RUST_METHOD_KEYS:
+                    values += 1
         assert named == set(), "a Rust snapshot now states a frame under {}".format(sorted(named))
+        assert values == 460, "the reading measured 460 method-keyed values"
 
     def test_the_zeek_baseline_states_no_frame(self):
         """A Zeek baseline keys a value on the connection, and it states no frame.
 
-        The `ts` field of a baseline states the time of the connection. A reader cannot
-        take a frame number from it, because a capture holds several packets at one time
-        and the baseline names no packet at all.
+        The `ts` field of a baseline states the time of the connection. A reader takes no
+        frame number from it, because a capture holds several packets at one time.
         """
         files = _zeek_baseline_files()
         assert len(files) == 7, "the reading covered 7 baselines"
@@ -135,8 +150,8 @@ class TestTheSourcesThatStateNoFrame:
         """`orig_pkts` and `resp_pkts` count packets, and they name no packet.
 
         A reader who searches a baseline for the word `pkt` finds these two fields. A
-        count of the packets of a connection locates no value in the capture, so neither
-        field turns a Zeek baseline into a source that states a frame.
+        count of the packets of a connection locates no value in the capture. Neither
+        field therefore states a frame.
         """
         baseline = VECTORS / "zeek_expected" / "Scripts.ja4-conn" / "conn.log"
         fields = []

--- a/tests/test_conformance_frame_discrimination.py
+++ b/tests/test_conformance_frame_discrimination.py
@@ -1,0 +1,228 @@
+"""What the conformance suite measures about the frame that carries a value.
+
+**A comparison that is never made reads as a comparison that passes.** #736 measured one.
+#606 moved the QUIC `JA4L-S` emission from the packet that fills point `B` to the packet
+that fills point `D`, and the conformance suite reported the identical three counts under
+the restored defect. Seven values changed frame and the suite discriminated none of them.
+
+This module holds the reading #736 took, so that no later reader derives it again.
+
+- The FoxIO Python expected output states no frame, and it is the source the conformance
+  value comparison reads.
+- The FoxIO Rust snapshots state no frame.
+- The Zeek baselines state no frame.
+- The FoxIO Wireshark dissector states the frame of every value it writes.
+
+**The dissector is therefore the one source a per-frame comparison could read**, and
+`.claude/rules/conformance.md` records why this project does not build that comparison
+into the conformance suite. `tests/test_ja4l_quic_point_d_emission.py` holds the frame of
+the QUIC `JA4L` values, and it runs in the unit suite.
+
+Run with: pytest -m spec_validation -k frame_discrimination
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+VECTORS = REPO_ROOT / "tests" / "foxio_vectors"
+
+RULE_FILE = REPO_ROOT / ".claude" / "rules" / "conformance.md"
+
+# The heading of the section that records this reading.
+RULE_SECTION = "## What a green conformance run does not measure"
+
+# A key of a reference source that would state the frame that carries a value. The
+# dissector writes `frame.number`, and this module reads every other source for a key of
+# the same kind. A frame states the position of one packet in the capture.
+FRAME_WORDS = ("frame", "packet_number", "packetno", "pktno")
+
+# The two Zeek fields that count packets. A count states how many packets a connection
+# holds, and it names none of them, so neither field states a frame.
+ZEEK_PACKET_COUNTS = ("orig_pkts", "resp_pkts")
+
+# The frame each of the seven values of #606 moved to. The dissector writes the QUIC
+# `ja4.ja4ls` value on each one, and `tests/test_ja4l_quic_point_d_emission.py` holds
+# this project against the same frames.
+FRAME_MOVES = {
+    "chrome-cloudflare-quic-with-secrets.pcapng": ((49, 52),),
+    "ssh2.pcapng": ((1140, 1147),),
+    "tls3.pcapng": ((144, 147), (149, 153), (155, 162), (159, 167), (303, 312)),
+}
+
+QUIC_SUFFIX = "_quic"
+
+
+def _python_expected_files():
+    """Return every FoxIO Python expected-output file."""
+    return sorted(VECTORS.glob("*.json"))
+
+
+def _rust_snapshot_files():
+    """Return every FoxIO Rust snapshot file."""
+    return sorted((VECTORS / "rust_expected").glob("*.snap"))
+
+
+def _zeek_baseline_files():
+    """Return every Zeek baseline file."""
+    return sorted((VECTORS / "zeek_expected").rglob("*.log"))
+
+
+def _wireshark_files():
+    """Return every FoxIO Wireshark dissector output file."""
+    return sorted((VECTORS / "wireshark_expected").glob("*.json"))
+
+
+def _names_a_frame(key):
+    """Report whether one key of a reference source states a frame."""
+    folded = key.lower()
+    return any(word in folded for word in FRAME_WORDS)
+
+
+@pytest.mark.spec_validation
+class TestTheSourcesThatStateNoFrame:
+    """Hold the clean negative of each source that frames no value."""
+
+    def test_the_foxio_python_expected_output_states_no_frame(self):
+        """The source the conformance value comparison reads frames nothing.
+
+        The key of a record names the method and the occurrence, and the record names the
+        stream. A value therefore rests on a connection and never on a packet.
+        """
+        files = _python_expected_files()
+        assert len(files) == 38, "the reading covered 38 expected-output files"
+        named = set()
+        for path in files:
+            for record in json.loads(path.read_text()):
+                named.update(key for key in record if _names_a_frame(key))
+        assert named == set(), (
+            "the FoxIO Python expected output now states a frame under {}".format(sorted(named))
+        )
+
+    def test_the_foxio_rust_snapshot_states_no_frame(self):
+        """The Rust snapshots key a value on the stream, and they state no frame."""
+        files = _rust_snapshot_files()
+        assert len(files) == 11, "the reading covered 11 snapshots"
+        named = set()
+        for path in files:
+            for line in path.read_text().splitlines():
+                match = re.match(r"^[- ]*([a-z0-9_]+):", line)
+                if match and _names_a_frame(match.group(1)):
+                    named.add(match.group(1))
+        assert named == set(), "a Rust snapshot now states a frame under {}".format(sorted(named))
+
+    def test_the_zeek_baseline_states_no_frame(self):
+        """A Zeek baseline keys a value on the connection, and it states no frame.
+
+        The `ts` field of a baseline states the time of the connection. A reader cannot
+        take a frame number from it, because a capture holds several packets at one time
+        and the baseline names no packet at all.
+        """
+        files = _zeek_baseline_files()
+        assert len(files) == 7, "the reading covered 7 baselines"
+        named = set()
+        for path in files:
+            for line in path.read_text().splitlines():
+                if line.startswith("#fields"):
+                    named.update(field for field in line.split("\t")[1:] if _names_a_frame(field))
+        assert named == set(), "a Zeek baseline now states a frame under {}".format(sorted(named))
+
+    def test_the_packet_count_of_a_zeek_baseline_states_no_frame(self):
+        """`orig_pkts` and `resp_pkts` count packets, and they name no packet.
+
+        A reader who searches a baseline for the word `pkt` finds these two fields. A
+        count of the packets of a connection locates no value in the capture, so neither
+        field turns a Zeek baseline into a source that states a frame.
+        """
+        baseline = VECTORS / "zeek_expected" / "Scripts.ja4-conn" / "conn.log"
+        fields = []
+        for line in baseline.read_text().splitlines():
+            if line.startswith("#fields"):
+                fields = line.split("\t")[1:]
+                break
+        for name in ZEEK_PACKET_COUNTS:
+            assert name in fields, name
+            assert not _names_a_frame(name), name
+
+
+@pytest.mark.spec_validation
+class TestTheSourceThatStatesTheFrame:
+    """Hold the one source a per-frame comparison could read."""
+
+    def test_the_wireshark_dissector_states_the_frame_of_every_value(self):
+        """Every value the dissector writes carries the frame that produced it."""
+        files = _wireshark_files()
+        assert len(files) == 26, "the reading covered 26 dissector output files"
+        framed = 0
+        unframed = 0
+        for path in files:
+            for row in json.loads(path.read_text()):
+                layers = row["_source"]["layers"]
+                carries = "frame.number" in layers
+                for key, values in layers.items():
+                    if key == "frame.number":
+                        continue
+                    for _ in values:
+                        if carries:
+                            framed += 1
+                        else:
+                            unframed += 1
+        assert unframed == 0, "{} dissector value(s) now carry no frame".format(unframed)
+        assert framed == 724, "the reading measured 724 framed values"
+
+    def test_the_dissector_names_the_destination_frame_of_every_move_of_606(self):
+        """The seven frames #606 moved to are the frames the dissector writes.
+
+        A move that no reference names would be a change this project made on its own.
+        The dissector names all seven, so #606 followed one source.
+        """
+        for capture, moves in FRAME_MOVES.items():
+            rows = json.loads((VECTORS / "wireshark_expected" / f"{capture}.json").read_text())
+            frames = set()
+            for row in rows:
+                layers = row["_source"]["layers"]
+                values = layers.get("ja4.ja4ls", [])
+                if values and values[0].endswith(QUIC_SUFFIX):
+                    frames.add(int(layers["frame.number"][0]))
+            for source, destination in moves:
+                assert destination in frames, (capture, destination)
+                assert source not in frames, (capture, source)
+
+
+@pytest.mark.spec_validation
+class TestWhatTheConformanceSuiteCompares:
+    """Hold what the conformance value comparison reads, and what it therefore misses."""
+
+    def test_the_conformance_value_comparison_reads_a_source_that_frames_nothing(self):
+        """Every value case of the conformance suite comes from the unframed source.
+
+        `tests/test_spec_validation.py` builds one case for each value of the FoxIO Python
+        expected output. That source states no frame, so no case of the suite can read
+        one. A frame move therefore passes the suite whatever it moved.
+        """
+        from tests.test_spec_validation import _value_params
+
+        cases = _value_params()
+        assert len(cases) == 1203, "the reading measured 1203 value cases"
+        for parameters in cases:
+            json_path = VECTORS / "{}.json".format(parameters.values[0].name)
+            assert json_path in _python_expected_files(), json_path
+
+    def test_the_rule_file_records_what_a_green_conformance_run_does_not_measure(self):
+        """`.claude/rules/conformance.md` states the limit and names the measurement.
+
+        A reading that lives only in a closed issue is a reading the next reader derives
+        again. #736 records this one in the rule file, and this case holds it there.
+        """
+        text = RULE_FILE.read_text()
+        assert RULE_SECTION in text, "{} holds no section {!r}".format(RULE_FILE, RULE_SECTION)
+        section = text.split(RULE_SECTION, 1)[1].split("\n## ", 1)[0]
+        assert "#606" in section, "the section names no measurement that earned it"
+        for capture, moves in FRAME_MOVES.items():
+            assert capture in section, "the section names no move of {}".format(capture)
+            for source, destination in moves:
+                assert "{} to {}".format(source, destination) in section, (capture, source)


### PR DESCRIPTION
Refs #736.

## What this delivers

**This issue asked for a reading, and answer 3 of the issue body is the answer.** The
conformance suite compares no frame, this change records why, and it moves no fingerprint
value.

## Step 1 — does each source state the frame that carries a value

| Source | States a frame | Values |
|---|---|---|
| FoxIO Python expected output, `tests/foxio_vectors/*.json` | No | 1203 |
| FoxIO Rust snapshots, `tests/foxio_vectors/rust_expected/*.snap` | No | 460 |
| Zeek baselines, `tests/foxio_vectors/zeek_expected/` | No | 7 baselines |
| FoxIO Wireshark dissector, `tests/foxio_vectors/wireshark_expected/*.json` | Yes, `frame.number` | 724 |

**The three clean negatives each rest on a key list, and not on a search of one file.** The
Python source holds 32 distinct keys over 38 files and 275 records, and the key of a value
names the method and the occurrence. The Rust snapshots hold 26 distinct keys over 11
files. The seven Zeek baselines each name their fields on a `#fields` line.

**One Zeek reading needed care.** `orig_pkts` and `resp_pkts` each count the packets of a
connection, and neither one names a packet. A first form of the key heuristic matched the
substring `pkt` and reported a frame there, and a case of the new module caught it.

**The dissector frames every value it writes**: 724 framed and 0 unframed.

## Step 2 — the cost where a frame is available

**The conformance suite builds all 1203 of its value cases from the FoxIO Python source**,
which frames nothing. A per-frame comparison would therefore be a new comparison against a
different source, and it adds no discrimination to any case the suite runs today.

Measured over the 445 dissector values of a hashed form, on the 26 captures this project
holds:

| Reading | Values |
|---|---|
| The value agrees and the frame agrees | 206 |
| The value agrees and the frame differs | 136 |
| This project produces no such value | 103 |

**The 136 frame disagreements are values this project already produces correctly.** Each
one would enter `tests/foxio_deviations.json`. 70 of the 136 are TCP `JA4L` and `JA4LS`
values, and the dissector writes each one on a later frame than this project. None of the
70 is a QUIC value.

## Step 3 — the answer

`.claude/rules/conformance.md` holds the new section
`## What a green conformance run does not measure`. It names the seven frame moves of #606
as the measurement that earned it.

**The change also declines one move it considered.** `tests/test_ja4l_quic_point_d_emission.py`
already holds the frame of every QUIC `JA4L` value against the dissector. The `test` job
runs it on five environments and the `conformance` job runs on one. A move into the
conformance suite would therefore take four readings away from the one frame guard this
project holds. `.github/workflows/test.yml:86-91` holds that matrix.

**The self-review corrected this count from six, and the correction is worth reading.** The
first form took the number from a sentence of `.claude/rules/batch-gate.md` that records a
measurement of 2026-08-10. #575 dropped Python 3.9 after that measurement. A record of a
past measurement is not a statement of the present matrix.

## The mutation proof, in both directions

The mutation restores the point `B` emission of #606, in `_quic_ja4l` of
`ja4plus/fingerprinters/ja4l.py`.

| Suite | Under the change | Under the restored defect |
|---|---|---|
| `pytest tests/ -m spec_validation` | 1684 passed, 142 skipped, 138 xfailed | 1676 passed, 142 skipped, 138 xfailed |
| `tests/test_ja4l_quic_point_d_emission.py` | 10 passed | 8 failed, 2 passed |

**The conformance counts under the defect equal the counts this branch measured before it
added a case.** The suite therefore discriminates the mutation nowhere, and the unit module
discriminates it on 8 cases. The mutation is reverted and `git diff` reads no change under
`ja4plus/`.

## The counts before and after

| Gate | Before | After |
|---|---|---|
| `pytest tests/ -m spec_validation` | 1676 passed, 142 skipped, 138 xfailed | 1684 passed, 142 skipped, 138 xfailed |
| `tests/foxio_deviations.json` | 138 keys | 138 keys |

The eight new cases belong to `tests/test_conformance_frame_discrimination.py`.

Verified against: https://github.com/FoxIO-LLC/ja4/tree/main/python/test/testdata (retrieved 2026-08-16)

