### PR TITLE
Print the address pair of every window a capture leaves open

### DIFF
--- a/ja4plus/cli.py
+++ b/ja4plus/cli.py
@@ -123,14 +123,53 @@ def _packet_timestamp(packet: Packet) -> datetime | None:
         return None
 
 
+def _endpoints_of_entry(entry: dict[str, Any]) -> tuple[str, int, str, int]:
+    """Return the four endpoint values of one window the processor closed.
+
+    The entry of the fingerprinter is the first source, and the connection key is the
+    fallback. #742 records the reason for that order. The entry states the pair the
+    fingerprinter attributed the value to, and a key restates the same pair in a form
+    each fingerprinter picks for itself.
+
+    `JA4LFingerprinter` states all four fields on a closed window.
+    `JA4SSHFingerprinter` states none, so the fallback reads its key.
+
+    Args:
+        entry: One result dict of `Processor.close_open_windows`.
+
+    Returns:
+        A tuple of the source address, the source port, the destination address and the
+        destination port. An entry that states no address and carries a key this call
+        cannot read produces empty addresses and the port zero.
+    """
+    src_ip = entry.get("src")
+    dst_ip = entry.get("dst")
+    if src_ip or dst_ip:
+        return (
+            str(src_ip or ""),
+            int(entry.get("srcport") or 0),
+            str(dst_ip or ""),
+            int(entry.get("dstport") or 0),
+        )
+    return _endpoints_from_connection(str(entry.get("connection") or ""))
+
+
 def _endpoints_from_connection(connection: str) -> tuple[str, int, str, int]:
     """Return the four endpoint values that a connection key names.
 
-    A window that no packet closes carries the connection key and no packet, so the
-    command reads the endpoints back from the key. The key form is
-    `<address>:<port>-<address>:<port>`. An IPv6 address holds a colon and no hyphen, so
-    the first hyphen separates the two endpoints and the last colon of each half
-    separates the port.
+    This call is the fallback of `_close_open_windows`. It reads a window whose entry
+    states no endpoint, and `JA4SSHFingerprinter` writes every such entry today.
+
+    The two fingerprinters that hold a window write two key forms, and this call reads
+    both. #742 measured what one form costs: the call read the hyphen form alone, so it
+    returned nothing for the 22 JA4L values of the committed captures.
+
+    - `JA4SSHFingerprinter` writes `<address>:<port>-<address>:<port>`.
+    - `JA4LFingerprinter` writes `<protocol>_<address>:<port>_<address>:<port>`, which
+      `_reported_key` builds.
+
+    An IPv6 address holds a colon and neither separator, so the first hyphen or the two
+    underscores name the two halves. The last colon of each half separates the port.
 
     Args:
         connection: The connection key the fingerprinter reported.
@@ -142,7 +181,15 @@ def _endpoints_from_connection(connection: str) -> tuple[str, int, str, int]:
     """
     first, separator, second = connection.partition("-")
     if not separator:
-        return "", 0, "", 0
+        # The underscore form opens with the protocol name, and an address holds no
+        # underscore. The first underscore therefore ends the protocol and the next one
+        # separates the two halves.
+        _, separator, remainder = connection.partition("_")
+        if not separator:
+            return "", 0, "", 0
+        first, separator, second = remainder.partition("_")
+        if not separator:
+            return "", 0, "", 0
     src_ip, src_port = _split_endpoint(first)
     dst_ip, dst_port = _split_endpoint(second)
     return src_ip, src_port, dst_ip, dst_port
@@ -343,9 +390,10 @@ def _report_no_result(args: argparse.Namespace, count: int) -> None:
 def _close_open_windows(processor: Processor, order: dict[str, int]) -> list[FingerprintResult]:
     """Return one result for every window the processor holds open.
 
-    Run this function when the packet source ends without an error. JA4SSH is the only
-    method that holds a window, and #214 decided that it emits the window a connection
-    holds open.
+    Run this function when the packet source ends without an error. Two methods hold a
+    window. JA4SSH emits the window a connection holds open, which #214 decided. JA4L
+    emits the QUIC server value of a connection that never fills point `D`, which #606
+    added on 2026-08-16.
 
     A read error ends the command with a message and the status 1, and the command
     writes no trailing window then. A partial window that follows an error describes a
@@ -357,12 +405,13 @@ def _close_open_windows(processor: Processor, order: dict[str, int]) -> list[Fin
 
     Returns:
         A list of `FingerprintResult`, in the order the user wrote. The endpoints read
-        the connection key of the window, because no packet produces them. The timestamp
-        is None for the same reason.
+        the entry of the fingerprinter, and they read the connection key of the window
+        where the entry states none. The timestamp is None, because no packet produces
+        the value.
     """
     # The selection reads `_selecting_token`, so one rule covers the two paths that
-    # `--types` filters. JA4SSH is the one method that holds a window today, and that
-    # method reaches the same answer as the earlier `entry["type"] in order` test.
+    # `--types` filters. The rule reaches both methods that hold a window, and it
+    # reaches the same answer as the earlier `entry["type"] in order` test.
     positioned: list[tuple[int, dict[str, Any]]] = []
     for candidate in processor.close_open_windows():
         token = _selecting_token(str(candidate["type"]), str(candidate["fingerprint"]), order)
@@ -371,9 +420,10 @@ def _close_open_windows(processor: Processor, order: dict[str, int]) -> list[Fin
     positioned.sort(key=lambda pair: pair[0])
     results: list[FingerprintResult] = []
     for _, entry in positioned:
-        src_ip, src_port, dst_ip, dst_port = _endpoints_from_connection(
-            entry.get("connection") or ""
-        )
+        # The entry is the first source, because it states the pair the fingerprinter
+        # attributed the value to. A key is a second encoding of that pair, and the two
+        # forms drift: #742 measured a key form that the parse below could not read.
+        src_ip, src_port, dst_ip, dst_port = _endpoints_of_entry(entry)
         results.append(
             FingerprintResult(
                 type=str(entry["type"]),

--- a/ja4plus/cli.py
+++ b/ja4plus/cli.py
@@ -128,8 +128,8 @@ def _endpoints_of_entry(entry: dict[str, Any]) -> tuple[str, int, str, int]:
 
     The entry of the fingerprinter is the first source, and the connection key is the
     fallback. #742 records the reason for that order. The entry states the pair the
-    fingerprinter attributed the value to, and a key restates the same pair in a form
-    each fingerprinter picks for itself.
+    fingerprinter attributed the value to. A key restates that same pair in a form each
+    fingerprinter picks for itself.
 
     `JA4LFingerprinter` states all four fields on a closed window.
     `JA4SSHFingerprinter` states none, so the fallback reads its key.
@@ -157,11 +157,11 @@ def _endpoints_of_entry(entry: dict[str, Any]) -> tuple[str, int, str, int]:
 def _endpoints_from_connection(connection: str) -> tuple[str, int, str, int]:
     """Return the four endpoint values that a connection key names.
 
-    This call is the fallback of `_close_open_windows`. It reads a window whose entry
+    This call is the fallback of `_endpoints_of_entry`. It reads a window whose entry
     states no endpoint, and `JA4SSHFingerprinter` writes every such entry today.
 
     The two fingerprinters that hold a window write two key forms, and this call reads
-    both. #742 measured what one form costs: the call read the hyphen form alone, so it
+    both. #742 measured what one form costs. The call read the hyphen form alone, so it
     returned nothing for the 22 JA4L values of the committed captures.
 
     - `JA4SSHFingerprinter` writes `<address>:<port>-<address>:<port>`.

--- a/ja4plus/processor.py
+++ b/ja4plus/processor.py
@@ -254,14 +254,16 @@ class Processor:
     def close_open_windows(self) -> list[dict[str, Any]]:
         """Emit every window the fingerprinters hold open, and return the results.
 
-        Run this method when the packet source ends. JA4SSH is the only method that
-        holds a window, and #214 decided that it emits the window a connection holds
-        open at the end of a capture.
+        Run this method when the packet source ends. Two methods hold a window. JA4SSH
+        emits the window a connection holds open, which #214 decided. JA4L emits the
+        QUIC server value of a connection that never fills point `D`, which #606 added
+        on 2026-08-16.
 
         Returns:
-            A list of result dicts. Each dict holds the method name, the fingerprint
-            and the connection key of the window. It holds no packet endpoint, because
-            no packet produces the value.
+            A list of result dicts. Each dict holds the method name, the fingerprint,
+            the connection key of the window and the four endpoint fields. An endpoint
+            field reads None where the fingerprinter entry states no endpoint, because
+            no packet produces the value. JA4L states all four and JA4SSH states none.
         """
         results: list[dict[str, Any]] = []
         for fp_type, fp in self.fingerprinters.items():
@@ -274,11 +276,19 @@ class Processor:
                 logger.debug(f"{fp_type} close_open_windows failed: {e}")
                 continue
             for entry in entries:
+                # The entry states the address pair the value belongs to, and the caller
+                # holds no packet to read it from. #742 measured what a dropped pair
+                # costs: the command printed `unknown` for 22 values of the committed
+                # captures, because the connection key was the one source it kept.
                 results.append(
                     {
                         "type": fp_type,
                         "fingerprint": entry["fingerprint"],
                         "connection": entry.get("connection"),
+                        "src": entry.get("src"),
+                        "srcport": entry.get("srcport"),
+                        "dst": entry.get("dst"),
+                        "dstport": entry.get("dstport"),
                     }
                 )
         return results

--- a/ja4plus/processor.py
+++ b/ja4plus/processor.py
@@ -278,7 +278,7 @@ class Processor:
             for entry in entries:
                 # The entry states the address pair the value belongs to, and the caller
                 # holds no packet to read it from. #742 measured what a dropped pair
-                # costs: the command printed `unknown` for 22 values of the committed
+                # costs. The command printed `unknown` for 22 values of the committed
                 # captures, because the connection key was the one source it kept.
                 results.append(
                     {

--- a/tests/test_cli_closed_window_endpoints.py
+++ b/tests/test_cli_closed_window_endpoints.py
@@ -7,10 +7,11 @@ of the committed captures printed that word.
 **Every guard that stood when the defect shipped read a fingerprint entry, and no guard
 read a printed line.** The entry of `JA4LFingerprinter` carries the four endpoint fields,
 so a reader of the entry sees a correct address pair. The loss happens between the entry
-and the line: `Processor.close_open_windows` dropped the four fields, and the command then
+and the line. `Processor.close_open_windows` dropped the four fields, and the command then
 read the endpoints back from the connection key. The conformance suite compares the value
-at the key `tls3.pcapng/25:61884/JA4L-S.1` and it reads no line of the command, so it
-reported 1684 passed with the defect live. The cases below read the printed line.
+at the key `tls3.pcapng/25:61884/JA4L-S.1` and it reads no line of the command. It
+therefore reported 1684 passed with the defect live, and the cases below read the printed
+line.
 
 The captures of `CAPTURES_THAT_HOLD_A_WINDOW` are the committed captures that publish a
 value from `close_open_windows`. A census of 2026-08-16 read 28 such values: 22 from JA4L

--- a/tests/test_cli_closed_window_endpoints.py
+++ b/tests/test_cli_closed_window_endpoints.py
@@ -1,0 +1,214 @@
+"""The command prints the address pair of every window the packet source leaves open.
+
+#742 measured the defect. `ja4plus analyze tests/foxio_vectors/tls3.pcapng` printed
+`unknown` in place of the address pair for the value `JA4L-S=3583_57_quic`, and 22 values
+of the committed captures printed that word.
+
+**Every guard that stood when the defect shipped read a fingerprint entry, and no guard
+read a printed line.** The entry of `JA4LFingerprinter` carries the four endpoint fields,
+so a reader of the entry sees a correct address pair. The loss happens between the entry
+and the line: `Processor.close_open_windows` dropped the four fields, and the command then
+read the endpoints back from the connection key. The conformance suite compares the value
+at the key `tls3.pcapng/25:61884/JA4L-S.1` and it reads no line of the command, so it
+reported 1684 passed with the defect live. The cases below read the printed line.
+
+The captures of `CAPTURES_THAT_HOLD_A_WINDOW` are the committed captures that publish a
+value from `close_open_windows`. A census of 2026-08-16 read 28 such values: 22 from JA4L
+and 6 from JA4SSH. The 22 are the count the register row of #606 states.
+"""
+
+import io
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+VECTOR_DIR = os.path.join(os.path.dirname(__file__), "foxio_vectors")
+
+# The committed captures that leave a window open, with the count of values each one
+# publishes from `close_open_windows`. The census of 2026-08-16 measured every capture of
+# `tests/foxio_vectors/` and found these eight.
+CAPTURES_THAT_HOLD_A_WINDOW = {
+    "ssh-scp-1050.pcap": 1,
+    "ssh.pcapng": 1,
+    "ssh2-malformed.pcap": 1,
+    "ssh2-moloch-crash.pcap": 1,
+    "ssh2.pcapng": 2,
+    "tcpdump-geneve.pcap": 1,
+    "tls-handshake.pcapng": 20,
+    "tls3.pcapng": 1,
+}
+
+# The count of values the eight captures publish. 22 belong to JA4L and 6 belong to
+# JA4SSH.
+CLOSED_WINDOW_VALUE_COUNT = 28
+
+# The line of `tls3.pcapng` that #742 measured, and the address pair it must carry.
+TLS3_QUIC_SERVER_VALUE = "JA4L-S=3583_57_quic"
+TLS3_QUIC_SERVER_PAIR = "104.21.234.234:443 -> 192.168.1.169:61884"
+
+
+def run_analyze(capture):
+    """Return the standard output that `ja4plus analyze` writes for one capture.
+
+    The call runs the command in this process, because a subprocess costs an interpreter
+    start for each capture and reads the same code.
+
+    Args:
+        capture: The file name of a capture of `tests/foxio_vectors/`.
+
+    Returns:
+        The standard output of the run, as one string.
+    """
+    from ja4plus.cli import main
+
+    captured_out = io.StringIO()
+    captured_err = io.StringIO()
+    argv = ["ja4plus", "analyze", os.path.join(VECTOR_DIR, capture)]
+    with patch.object(sys, "argv", argv):
+        with patch.object(sys, "stdout", captured_out):
+            with patch.object(sys, "stderr", captured_err):
+                try:
+                    main()
+                except SystemExit as end:
+                    assert end.code in (None, 0), captured_err.getvalue()
+    return captured_out.getvalue()
+
+
+def closed_window_entries(capture):
+    """Return every entry that `close_open_windows` publishes for one capture.
+
+    Args:
+        capture: The file name of a capture of `tests/foxio_vectors/`.
+
+    Returns:
+        The list of result dicts the processor returns after it reads every packet.
+    """
+    from scapy.utils import rdpcap
+
+    from ja4plus import Processor
+
+    processor = Processor()
+    for packet in rdpcap(os.path.join(VECTOR_DIR, capture)):
+        processor.process_packet(packet)
+    return processor.close_open_windows()
+
+
+class TheCommandPrintsAnAddressPairForEveryClosedWindow(unittest.TestCase):
+    """#742 — the printed line carries the address pair, and never the word `unknown`."""
+
+    def test_the_command_prints_the_address_pair_of_the_quic_server_value_of_tls3(self):
+        lines = [
+            line
+            for line in run_analyze("tls3.pcapng").splitlines()
+            if TLS3_QUIC_SERVER_VALUE in line
+        ]
+        self.assertEqual(len(lines), 1, lines)
+        self.assertTrue(
+            lines[0].startswith(TLS3_QUIC_SERVER_PAIR),
+            f"the line reads {lines[0]!r} and it must start with {TLS3_QUIC_SERVER_PAIR!r}",
+        )
+
+    def test_no_capture_that_holds_an_open_window_prints_unknown(self):
+        for capture in sorted(CAPTURES_THAT_HOLD_A_WINDOW):
+            with self.subTest(capture=capture):
+                unknown = [
+                    line for line in run_analyze(capture).splitlines() if line.startswith("unknown")
+                ]
+                self.assertEqual(unknown, [], f"{capture} prints {len(unknown)} lines of unknown")
+
+    def test_the_eight_captures_publish_the_count_of_values_the_census_measured(self):
+        counted = {
+            capture: len(closed_window_entries(capture))
+            for capture in sorted(CAPTURES_THAT_HOLD_A_WINDOW)
+        }
+        self.assertEqual(counted, CAPTURES_THAT_HOLD_A_WINDOW)
+        self.assertEqual(sum(counted.values()), CLOSED_WINDOW_VALUE_COUNT)
+
+
+class TheProcessorCarriesTheEndpointsOfTheEntry(unittest.TestCase):
+    """The result of `close_open_windows` holds the four endpoint fields of the entry."""
+
+    def test_the_quic_server_value_of_tls3_carries_the_four_endpoint_fields(self):
+        entries = closed_window_entries("tls3.pcapng")
+        self.assertEqual(len(entries), 1, entries)
+        entry = entries[0]
+        self.assertEqual(entry["src"], "104.21.234.234")
+        self.assertEqual(entry["srcport"], 443)
+        self.assertEqual(entry["dst"], "192.168.1.169")
+        self.assertEqual(entry["dstport"], 61884)
+
+    def test_a_ja4ssh_window_carries_no_endpoint_field_and_carries_the_key(self):
+        entries = closed_window_entries("ssh.pcapng")
+        self.assertEqual(len(entries), 1, entries)
+        entry = entries[0]
+        self.assertEqual(entry["type"], "ja4ssh")
+        self.assertEqual(entry["connection"], "172.16.225.48:57377-54.160.114.75:22")
+        # The fallback exists for this entry. `JA4SSHFingerprinter._close_window` writes
+        # no endpoint field, so the key is the one source the command holds.
+        self.assertIsNone(entry["src"])
+        self.assertIsNone(entry["srcport"])
+
+
+class TheKeyParseReadsEveryFormAFingerprinterWrites(unittest.TestCase):
+    """The fallback reads both key forms, because the two fingerprinters disagree."""
+
+    def test_the_parse_reads_the_hyphen_form_that_ja4ssh_writes(self):
+        from ja4plus.cli import _endpoints_from_connection
+
+        self.assertEqual(
+            _endpoints_from_connection("172.16.225.48:57377-54.160.114.75:22"),
+            ("172.16.225.48", 57377, "54.160.114.75", 22),
+        )
+
+    def test_the_parse_reads_the_underscore_form_that_ja4l_writes(self):
+        from ja4plus.cli import _endpoints_from_connection
+
+        self.assertEqual(
+            _endpoints_from_connection("udp_104.21.234.234:443_192.168.1.169:61884"),
+            ("104.21.234.234", 443, "192.168.1.169", 61884),
+        )
+
+    def test_the_parse_reads_an_ipv6_pair_of_the_underscore_form(self):
+        from ja4plus.cli import _endpoints_from_connection
+
+        # An IPv6 address holds a colon and no underscore, so the two separators of the
+        # underscore form still name the two halves.
+        self.assertEqual(
+            _endpoints_from_connection("udp_2001:db8::1:443_2001:db8::2:61884"),
+            ("2001:db8::1", 443, "2001:db8::2", 61884),
+        )
+
+    def test_the_parse_returns_empty_values_for_a_key_of_neither_form(self):
+        from ja4plus.cli import _endpoints_from_connection
+
+        self.assertEqual(_endpoints_from_connection("no separator here"), ("", 0, "", 0))
+
+
+class TheDocstringsNameNoSingleMethodThatHoldsAWindow(unittest.TestCase):
+    """#606 ended the premise that JA4SSH is the one method that holds a window.
+
+    `JA4LFingerprinter.close_open_windows` publishes the QUIC server value of every
+    connection that never fills point `D`. A reader who trusts the older sentence reads
+    the JA4L path as dead code.
+    """
+
+    def test_the_command_docstring_names_ja4l_beside_ja4ssh(self):
+        from ja4plus.cli import _close_open_windows
+
+        text = _close_open_windows.__doc__ or ""
+        self.assertNotIn("JA4SSH is the only method", text)
+        self.assertNotIn("JA4SSH is the one method", text)
+        self.assertIn("JA4L", text)
+
+    def test_the_processor_docstring_names_ja4l_beside_ja4ssh(self):
+        from ja4plus.processor import Processor
+
+        text = Processor.close_open_windows.__doc__ or ""
+        self.assertNotIn("JA4SSH is the only method", text)
+        self.assertNotIn("JA4SSH is the one method", text)
+        self.assertIn("JA4L", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this change does

`ja4plus analyze` printed `unknown` in place of the address pair for every JA4L value that
`close_open_windows` publishes. 22 values of the committed captures printed that word. The
command now prints the pair.

```
$ ja4plus analyze tests/foxio_vectors/tls3.pcapng   # before
unknown                                             ja4l        JA4L-S=3583_57_quic

$ ja4plus analyze tests/foxio_vectors/tls3.pcapng   # after
104.21.234.234:443 -> 192.168.1.169:61884           ja4l        JA4L-S=3583_57_quic
```

## Warning: the issue names the wrong function, and this change measured it

**The issue body states that `_close_open_windows` at `ja4plus/cli.py:343` drops the four
endpoint fields of the entry. `Processor.close_open_windows` at `ja4plus/processor.py:254`
drops them, and the command never receives them.** The fingerprinter entry carries all
four, and the processor built a result dict of three keys.

```python
# ja4plus/processor.py, before this change
{"type": fp_type, "fingerprint": entry["fingerprint"], "connection": entry.get("connection")}
```

**The plan therefore names one file where the repair needs two.** The cause chain of the
issue holds otherwise, and so does every acceptance criterion. The change adds the four
keys to the result dict of the processor. That addition breaks no caller: every case of
`tests/test_processor.py`, `tests/test_method_pages.py` and `tests/test_thread_safety.py`
reads a named key and none reads the key set.

**The Go port already carries the endpoints through this path, and parity rule 2 adopts
it.** `Processor.CloseOpenWindows` of `processor.go:239` returns `[]FingerprintResult`, and
`JA4SSHFingerprinter.CloseOpenWindows` of `ja4ssh.go:590` fills the address pair from the
connection state. The port parses no key. This change adopts the source and not the
container type, so `close_open_windows` returns dicts as before.

## Which source the command reads, and why

**The entry of the fingerprinter is the first source, and the connection key is the
fallback.** The entry states the pair the fingerprinter attributed the value to. A key
restates that same pair in a form each fingerprinter picks for itself, and the two forms
drift as they did here.

**Two fingerprinters hold a window, and the fallback reads the key form of each one.**

| Fingerprinter | The key form it writes | Endpoint fields on the entry |
|---|---|---|
| `JA4LFingerprinter` | `<protocol>_<address>:<port>_<address>:<port>`, which `_reported_key` of `ja4plus/fingerprinters/ja4l.py:376` builds | All four |
| `JA4SSHFingerprinter` | `<address>:<port>-<address>:<port>` | None |

`JA4SSHFingerprinter` states no endpoint field on a closed window, so the fallback stays
and it serves that fingerprinter today.

## The count

**A census of 2026-08-16 read 28 values that `close_open_windows` publishes over the
committed captures: 22 from JA4L and 6 from JA4SSH.** The 22 are the count that the
register row of #606 states, and all 22 printed `unknown`. The 6 JA4SSH values printed a
correct pair, because the key parse read their form.

| Capture | Values |
|---|---|
| `tls-handshake.pcapng` | 20 |
| `ssh2.pcapng` | 2 |
| `ssh-scp-1050.pcap`, `ssh.pcapng`, `ssh2-malformed.pcap`, `ssh2-moloch-crash.pcap`, `tcpdump-geneve.pcap`, `tls3.pcapng` | 1 each |

## Why the present guards missed the defect

**Every guard that stood read a fingerprint entry, and no guard read a printed line.** The
entry of `JA4LFingerprinter` carries the correct address pair, so a reader of the entry
sees no defect. The conformance suite compares the value at the key
`tls3.pcapng/25:61884/JA4L-S.1` and it reads no line of the command. It reported 1684
passed with the defect live.

`tests/test_cli_closed_window_endpoints.py` reads the printed line of the command for the
eight captures that hold an open window.

## How this was tested

Test-driven. The new module failed 10 cases and 3 subtests against the defect, and the
first failure is the acceptance criterion:

```
FAILED TheCommandPrintsAnAddressPairForEveryClosedWindow::test_the_command_prints_the_address_pair_of_the_quic_server_value_of_tls3
```

**The change moves no fingerprint value.** A replay of all 38 files of
`tests/foxio_vectors/` read 788 values before the change and 788 after it, and the two
dumps compare byte-identical. `tests/foxio_deviations.json` holds 138 keys before and
after.

The five gates, run in this worktree:

| Gate | Result |
|---|---|
| `pytest tests/ -m "not spec_validation"` | 5892 passed, 8 skipped, 8 xfailed |
| `pytest tests/ -m spec_validation` | 1684 passed, 142 skipped, 138 xfailed |
| `ruff check ja4plus/ tests/` | All checks passed |
| `ruff format --check ja4plus/ tests/` | 265 files already formatted |
| `mypy --strict ja4plus/` | no issues found in 32 source files |

The conformance reading equals the baseline of the base branch, which this worktree
measured before the change.

## What this change leaves

**Four other prose sites state the premise that #606 ended, and this change repairs the
two in the files it touches.** `ja4plus/cli.py` and `ja4plus/processor.py` no longer name
JA4SSH as the only method that holds a window. These four keep the older sentence, and no
file of this change touches them.

- `ja4plus/fingerprinters/base.py:166`
- `docs/api_reference.md:63`
- `tests/test_processor.py:99`, `tests/test_ja4ssh_windows.py:317` and
  `tests/conformance_index.py:243`, each in a docstring or a comment.

Refs #742
