### PR TITLE
Truncate the reassembled TCP run at the byte cap

### DIFF
--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -223,8 +223,8 @@ class TCPStreamReassembler(StateTable):
                 break
 
         # This truncation removes no byte today. `add_segment` refuses the segment that
-        # would cross the byte cap, so one stream stores no more bytes than the cap and
-        # the run this method builds never reaches it. #697 records that reading.
+        # would cross the byte cap. One stream therefore stores no more bytes than the
+        # cap, and the run this method builds never reaches it. #697 records the reading.
         #
         # The truncation stands here because `GetStream` of `Crank-Git/ja4plus-go`
         # truncates. FoxIO states no byte cap on a stream reader, so parity rule 2 of

--- a/ja4plus/utils/tcp_stream.py
+++ b/ja4plus/utils/tcp_stream.py
@@ -196,8 +196,9 @@ class TCPStreamReassembler(StateTable):
     def get_stream(self, key: Any) -> bytes:
         """Reassemble and return contiguous stream data from base_seq.
 
-        Returns data from the earliest sequence number up to the first gap. The order
-        holds across a wrap of the 32-bit sequence number.
+        Returns data from the earliest sequence number up to the first gap, or up to
+        `max_stream_bytes`, whichever comes first. The order holds across a wrap of the
+        32-bit sequence number.
         """
         if key not in self.streams:
             return b""
@@ -221,9 +222,22 @@ class TCPStreamReassembler(StateTable):
             else:
                 break
 
-        # `add_segment` bounds the bytes the stream stores, and the result never holds
-        # more than the stream stores, so this method needs no bound of its own.
-        return bytes(result)
+        # This truncation removes no byte today. `add_segment` refuses the segment that
+        # would cross the byte cap, so one stream stores no more bytes than the cap and
+        # the run this method builds never reaches it. #697 records that reading.
+        #
+        # The truncation stands here because `GetStream` of `Crank-Git/ja4plus-go`
+        # truncates. FoxIO states no byte cap on a stream reader, so parity rule 2 of
+        # `CLAUDE.md` gives the port the interface.
+        #
+        # #654 records the admission rule of each port in the divergence register, and the
+        # user decides which form this project keeps. The port admits the crossing segment
+        # and stores 250 bytes past the cap. A move to that admission rule therefore
+        # reaches this line, and it moves no byte of the value this method returns.
+        #
+        # A byte cap below zero holds no byte, and the port states that rule too. A slice
+        # on the negative value would drop the last bytes of the run instead.
+        return bytes(result[: max(self.max_stream_bytes, 0)])
 
     def base_seq(self, key: Any) -> int | None:
         """Return the sequence number the reassembled stream starts at, or None.

--- a/tests/test_get_stream_byte_cap_truncation.py
+++ b/tests/test_get_stream_byte_cap_truncation.py
@@ -1,0 +1,109 @@
+"""`get_stream` truncates the contiguous run at the byte cap.
+
+#654 found that `get_stream` returned the stored bytes with no truncation, and that
+`GetStream` of the port truncates. #697 holds the answer: this project truncates, and
+parity rule 2 of `CLAUDE.md` decides it. FoxIO specifies no byte cap on a stream reader,
+so the port holds the interface and this project adopts it.
+
+**The truncation removes no byte today.** `add_segment` refuses the segment that would
+cross the byte cap, so one stream stores no more bytes than the cap. A case therefore
+reaches the truncation through a stream that stores its segments under a cap that admits
+every one of them, and then reads that stream under a lower cap. The state reaches
+`get_stream` through the public writer alone, and no case of this file writes
+`reassembler.streams` and no case reverses the admission rule.
+
+**No case of this file builds, runs or imports the port.** Parity rule 3 bars that.
+"""
+
+from pathlib import Path
+
+from ja4plus.utils.tcp_stream import TCPStreamReassembler
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULE = REPO_ROOT / "ja4plus" / "utils" / "tcp_stream.py"
+
+# The key of the one stream every case of this file builds.
+STREAM = "192.0.2.1:443->192.0.2.2:50000"
+
+# The three segments of the run, each 50 bytes, and each of one repeated byte. A reader
+# that returns the last bytes of the run rather than the first returns a different value.
+SEGMENT_LENGTH = 50
+FIRST = b"a" * SEGMENT_LENGTH
+SECOND = b"b" * SEGMENT_LENGTH
+THIRD = b"c" * SEGMENT_LENGTH
+RUN_LENGTH = 3 * SEGMENT_LENGTH
+
+# The cap the reader reads, which stands below the run.
+LOW_CAP = 100
+
+
+def _stream_past_the_byte_cap(cap: int) -> TCPStreamReassembler:
+    """Return a reassembler whose one stream stores a run longer than the byte cap.
+
+    The stream stores its three segments under a cap that admits every one of them, and
+    this function then lowers the cap to the value the reader reads.
+
+    Args:
+        cap: The byte cap `get_stream` reads.
+
+    Returns:
+        A reassembler that holds one stream under the key `STREAM`.
+    """
+    reassembler = TCPStreamReassembler(max_stream_bytes=RUN_LENGTH)
+    reassembler.add_segment(STREAM, 0, FIRST)
+    reassembler.add_segment(STREAM, SEGMENT_LENGTH, SECOND)
+    reassembler.add_segment(STREAM, 2 * SEGMENT_LENGTH, THIRD)
+    assert reassembler.streams[STREAM]["bytes"] == RUN_LENGTH
+    reassembler.max_stream_bytes = cap
+    return reassembler
+
+
+def test_get_stream_returns_no_more_bytes_than_the_byte_cap() -> None:
+    """`get_stream` returns 100 bytes where the stream stores a run of 150 bytes."""
+    reassembler = _stream_past_the_byte_cap(LOW_CAP)
+    assert len(reassembler.get_stream(STREAM)) == LOW_CAP
+
+
+def test_get_stream_returns_the_earliest_bytes_of_the_run() -> None:
+    """The truncation drops the last bytes of the run and keeps the earliest ones.
+
+    A fingerprinter reads the request line and the certificate message, and both stand at
+    the start of the run.
+    """
+    reassembler = _stream_past_the_byte_cap(LOW_CAP)
+    assert reassembler.get_stream(STREAM) == FIRST + SECOND
+
+
+def test_get_stream_returns_no_byte_where_the_byte_cap_stands_below_zero() -> None:
+    """A byte cap below zero holds no byte, and the port states the same rule.
+
+    A plain slice would read the cap as an offset from the end of the run, so it would
+    return 145 bytes for a cap of -5.
+    """
+    reassembler = _stream_past_the_byte_cap(-5)
+    assert reassembler.get_stream(STREAM) == b""
+
+
+def test_get_stream_removes_no_byte_under_the_present_admission_rule() -> None:
+    """The truncation removes nothing where `add_segment` admits every stored segment.
+
+    `add_segment` refuses the segment that would cross the cap, so the stored run stands
+    below the cap and the reader returns it whole.
+    """
+    reassembler = TCPStreamReassembler(max_stream_bytes=LOW_CAP)
+    reassembler.add_segment(STREAM, 0, FIRST)
+    reassembler.add_segment(STREAM, SEGMENT_LENGTH, SECOND)
+    reassembler.add_segment(STREAM, 2 * SEGMENT_LENGTH, THIRD)
+    assert reassembler.streams[STREAM]["bytes"] == LOW_CAP
+    assert reassembler.get_stream(STREAM) == FIRST + SECOND
+
+
+def test_the_module_states_the_parity_rule_that_decides_the_truncation() -> None:
+    """`ja4plus/utils/tcp_stream.py` records the answer and the rule that decides it.
+
+    A reader of the module cannot see from the code that the truncation removes nothing
+    today, or that the port decides the interface.
+    """
+    module = MODULE.read_text(encoding="utf-8")
+    assert "parity rule 2" in module
+    assert "#697" in module

--- a/tests/test_get_stream_byte_cap_truncation.py
+++ b/tests/test_get_stream_byte_cap_truncation.py
@@ -7,10 +7,9 @@ so the port holds the interface and this project adopts it.
 
 **The truncation removes no byte today.** `add_segment` refuses the segment that would
 cross the byte cap, so one stream stores no more bytes than the cap. A case therefore
-reaches the truncation through a stream that stores its segments under a cap that admits
-every one of them, and then reads that stream under a lower cap. The state reaches
-`get_stream` through the public writer alone, and no case of this file writes
-`reassembler.streams` and no case reverses the admission rule.
+stores its segments under a cap that admits every one of them. It then reads that stream
+under a lower cap. The state reaches `get_stream` through the public writer alone. No case
+of this file writes `reassembler.streams`, and no case reverses the admission rule.
 
 **No case of this file builds, runs or imports the port.** Parity rule 3 bars that.
 """
@@ -22,7 +21,6 @@ from ja4plus.utils.tcp_stream import TCPStreamReassembler
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODULE = REPO_ROOT / "ja4plus" / "utils" / "tcp_stream.py"
 
-# The key of the one stream every case of this file builds.
 STREAM = "192.0.2.1:443->192.0.2.2:50000"
 
 # The three segments of the run, each 50 bytes, and each of one repeated byte. A reader
@@ -33,15 +31,15 @@ SECOND = b"b" * SEGMENT_LENGTH
 THIRD = b"c" * SEGMENT_LENGTH
 RUN_LENGTH = 3 * SEGMENT_LENGTH
 
-# The cap the reader reads, which stands below the run.
+# This cap stands below the run, so the truncation drops the third segment.
 LOW_CAP = 100
 
 
 def _stream_past_the_byte_cap(cap: int) -> TCPStreamReassembler:
     """Return a reassembler whose one stream stores a run longer than the byte cap.
 
-    The stream stores its three segments under a cap that admits every one of them, and
-    this function then lowers the cap to the value the reader reads.
+    The stream stores its three segments under a cap that admits every one of them. This
+    function then lowers the cap to the value the reader reads.
 
     Args:
         cap: The byte cap `get_stream` reads.
@@ -77,7 +75,7 @@ def test_get_stream_returns_the_earliest_bytes_of_the_run() -> None:
 def test_get_stream_returns_no_byte_where_the_byte_cap_stands_below_zero() -> None:
     """A byte cap below zero holds no byte, and the port states the same rule.
 
-    A plain slice would read the cap as an offset from the end of the run, so it would
+    A plain slice would read the cap as an offset from the end of the run. It would then
     return 145 bytes for a cap of -5.
     """
     reassembler = _stream_past_the_byte_cap(-5)


### PR DESCRIPTION
Refs #697.

## The answer, and the rule that decides it

**`get_stream` truncates.** FoxIO states no byte cap on a stream reader, so parity rule 2
of `CLAUDE.md` gives the port the interface. `GetStream` of `Crank-Git/ja4plus-go`
truncates the run at `MaxBytes`, and this project adopts that reading.

`internal/parser/tcp_stream.go:225` holds `GetStream`, and its own comment states the
rule: `Returns data up to the first gap or MaxBytes, whichever comes first.`

## Every premise of the brief measured true

| Premise | The measurement |
|---|---|
| `get_stream` truncates nothing | The base form reads `return bytes(result)`, and its comment states that the method needs no bound of its own. |
| The admission rule refuses the crossing segment | `ja4plus/utils/tcp_stream.py:151` reads `if stream["bytes"] + len(data) > self.max_stream_bytes`. |
| The register row of #654 records the split | `docs/specs/spec.md:331` holds the row `The segment one TCP stream refuses at its byte cap`, and it states that `GetStream` truncates the run at `MaxBytes`. |

## What the truncation removes today, which is nothing

`add_segment` refuses the segment that would cross the byte cap, so one stream stores no
more bytes than the cap and the run never reaches it. The module states that reason above
the return, because a reader cannot see it from the code.

**#654 left the admission rule with the user.** The port admits the crossing segment and
stores 250 bytes past the cap. A move to that admission rule reaches this line, and this
change makes that move cost no byte of the value the method returns.

## How the cases reach a path the admission rule blocks

**Each case stores its segments under a byte cap that admits every one of them, and it
then lowers the cap to the value the reader reads.** The stored run of 150 bytes then
stands above a cap of 100.

The shape uses the public writer alone. No case writes `reassembler.streams`, and no case
reverses the admission rule of `add_segment`. The plan named two other shapes, and each
one costs more: a direct write of the stored state couples the case to four private keys,
and a reversal of the admission rule edits the line that the register row of #654 pins.

## The red-to-green

The five cases were written first. Against the unchanged module, four failed and one
passed.

```
FAILED tests/test_get_stream_byte_cap_truncation.py::test_get_stream_returns_no_more_bytes_than_the_byte_cap
FAILED tests/test_get_stream_byte_cap_truncation.py::test_get_stream_returns_the_earliest_bytes_of_the_run
FAILED tests/test_get_stream_byte_cap_truncation.py::test_get_stream_returns_no_byte_where_the_byte_cap_stands_below_zero
FAILED tests/test_get_stream_byte_cap_truncation.py::test_the_module_states_the_parity_rule_that_decides_the_truncation
4 failed, 1 passed
```

**The one case that passed is `test_get_stream_removes_no_byte_under_the_present_admission_rule`.**
It holds the reading of the base form, and it holds the same reading after the change.

## The mutation reversal

Two mutations ran live, and each one discriminates in both directions.

| Mutation | The reading |
|---|---|
| `return bytes(result)`, which is the base form | 3 failed, 2 passed |
| `return bytes(result[: self.max_stream_bytes])`, which drops the clamp | 1 failed, 4 passed |
| The committed form | 5 passed |

The second mutation returns 145 bytes of a 150-byte run for a cap of -5, because a plain
slice reads the negative value as an offset from the end.

## This change moves no fingerprint value

**A replay of the 38 captures of `tests/foxio_vectors/` through the command-line program
writes 788 values before this change and 788 after, and 0 differ.** The replay reads
`ja4plus analyze --format json` on each capture and compares every field of every value.

`tests/foxio_deviations.json` holds 138 keys before and after.

## The five gates

| Gate | Before | After |
|---|---|---|
| `pytest tests/ -m spec_validation` | 1684 passed, 142 skipped, 138 xfailed | 1684 passed, 142 skipped, 138 xfailed |
| `pytest tests/ -m "not spec_validation"` | 5872 passed, 8 skipped, 8 xfailed, 114 subtests passed | 5880 passed, 8 skipped, 8 xfailed, 114 subtests passed |
| `ruff check ja4plus/ tests/` | All checks passed | All checks passed |
| `ruff format --check ja4plus/ tests/` | 264 files already formatted | 264 files already formatted |
| `mypy --strict ja4plus/` | no issue | no issue in 32 source files |

The unit suite rises by 8, which is the 5 cases of the new file and 3 cases that
parametrize over the tracked test files.

## What this change does not touch

- **The admission rule of `add_segment`.** #654 left it with the user, and no line of it
  moves. `ja4plus/utils/tcp_stream.py:151` still holds the condition the register row
  cites, on the same line.
- **`docs/specs/spec.md`.** The register row of #654 records the admission rule, and this
  change moves no row of it.
- **`CHANGELOG.md` and the `## Changelog` table.** #727 moved the round record to the
  batch pull request.

Verified against: `Crank-Git/ja4plus-go`, `internal/parser/tcp_stream.go:225`, at commit
`a83caa56ef39ff6b4b524a104e4ea30b9e2bdffa` on branch `dev`, read 2026-08-16. This pull
request edits no file of the port, and no case of this repository builds, runs or imports
it.
