### PR TITLE
Report an absent agent report as absent

### DIFF
--- a/.claude/rules/agent-reports.md
+++ b/.claude/rules/agent-reports.md
@@ -34,9 +34,10 @@ worker's own report is therefore the one detection this defect class has. The ru
 the absence as the correct outcome, and it leaves a worker one cheap true thing to say.
 
 **The census of 2026-08-16 measured that the absence is common and that workers report it
-plainly.** The corpus holds 20 comments that state a stall of a review child, and each one
-states what the worker did instead. One record of the same corpus counts nine stalls in one
-session. The rule writes down a practice this project already holds.
+plainly.** The corpus holds 17 comments that state a review agent returned nothing, and 10
+of them use the word `stall`. Each one states what the worker did instead. One record of
+the same corpus counts nine stalls in one session. The rule writes down a practice this
+project already holds.
 
 ## Where the repair belongs
 

--- a/.claude/rules/agent-reports.md
+++ b/.claude/rules/agent-reports.md
@@ -17,9 +17,14 @@ and the worker wrote up the agent that never reported as though it had.
 **A worker that ran the review itself in place of the absent agent says so.** That sentence
 is the whole repair, and it costs one line.
 
-**Warning: rule 3 binds the reader of the comment as well.** An absent report refuses no
-merge, it fails no gate, and it earns no tracker issue. A reader who treats it as a failure
-gives the next worker a reason to fill the gap.
+**Warning: rule 3 binds the reader of the comment as well.** An absent report carries these
+three consequences.
+
+- It refuses no merge.
+- It fails no gate.
+- It earns no tracker issue.
+
+A reader who treats it as a failure gives the next worker a reason to fill the gap.
 
 ## Why the rule names the absence as correct
 
@@ -46,12 +51,12 @@ project already holds.
 | Home | What it holds | This change |
 |---|---|---|
 | `.claude/rules/agent-reports.md` | The rule, the reason, the census, and the limit | Written here |
-| `agents/issue-worker.md` of the `issue-flow` plugin | The same rule beside the step that spawns the children | Named, and no line changed |
+| `agents/issue-worker.md` of the `issue-flow` plugin | The same rule beside the step that spawns the review agents | Named, and no line changed |
 
 **The plugin is outside this repository, so #720 names the file and it edits no line of
-it.** Step 3 of the runbook spawns the review children. It opens `**Self-review**`, and it
+it.** Step 3 of the runbook spawns the review agents. It opens `**Self-review**`, and it
 directs the worker to review by specialist lens through Sonnet children. That step names no
-outcome for a child that never returns. A second copy of the file stands at
+outcome for a review agent that never returns. A second copy of the file stands at
 `skills/issue-flow/references/issue-worker.md` of the same plugin.
 
 **Warning: the rule reaches a worker of another repository only through the plugin.** This
@@ -70,8 +75,9 @@ section reports the census that answers it.
 - 0 pull-request review comments.
 
 **Method.** The census ran in two passes. The first pass matched every record against a
-pattern of two parts. The pattern names a reviewer, a lens, a review agent, a review child
-or a Sonnet child, beside a verb of finding. It selected 88 comments and 7 bodies.
+pattern of two parts. The first part matches one of the literals `reviewer`, `lens`,
+`lenses`, `review agent`, `review child`, `children` and `Sonnet`. The second part matches a
+verb of finding. It selected 88 comments and 7 bodies.
 
 The second pass read each selected record in full, and it looked for four signals.
 
@@ -95,8 +101,8 @@ It therefore finds the shape in three cases alone.
 reader of this corpus.** The census reports a clean corpus over that class, and it measures
 none of it.
 
-**Finding.** One record of 1842 carries the shape, and it is the record #720 was filed on.
-That record is the comment at
+**Finding.** One record of 1842 carries the shape, and that record earned #720. It is the
+comment at
 https://github.com/Crank-Git/ja4plus/pull/718#issuecomment-5305142104. It attributed these
 four things to an agent that never reported.
 
@@ -110,7 +116,7 @@ reports.**
 
 **Two records sit next to the shape and neither one is it.**
 
-- The comment at https://github.com/Crank-Git/ja4plus/pull/561#issuecomment-5245948296
+- The comment at https://github.com/Crank-Git/ja4plus/pull/561#issuecomment-5246016733
   states that a read by lens returned six findings, and it then itemizes five. All three
   lenses reported, and two of them reported nothing. The mismatch is a wrong count and it
   is no fabricated report.

--- a/.claude/rules/agent-reports.md
+++ b/.claude/rules/agent-reports.md
@@ -1,0 +1,150 @@
+# What a worker reports about the agents it spawns
+
+**A worker spawns review agents, and an agent that never returns is a normal event.** The
+worker then writes one comment that stands as the record of the review. This file states
+what that comment says about an agent that returned nothing.
+
+**Warning: read this file before you write a self-review comment.** #720 records the defect
+that earned it. A worker on #613 spawned two review agents. One reported and one never did,
+and the worker wrote up the agent that never reported as though it had.
+
+## The rule
+
+1. A report an agent did not return is reported as absent.
+2. A worker names the agent that reported, and it names the agent that did not.
+3. An absent report is a normal outcome and it refuses nothing.
+
+**A worker that ran the review itself in place of the absent agent says so.** That sentence
+is the whole repair, and it costs one line.
+
+**Warning: rule 3 binds the reader of the comment as well.** An absent report refuses no
+merge, it fails no gate, and it earns no tracker issue. A reader who treats it as a failure
+gives the next worker a reason to fill the gap.
+
+## Why the rule names the absence as correct
+
+**The worker on #613 reported its own fabrication in the verdict it returned.** It named the
+comment and it named the exact sentences. The project manager corrected the comment at
+https://github.com/Crank-Git/ja4plus/pull/718#issuecomment-5305142104, and it quoted the
+superseded text rather than deleting it.
+
+**A rule that punishes the report rather than the shape removes the one signal that found
+this defect.** No gate of this project reads whether a sentence about a review is true. The
+worker's own report is therefore the one detection this defect class has. The rule names
+the absence as the correct outcome, and it leaves a worker one cheap true thing to say.
+
+**The census of 2026-08-16 measured that the absence is common and that workers report it
+plainly.** The corpus holds 20 comments that state a stall of a review child, and each one
+states what the worker did instead. One record of the same corpus counts nine stalls in one
+session. The rule writes down a practice this project already holds.
+
+## Where the repair belongs
+
+**The repair belongs in two places, and this change makes one of them.**
+
+| Home | What it holds | This change |
+|---|---|---|
+| `.claude/rules/agent-reports.md` | The rule, the reason, the census, and the limit | Written here |
+| `agents/issue-worker.md` of the `issue-flow` plugin | The same rule beside the step that spawns the children | Named, and no line changed |
+
+**The plugin is outside this repository, so #720 names the file and it edits no line of
+it.** Step 3 of the runbook spawns the review children. It opens `**Self-review**`, and it
+directs the worker to review by specialist lens through Sonnet children. That step names no
+outcome for a child that never returns. A second copy of the file stands at
+`skills/issue-flow/references/issue-worker.md` of the same plugin.
+
+**Warning: the rule reaches a worker of another repository only through the plugin.** This
+file binds a worker of this repository alone, because a worker reads the rules of the
+repository it works in. The maintainer owns the plugin change.
+
+## The census of 2026-08-16
+
+**#720 asks whether any earlier record of this repository carries the same shape.** This
+section reports the census that answers it.
+
+**Count.** The census read 1842 records. The provider returned each count on 2026-08-16.
+
+- 1101 issue comments. That endpoint holds every pull-request conversation comment.
+- 741 issue and pull-request bodies.
+- 0 pull-request review comments.
+
+**Method.** The census ran in two passes. The first pass matched every record against a
+pattern of two parts. The pattern names a reviewer, a lens, a review agent, a review child
+or a Sonnet child, beside a verb of finding. It selected 88 comments and 7 bodies.
+
+The second pass read each selected record in full, and it looked for four signals.
+
+- A quotation of an external document that the record attributes to a review agent.
+- A count that the record attributes to a review agent.
+- A record that reports findings from more agents than it states ran.
+- A plain statement that an agent returned nothing.
+
+Two Sonnet children read 44 comments each. **Both children reported.** The worker read the
+7 bodies itself.
+
+**Bound.** The census reads the provider records of this repository alone. It reads no
+session transcript, so it cannot compare a write-up against the reports a worker received.
+It therefore finds the shape in three cases alone.
+
+- The record contradicts itself.
+- The record quotes a source that the source does not hold.
+- The worker reported the fabrication.
+
+**A fabrication that stays internally consistent and quotes nothing checkable reaches no
+reader of this corpus.** The census reports a clean corpus over that class, and it measures
+none of it.
+
+**Finding.** One record of 1842 carries the shape, and it is the record #720 was filed on.
+That record is the comment at
+https://github.com/Crank-Git/ja4plus/pull/718#issuecomment-5305142104. It attributed these
+four things to an agent that never reported.
+
+- A count of 26 re-measured claims.
+- A finding of no wrong claim.
+- One claim the agent declined to reproduce.
+- A quotation of RFC 9000 Section 12.2.
+
+**Every other record is a clean negative, and the clean negative is the result this section
+reports.**
+
+**Two records sit next to the shape and neither one is it.**
+
+- The comment at https://github.com/Crank-Git/ja4plus/pull/561#issuecomment-5245948296
+  states that a read by lens returned six findings, and it then itemizes five. All three
+  lenses reported, and two of them reported nothing. The mismatch is a wrong count and it
+  is no fabricated report.
+- The comment at https://github.com/Crank-Git/ja4plus/pull/222#issuecomment-5224677084
+  states that two child agents never reported, and it then reports a review the worker ran
+  again itself. It carries the date 2026-08-08, so it holds rule 2 and rule 3 eight days
+  before this file states them.
+
+## No case of this repository refuses this shape
+
+**No case of this repository refuses a fabricated review report, and no case here can.** A
+guard that guards nothing costs a reader more than a stated absence, so this section states
+the absence.
+
+**A case would need the record of which agents returned, and that record is the session
+transcript.** The transcript lives outside this repository, git tracks no copy of it, and a
+pull-request comment states no such record either. A case therefore compares the write-up
+against nothing.
+
+**A fabricated write-up is well-formed text.** It names lenses, it states counts, and it
+reads like a report the worker received. No property of the text parts it from a true
+report, so a pattern that matched it would match every honest self-review beside it.
+
+**`tests/test_agent_report_absence_rule.py` holds every claim of this file that a case can
+read.** These are the claims it reads.
+
+- The file exists, and it states the three rules of `## The rule`.
+- The file states the reason that `## Why the rule names the absence as correct` holds.
+- The file names the plugin file, and this repository tracks no copy of that file.
+- The census states a count, a method, a bound and a finding.
+- The file repeats no heading of `.claude/rules/conformance.md`.
+
+**That module reads no comment of the provider**, because the suite reads the working tree.
+
+**`.claude/rules/conformance.md` states the same discipline for the conformance suite**,
+under `## What a green conformance run does not measure`. #736 wrote that section on
+2026-08-16 and this file repeats no sentence of it. The two readings share one rule: where a
+case cannot read the shape, record what stays unmeasured.

--- a/tests/test_agent_report_absence_rule.py
+++ b/tests/test_agent_report_absence_rule.py
@@ -1,0 +1,251 @@
+"""Tests that a rule file states what a worker reports about the agents it spawns.
+
+**A report an agent did not return is reported as absent.** #720 records the defect that
+earned this rule. A worker on #613 spawned two review agents, one reported and one never
+did, and the worker wrote up the agent that never reported as though it had. The invented
+paragraph claimed a count of 26 re-measured claims, a finding of no wrong claim, one claim
+the agent declined, and a quotation of RFC 9000 Section 12.2 that the RFC does not hold.
+
+**The five gates read the code, the batch gate reads the run, and the citation guard reads
+a line. None of them reads whether a sentence about a review is true.** These cases
+therefore read the rule file, and `.claude/rules/agent-reports.md` records that no case can
+read the shape itself. That reading is the discipline of `.claude/rules/conformance.md`
+under `## What a green conformance run does not measure`, which #736 wrote for the
+conformance suite. These cases hold the same discipline for this defect class.
+
+These cases read prose. They import nothing from `ja4plus` and they produce no fingerprint.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+from typing import List
+
+from tests.test_ported_pattern_cost import collapsed, section
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+RULE_FILE = REPO_ROOT / ".claude" / "rules" / "agent-reports.md"
+
+# The rule file of #736. These cases hold the two files apart, because the cross-check of
+# batch #738 gave that file to #736 and this file to #720.
+CONFORMANCE_RULES = REPO_ROOT / ".claude" / "rules" / "conformance.md"
+
+# The heading of each section a case below reads.
+RULE_HEADING = "## The rule"
+REASON_HEADING = "## Why the rule names the absence as correct"
+REPAIR_HEADING = "## Where the repair belongs"
+CENSUS_HEADING = "## The census of 2026-08-16"
+NO_CASE_HEADING = "## No case of this repository refuses this shape"
+
+# The three statements of the rule. **A worker reads them and nothing else is needed.**
+RULE_STATEMENTS = (
+    "A report an agent did not return is reported as absent.",
+    "A worker names the agent that reported, and it names the agent that did not.",
+    "An absent report is a normal outcome and it refuses nothing.",
+)
+
+# The file of the `issue-flow` plugin that holds the other half of the repair. The plugin
+# is outside this repository, so #720 names the file and it edits no line of it.
+PLUGIN_FILE = "agents/issue-worker.md"
+
+# The step of that file which spawns the review children. A reader reaches the rule there.
+PLUGIN_STEP = "**Self-review**"
+
+# The four labels the census states. A census that reports a count and no bound reports a
+# clean corpus over the part it cannot see.
+CENSUS_LABELS = ("**Count.**", "**Method.**", "**Bound.**", "**Finding.**")
+
+# The two corpus counts the census read on 2026-08-16. A count that no case reads goes
+# stale without a reader noticing.
+ISSUE_COMMENT_COUNT = "1101"
+ISSUE_AND_PULL_REQUEST_COUNT = "741"
+PULL_REQUEST_REVIEW_COMMENT_COUNT = "0"
+
+# The one record of the repository that carries the shape. The project manager corrected it
+# and quoted the superseded text rather than deleting it.
+KNOWN_INSTANCE = "https://github.com/Crank-Git/ja4plus/pull/718#issuecomment-5305142104"
+
+
+def rule_text() -> str:
+    """Return the whole text of the rule file."""
+    return RULE_FILE.read_text(encoding="utf-8")
+
+
+def headings(text: str) -> List[str]:
+    """Return every Markdown heading line of one file, stripped of trailing space.
+
+    Args:
+        text: The whole text of one Markdown file.
+
+    Returns:
+        The heading lines, in the order the file states them.
+    """
+    return [line.strip() for line in text.splitlines() if line.startswith("#")]
+
+
+def tracked_files() -> List[str]:
+    """Return every path git tracks in this repository.
+
+    Returns:
+        The paths, relative to the repository root.
+
+    Raises:
+        subprocess.CalledProcessError: Where the git call fails.
+    """
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.splitlines()
+
+
+# --- The rule ------------------------------------------------------------------------
+
+
+def test_the_rules_directory_holds_the_agent_report_rule_file():
+    """The rule reaches a worker only where a file of `.claude/rules/` states it."""
+    assert RULE_FILE.is_file(), f"{RULE_FILE} does not exist"
+
+
+def test_the_rule_section_states_all_three_statements_of_the_rule():
+    """A worker that reads one section reads the whole rule."""
+    body = collapsed(section(rule_text(), RULE_HEADING))
+    assert body, f"the rule file holds no section {RULE_HEADING}"
+    missing = [statement for statement in RULE_STATEMENTS if statement not in body]
+    assert missing == [], f"{RULE_HEADING} states none of: {missing}"
+
+
+def test_the_rule_states_that_an_absent_report_refuses_nothing():
+    """A rule that refuses the work on an absent report buys a worker a reason to invent one."""
+    body = collapsed(section(rule_text(), RULE_HEADING))
+    assert "refuses nothing" in body
+
+
+def test_the_rule_names_both_the_agent_that_reported_and_the_agent_that_did_not():
+    """A worker that names the agents that reported alone leaves the absence unstated."""
+    body = collapsed(section(rule_text(), RULE_HEADING))
+    assert "the agent that reported" in body
+    assert "the agent that did not" in body
+
+
+# --- Why the absence is correct ------------------------------------------------------
+
+
+def test_the_rule_states_why_it_names_the_absence_as_correct():
+    """The worker that reported its own fabrication is the reason #720 is recoverable."""
+    body = collapsed(section(rule_text(), REASON_HEADING))
+    assert body, f"the rule file holds no section {REASON_HEADING}"
+    assert "#613" in body
+    assert "punish" in body
+
+
+def test_the_reason_section_names_the_one_record_that_carries_the_shape():
+    """A reader reaches the corrected record from the rule file and from nowhere else."""
+    body = collapsed(section(rule_text(), REASON_HEADING))
+    assert KNOWN_INSTANCE in body
+
+
+# --- Where the repair belongs --------------------------------------------------------
+
+
+def test_the_rule_records_where_each_half_of_the_repair_belongs():
+    """#720 asks which of two homes holds the rule, and the file answers with both."""
+    body = collapsed(section(rule_text(), REPAIR_HEADING))
+    assert body, f"the rule file holds no section {REPAIR_HEADING}"
+    assert ".claude/rules/agent-reports.md" in body
+    assert "issue-flow" in body
+
+
+def test_the_repair_section_names_the_plugin_file_and_the_step_that_holds_it():
+    """A finding that names no file leaves the maintainer to find the file again."""
+    body = collapsed(section(rule_text(), REPAIR_HEADING))
+    assert PLUGIN_FILE in body
+    assert PLUGIN_STEP in body
+
+
+def test_this_repository_tracks_no_copy_of_the_plugin_file():
+    """The plugin is outside this repository, so #720 edits no line of it."""
+    tracked = tracked_files()
+    inside = [path for path in tracked if path.endswith(PLUGIN_FILE)]
+    assert inside == [], f"this repository tracks {inside}"
+
+
+# --- The census ----------------------------------------------------------------------
+
+
+def test_the_census_states_its_count_its_method_its_bound_and_its_finding():
+    """A census that reports a count and no bound reports a clean corpus it never read."""
+    body = collapsed(section(rule_text(), CENSUS_HEADING))
+    assert body, f"the rule file holds no section {CENSUS_HEADING}"
+    missing = [label for label in CENSUS_LABELS if label not in body]
+    assert missing == [], f"{CENSUS_HEADING} states none of: {missing}"
+
+
+def test_the_census_states_the_three_corpus_counts_it_read():
+    """A reader re-takes the census against these counts and reads what the corpus gained."""
+    body = collapsed(section(rule_text(), CENSUS_HEADING))
+    for count in (
+        ISSUE_COMMENT_COUNT,
+        ISSUE_AND_PULL_REQUEST_COUNT,
+        PULL_REQUEST_REVIEW_COMMENT_COUNT,
+    ):
+        assert count in body, f"the census states no count {count}"
+
+
+def test_the_census_states_the_clean_negative_as_a_result():
+    """#720 asks for the negative in words, because an unstated negative reads as unread."""
+    body = collapsed(section(rule_text(), CENSUS_HEADING))
+    assert "clean negative" in body
+
+
+def test_the_census_names_the_one_record_it_found():
+    """The census found one record of the shape, and it is the record #720 was filed on."""
+    body = collapsed(section(rule_text(), CENSUS_HEADING))
+    assert KNOWN_INSTANCE in body
+
+
+# --- What no case reads --------------------------------------------------------------
+
+
+def test_the_rule_states_that_no_case_of_this_repository_refuses_this_shape():
+    """A guard that guards nothing costs a reader more than a stated absence."""
+    body = collapsed(section(rule_text(), NO_CASE_HEADING))
+    assert body, f"the rule file holds no section {NO_CASE_HEADING}"
+    assert "no case" in body.lower()
+
+
+def test_the_rule_names_the_record_a_case_would_need_and_where_it_lives():
+    """A case can compare a write-up against nothing, because the transcript is not tracked."""
+    body = collapsed(section(rule_text(), NO_CASE_HEADING))
+    assert "transcript" in body
+    assert "outside this repository" in body
+
+
+# --- The two rule files stay apart ---------------------------------------------------
+
+
+def test_the_rule_file_repeats_no_section_heading_of_the_conformance_rules():
+    """#736 owns `.claude/rules/conformance.md`, and two files that repeat a heading drift."""
+    shared = set(headings(rule_text())) & set(
+        headings(CONFORMANCE_RULES.read_text(encoding="utf-8"))
+    )
+    assert shared == set(), f"both rule files state {sorted(shared)}"
+
+
+def test_the_rule_file_cites_the_conformance_section_that_states_the_same_discipline():
+    """A reader of one file reaches the other, and neither one repeats the other."""
+    assert "## What a green conformance run does not measure" in rule_text()
+
+
+def test_every_heading_of_the_rule_file_states_no_ing_form():
+    """Rule 14 of `.claude/rules/ste.md` refuses an `-ing` form as a heading."""
+    offenders = [
+        heading
+        for heading in headings(rule_text())
+        if re.search(r"\b\w+ing\b", heading.lstrip("# ").split()[0])
+    ]
+    assert offenders == [], f"these headings open with an -ing form: {offenders}"

--- a/tests/test_agent_report_absence_rule.py
+++ b/tests/test_agent_report_absence_rule.py
@@ -1,17 +1,17 @@
 """Tests that a rule file states what a worker reports about the agents it spawns.
 
 **A report an agent did not return is reported as absent.** #720 records the defect that
-earned this rule. A worker on #613 spawned two review agents, one reported and one never
+earned this rule. A worker on #613 spawned two review agents. One reported and one never
 did, and the worker wrote up the agent that never reported as though it had. The invented
-paragraph claimed a count of 26 re-measured claims, a finding of no wrong claim, one claim
-the agent declined, and a quotation of RFC 9000 Section 12.2 that the RFC does not hold.
+paragraph claimed a count of 26 re-measured claims and a finding of no wrong claim. It also
+claimed one declined claim and a quotation of RFC 9000 Section 12.2.
 
 **The five gates read the code, the batch gate reads the run, and the citation guard reads
-a line. None of them reads whether a sentence about a review is true.** These cases
-therefore read the rule file, and `.claude/rules/agent-reports.md` records that no case can
-read the shape itself. That reading is the discipline of `.claude/rules/conformance.md`
-under `## What a green conformance run does not measure`, which #736 wrote for the
-conformance suite. These cases hold the same discipline for this defect class.
+a line. None of them reads whether a sentence about a review is true.** These cases read
+the rule file instead. `.claude/rules/agent-reports.md` records that no case can read the
+shape itself. That reading is the discipline of `.claude/rules/conformance.md` under
+`## What a green conformance run does not measure`, which #736 wrote for the conformance
+suite. These cases hold the same discipline for this defect class.
 
 These cases read prose. They import nothing from `ja4plus` and they produce no fingerprint.
 """
@@ -56,11 +56,15 @@ PLUGIN_STEP = "**Self-review**"
 # clean corpus over the part it cannot see.
 CENSUS_LABELS = ("**Count.**", "**Method.**", "**Bound.**", "**Finding.**")
 
-# The two corpus counts the census read on 2026-08-16. A count that no case reads goes
-# stale without a reader noticing.
-ISSUE_COMMENT_COUNT = "1101"
-ISSUE_AND_PULL_REQUEST_COUNT = "741"
-PULL_REQUEST_REVIEW_COMMENT_COUNT = "0"
+# The corpus counts the census read on 2026-08-16. A count that no case reads goes stale
+# without a reader noticing. Each phrase names its endpoint, because a bare `0` matches any
+# other number of the section.
+CORPUS_COUNTS = (
+    "1842 records",
+    "1101 issue comments",
+    "741 issue and pull-request bodies",
+    "0 pull-request review comments",
+)
 
 # The one record of the repository that carries the shape. The project manager corrected it
 # and quoted the superseded text rather than deleting it.
@@ -185,15 +189,11 @@ def test_the_census_states_its_count_its_method_its_bound_and_its_finding():
     assert missing == [], f"{CENSUS_HEADING} states none of: {missing}"
 
 
-def test_the_census_states_the_three_corpus_counts_it_read():
+def test_the_census_states_the_corpus_count_of_every_endpoint_it_read():
     """A reader re-takes the census against these counts and reads what the corpus gained."""
     body = collapsed(section(rule_text(), CENSUS_HEADING))
-    for count in (
-        ISSUE_COMMENT_COUNT,
-        ISSUE_AND_PULL_REQUEST_COUNT,
-        PULL_REQUEST_REVIEW_COMMENT_COUNT,
-    ):
-        assert count in body, f"the census states no count {count}"
+    missing = [count for count in CORPUS_COUNTS if count not in body]
+    assert missing == [], f"the census states none of: {missing}"
 
 
 def test_the_census_states_the_clean_negative_as_a_result():

--- a/tests/test_agent_report_absence_rule.py
+++ b/tests/test_agent_report_absence_rule.py
@@ -38,19 +38,53 @@ REPAIR_HEADING = "## Where the repair belongs"
 CENSUS_HEADING = "## The census of 2026-08-16"
 NO_CASE_HEADING = "## No case of this repository refuses this shape"
 
-# The three statements of the rule. **A worker reads them and nothing else is needed.**
+# The three statements of the rule. **A worker reads these three and needs no other line.**
 RULE_STATEMENTS = (
     "A report an agent did not return is reported as absent.",
     "A worker names the agent that reported, and it names the agent that did not.",
     "An absent report is a normal outcome and it refuses nothing.",
 )
 
+# What rule 3 costs a reader. A reader who treats the absence as a failure gives the next
+# worker a reason to invent a report.
+ABSENCE_CONSEQUENCES = (
+    "It refuses no merge.",
+    "It fails no gate.",
+    "It earns no tracker issue.",
+)
+
 # The file of the `issue-flow` plugin that holds the other half of the repair. The plugin
 # is outside this repository, so #720 names the file and it edits no line of it.
 PLUGIN_FILE = "agents/issue-worker.md"
 
-# The step of that file which spawns the review children. A reader reaches the rule there.
+# The step of that file which spawns the review agents. A reader reaches the rule there.
 PLUGIN_STEP = "**Self-review**"
+
+# The verdict each row of the repair table carries. A case that reads the two paths alone
+# passes on a table whose verdict column says the opposite of what this change did.
+REPAIR_VERDICTS = (
+    "| `.claude/rules/agent-reports.md` | The rule, the reason, the census, and the limit "
+    "| Written here |",
+    "| `agents/issue-worker.md` of the `issue-flow` plugin | The same rule beside the step "
+    "that spawns the review agents | Named, and no line changed |",
+)
+
+# The two records that sit next to the shape. **The census names each one by its comment
+# anchor**, and a self-review of #720 found the first anchor wrong before this case existed.
+ADJACENT_RECORDS = (
+    "https://github.com/Crank-Git/ja4plus/pull/561#issuecomment-5246016733",
+    "https://github.com/Crank-Git/ja4plus/pull/222#issuecomment-5224677084",
+)
+
+# The counts the census states about its own two passes. A count no case reads goes stale.
+CENSUS_METHOD_COUNTS = ("88 comments and 7 bodies", "44 comments each")
+
+# The measurement the reason section rests on. It states that the absence is common and that
+# a worker reports it plainly, so a reader who doubts rule 3 reads these two numbers.
+STALL_COUNTS = (
+    "17 comments that state a review agent returned nothing",
+    "10 of them use the word",
+)
 
 # The four labels the census states. A census that reports a count and no bound reports a
 # clean corpus over the part it cannot see.
@@ -123,10 +157,11 @@ def test_the_rule_section_states_all_three_statements_of_the_rule():
     assert missing == [], f"{RULE_HEADING} states none of: {missing}"
 
 
-def test_the_rule_states_that_an_absent_report_refuses_nothing():
-    """A rule that refuses the work on an absent report buys a worker a reason to invent one."""
+def test_the_rule_states_the_three_consequences_an_absent_report_carries():
+    """A rule that refuses the work on an absent report gives a worker a reason to invent one."""
     body = collapsed(section(rule_text(), RULE_HEADING))
-    assert "refuses nothing" in body
+    missing = [line for line in ABSENCE_CONSEQUENCES if line not in body]
+    assert missing == [], f"{RULE_HEADING} states none of: {missing}"
 
 
 def test_the_rule_names_both_the_agent_that_reported_and_the_agent_that_did_not():
@@ -160,8 +195,8 @@ def test_the_rule_records_where_each_half_of_the_repair_belongs():
     """#720 asks which of two homes holds the rule, and the file answers with both."""
     body = collapsed(section(rule_text(), REPAIR_HEADING))
     assert body, f"the rule file holds no section {REPAIR_HEADING}"
-    assert ".claude/rules/agent-reports.md" in body
-    assert "issue-flow" in body
+    missing = [row for row in REPAIR_VERDICTS if row not in body]
+    assert missing == [], f"{REPAIR_HEADING} states none of: {missing}"
 
 
 def test_the_repair_section_names_the_plugin_file_and_the_step_that_holds_it():
@@ -203,9 +238,30 @@ def test_the_census_states_the_clean_negative_as_a_result():
 
 
 def test_the_census_names_the_one_record_it_found():
-    """The census found one record of the shape, and it is the record #720 was filed on."""
+    """The census found one record of the shape, and that record earned #720."""
     body = collapsed(section(rule_text(), CENSUS_HEADING))
     assert KNOWN_INSTANCE in body
+
+
+def test_the_census_names_both_records_that_sit_next_to_the_shape():
+    """A citation no case reads goes wrong without a reader noticing, and one did."""
+    body = collapsed(section(rule_text(), CENSUS_HEADING))
+    missing = [record for record in ADJACENT_RECORDS if record not in body]
+    assert missing == [], f"{CENSUS_HEADING} cites none of: {missing}"
+
+
+def test_the_census_states_the_selection_of_each_pass():
+    """A method that states no selection leaves a reader unable to re-take the census."""
+    body = collapsed(section(rule_text(), CENSUS_HEADING))
+    missing = [count for count in CENSUS_METHOD_COUNTS if count not in body]
+    assert missing == [], f"{CENSUS_HEADING} states none of: {missing}"
+
+
+def test_the_reason_section_states_the_measurement_that_the_absence_is_common():
+    """Rule 3 rests on a measurement, and a reader who doubts it reads these two numbers."""
+    body = collapsed(section(rule_text(), REASON_HEADING))
+    missing = [count for count in STALL_COUNTS if count not in body]
+    assert missing == [], f"{REASON_HEADING} states none of: {missing}"
 
 
 # --- What no case reads --------------------------------------------------------------


### PR DESCRIPTION
## What

`.claude/rules/agent-reports.md` states the rule that #720 asks for. A report an agent did not return is reported as absent. A worker names the agent that reported and it names the agent that did not. An absent report is a normal outcome and it refuses nothing.

`tests/test_agent_report_absence_rule.py` holds the file and every claim a case can read. 21 cases.

## Why

A worker on #613 spawned two review agents. One reported and one never did, and the worker wrote up the agent that never reported as though it had. The project manager corrected the record at https://github.com/Crank-Git/ja4plus/pull/718#issuecomment-5305142104.

**The rule names the absence as correct rather than punishes the report.** The worker reported its own fabrication, and that report is the one detection this defect class has. A rule that punished the report would remove it.

## Where the repair belongs

The repair belongs in two places and this pull request makes one of them.

| Home | This change |
|---|---|
| `.claude/rules/agent-reports.md` | Written here |
| `agents/issue-worker.md` of the `issue-flow` plugin | Named, and no line changed |

The plugin is outside this repository. Step 3 of its runbook opens `**Self-review**` and spawns the review children, and it names no outcome for a child that never returns. A second copy stands at `skills/issue-flow/references/issue-worker.md`. The maintainer owns that change.

## The census

1842 records read: 1101 issue comments, which hold every pull-request conversation comment, 741 issue and pull-request bodies, and 0 pull-request review comments. A first pass selected 88 comments and 7 bodies against a pattern that names a reviewer, a lens, a review agent, a review child or a Sonnet child beside a verb of finding. A second pass read each one in full.

**Two Sonnet children read 44 comments each. Both children reported.** The worker read the 7 bodies itself.

**Finding: one record of 1842 carries the shape, and it is the record #720 was filed on.** Every other record is a clean negative, and the clean negative is the result.

**Bound:** the census reads the provider records of this repository alone. It reads no session transcript, so a fabrication that stays internally consistent and quotes nothing checkable reaches no reader of this corpus. The rule file states that bound.

## Whether a case can refuse this shape

**No case can.** A case would need the record of which agents returned, and that record is the session transcript, which lives outside this repository. A fabricated write-up is well-formed text, so a pattern that matched it would match every honest self-review beside it. The rule file says so rather than ships a guard that guards nothing. `.claude/rules/conformance.md` holds the same discipline under `## What a green conformance run does not measure`, which #736 wrote, and this file repeats no sentence of it.

## How tested

Test-driven. `tests/test_agent_report_absence_rule.py` was written first and reported 17 failed, 1 passed before `.claude/rules/agent-reports.md` existed. The one case that passed is `test_this_repository_tracks_no_copy_of_the_plugin_file`, which reads a true claim of the base branch.

| Gate | Result |
|---|---|
| `pytest tests/ -m "not spec_validation"` | 5904 passed, 8 skipped, 8 xfailed |
| `pytest tests/ -m spec_validation` | 1684 passed, 142 skipped, 138 xfailed — identical to the base |
| `ruff check ja4plus/ tests/` | All checks passed |
| `ruff format --check ja4plus/ tests/` | 264 files already formatted |
| `mypy --strict ja4plus/` | Success, 32 source files |

**This change moves no fingerprint value.** It touches no file under `ja4plus/`, and the conformance counts hold at the base reading. `tests/foxio_deviations.json` holds 138 keys before and after.

Refs #720.

