### PR TITLE
Promote dev to master: dependency and tooling bumps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ docs = [
     "mkdocs-material==9.7.7",
     "mkdocstrings==1.0.6",
     "mkdocstrings-python==2.0.7",
-    "griffe==2.1.0",
+    "griffe==2.2.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
     # file under `.github/workflows/` and every second dependency record this repository
     # could carry. The `dev` extra therefore stays the one place a tool reads the version
     # from.
-    "ruff==0.16.2",
+    "ruff==0.16.4",
     # **The version floats, and #446 chose that shape against the four exact pins beside
     # it.** A pinned type checker falls behind, and a frozen release hides a defect that a
     # later release reports. A floating formatter turns a green tree red, which is noisy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ docs = [
     "mkdocs==1.6.1",
     "mkdocs-material==9.7.7",
     "mkdocstrings==1.0.6",
-    "mkdocstrings-python==2.0.5",
+    "mkdocstrings-python==2.0.7",
     "griffe==2.1.0",
 ]
 

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -530,7 +530,7 @@ DOCS_ENTRIES = [
     "mkdocs==1.6.1",
     "mkdocs-material==9.7.7",
     "mkdocstrings==1.0.6",
-    "mkdocstrings-python==2.0.5",
+    "mkdocstrings-python==2.0.7",
     "griffe==2.1.0",
 ]
 

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -511,7 +511,7 @@ def _dependency_block(text: str, opener: str) -> list[str]:
 DEV_ENTRIES = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "ruff==0.16.2",
+    "ruff==0.16.4",
     "mypy>=1.11",
     "build==1.5.0",
     "twine==7.0.0",

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -531,7 +531,7 @@ DOCS_ENTRIES = [
     "mkdocs-material==9.7.7",
     "mkdocstrings==1.0.6",
     "mkdocstrings-python==2.0.7",
-    "griffe==2.1.0",
+    "griffe==2.2.0",
 ]
 
 


### PR DESCRIPTION
## Summary
- Promotes two tooling/dependency PRs from `dev`: #756 (`actions/deploy-pages` 5.0.0→5.0.1) and #760 (bumps `build`, `ruff`, `mkdocstrings-python` and `griffe` pins, plus the matching literals in `tests/test_documentation_site.py`).
- No fingerprinting code, spec, or behavior changes. No version bump — `ja4plus/__init__.py` stays at 1.2.1 on both branches, matching the version gate's own reading.
- #755, #757, #758 and #759 (the individual dependabot PRs for the same pins) are closed as superseded by #760.

## The gate
| Gate | Reading |
|---|---|
| `pytest tests/ -m "not spec_validation"` | 6030 passed, 0 failed |
| `ruff check`, `ruff format --check` | clean |
| `mkdocs build --strict` with new docs-extra pins | builds, no warning |
| `test.yml` on `dev` tip (7b9d239) | success |